### PR TITLE
chore: LANDGRIF-45 - Configure Docker for Frontend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,9 +31,13 @@ test-commands:
 start-api:
 	docker-compose --project-name ${COMPOSE_PROJECT_NAME} up --build api
 
+# Starts the CLIENT application
+start-client:
+	docker-compose --project-name ${COMPOSE_PROJECT_NAME} up --build client
+
 # Start all the services.
 start:
-	docker-compose --project-name ${COMPOSE_PROJECT_NAME} up --build api
+	docker-compose --project-name ${COMPOSE_PROJECT_NAME} up --build
 
 stop:
 	docker-compose $(DOCKER_COMPOSE_FILE) stop

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,0 +1,32 @@
+FROM node:14.17-alpine3.13
+LABEL maintainer="hello@vizzuality.com"
+
+ARG UID=5000
+ARG GID=5000
+
+ENV NAME landgriffon-client
+ENV USER $NAME
+ENV APP_HOME /opt/$NAME
+
+RUN addgroup -g $GID $USER &&  adduser -u $UID -D -G $USER $USER
+
+WORKDIR $APP_HOME
+RUN chown $USER:$USER $APP_HOME
+
+USER $USER
+
+COPY --chown=$USER:$USER package.json yarn.lock ./
+RUN yarn install --frozen-lockfile
+
+# NextJS project folders
+COPY --chown=$USER:$USER components containers lib pages public services styles svgs ./
+# NextJS config files
+COPY --chown=$USER:$USER next.config.js next-env.d.ts now.json postcss.config.js tailwind.config.js ./
+# Testing folders / files
+COPY --chown=$USER:$USER cypress cypress.json ./
+# Project config giles
+COPY --chown=$USER:$USER .* ./
+COPY --chown=$USER:$USER entrypoint.sh tsconfig.json ./
+
+EXPOSE 3000
+ENTRYPOINT ["./entrypoint.sh"]

--- a/client/entrypoint.sh
+++ b/client/entrypoint.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+set -e
+
+case "$1" in
+    develop)
+        echo "Running web application in development mode"
+        exec yarn dev
+        ;;
+    test)
+        echo "Running Tests"
+        exec yarn cypress:run
+        ;;
+    build)
+        echo "Build web application"
+        exec yarn build
+        ;;
+    start)
+        echo "Run previously built application"
+        exec yarn start
+        ;;
+    *)
+        echo "Usage: entrypoint.sh {develop|test|build|start}" >&2
+        exit 1
+        ;;
+esac

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,19 @@
 version: "3.8"
 services:
+
+  client:
+    build:
+      context: ./client
+      dockerfile: Dockerfile
+    ports:
+      - "${CLIENT_SERVICE_PORT}:3000"
+    container_name: landgriffon-client
+    command: develop
+    user: "5000:5000"
+    volumes:
+      - ./client:/opt/landgriffon-client/
+    env_file: .env
+
   api:
     build:
       context: ./api

--- a/env.default
+++ b/env.default
@@ -1,3 +1,4 @@
+#API ENV VARS:
 # API_AUTH_JWT_SECRET *must* be set for the API to work.
 # `dd if=/dev/urandom bs=1024 count=1 2>/dev/null | base64 -w0` is a simple way
 # to generate a strong random secret.
@@ -7,3 +8,6 @@ API_POSTGRES_PORT=
 API_POSTGRES_USERNAME=
 API_POSTGRES_PASSWORD=
 API_POSTGRES_DATABASE=
+
+#CLIENT ENV VARS:
+CLIENT_SERVICE_PORT=


### PR DESCRIPTION
This PR adds:

[`Dockerfile`](https://github.com/Vizzuality/landgriffon/compare/chore/LANDGRIF-43-configure-docker-frontend?expand=1#diff-c0a19429aa475a5c4fba2e72499771095a4d55a72adf8271238b2a402928b475) file for `client` application

Update [`docker-compose.yml`](https://github.com/Vizzuality/landgriffon/compare/chore/LANDGRIF-43-configure-docker-frontend?expand=1#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3) adding client service

Update [`Makefile`](https://github.com/Vizzuality/landgriffon/compare/chore/LANDGRIF-43-configure-docker-frontend?expand=1#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52) to start just the frontend app or all services at once

New [`ENV VAR`](https://github.com/Vizzuality/landgriffon/compare/chore/LANDGRIF-43-configure-docker-frontend?expand=1#diff-14d0b30702e03f0c4431c6bb68320bc3b0d1660ab34d9e501d28b503d424d42a) **REQUIRED** for exposing the client outside the docker network