### PR TITLE
chore: LANDGRIF-134 Create Admin-Regions / Geo-Regions modules, entities

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -57,6 +57,7 @@
     "@types/config": "^0.0.38",
     "@types/express": "^4.17.11",
     "@types/faker": "^5.5.3",
+    "@types/geojson": "^7946.0.7",
     "@types/jest": "^26.0.22",
     "@types/jsonapi-serializer": "^3.6.3",
     "@types/lodash": "^4.14.168",

--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -9,6 +9,8 @@ import { SuppliersModule } from 'modules/suppliers/suppliers.module';
 import { BusinessUnitsModule } from 'modules/business-units/business-units.module';
 import { MaterialsModule } from 'modules/materials/materials.module';
 import { LayersModule } from 'modules/layers/layers.module';
+import { AdminRegionsModule } from 'modules/admin-regions/admin-regions.module';
+import { GeoRegionsModule } from 'modules/geo-regions/geo-regions.module';
 
 @Module({
   imports: [
@@ -19,6 +21,8 @@ import { LayersModule } from 'modules/layers/layers.module';
     BusinessUnitsModule,
     MaterialsModule,
     LayersModule,
+    AdminRegionsModule,
+    GeoRegionsModule,
   ],
   providers: [
     {

--- a/api/src/modules/admin-regions/admin-regions.entity.ts
+++ b/api/src/modules/admin-regions/admin-regions.entity.ts
@@ -1,0 +1,53 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  BaseEntity,
+  JoinColumn,
+  ManyToOne,
+  Tree,
+  TreeChildren,
+  TreeParent,
+} from 'typeorm';
+import { entityStatus } from 'utils/entity-status.enum';
+import { GeoRegions } from '../geo-regions/geo-regions.entity';
+
+export enum ADMIN_REGIONS_STATUS {
+  ACTIVE = 'active',
+  INACTIVE = 'inactive',
+  DELETED = 'deleted',
+}
+
+@Entity()
+@Tree('materialized-path')
+export class AdminRegions extends BaseEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @TreeChildren()
+  children: AdminRegions[];
+
+  @TreeParent()
+  parent: AdminRegions;
+
+  @Column({ nullable: true })
+  name: string;
+
+  @Column({ nullable: true })
+  description: string;
+
+  @Column({
+    type: 'enum',
+    enum: ADMIN_REGIONS_STATUS,
+    enumName: 'entity_status',
+    default: ADMIN_REGIONS_STATUS.INACTIVE,
+  })
+  status: entityStatus;
+
+  @Column({ name: 'iso_a3', nullable: true })
+  isoA3: string;
+
+  @ManyToOne(() => GeoRegions, (geo: GeoRegions) => geo.id)
+  @JoinColumn({ name: 'geo_region_id' })
+  geoRegionId: string;
+}

--- a/api/src/modules/admin-regions/admin-regions.module.ts
+++ b/api/src/modules/admin-regions/admin-regions.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { AdminRegionsRepository } from './admin-regions.repository';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([AdminRegionsRepository])],
+})
+export class AdminRegionsModule {}

--- a/api/src/modules/admin-regions/admin-regions.repository.ts
+++ b/api/src/modules/admin-regions/admin-regions.repository.ts
@@ -1,0 +1,5 @@
+import { EntityRepository, Repository } from 'typeorm';
+import { AdminRegions } from './admin-regions.entity';
+
+@EntityRepository(AdminRegions)
+export class AdminRegionsRepository extends Repository<AdminRegions> {}

--- a/api/src/modules/geo-regions/geo-regions.entity.ts
+++ b/api/src/modules/geo-regions/geo-regions.entity.ts
@@ -1,0 +1,28 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  BaseEntity,
+  OneToMany,
+} from 'typeorm';
+import { Geometry } from 'geojson';
+import { AdminRegions } from '../admin-regions/admin-regions.entity';
+
+@Entity()
+export class GeoRegions extends BaseEntity {
+  @PrimaryGeneratedColumn('uuid')
+  @OneToMany(
+    () => AdminRegions,
+    (adminReg: AdminRegions) => adminReg.geoRegionId,
+  )
+  id: string;
+
+  @Column({ name: 'h3_compact', type: 'text', array: true, nullable: true })
+  h3Compact: string[];
+
+  @Column({ nullable: true })
+  name: string;
+
+  @Column({ name: 'the_geom', type: 'geometry', nullable: true })
+  theGeom: Geometry;
+}

--- a/api/src/modules/geo-regions/geo-regions.module.ts
+++ b/api/src/modules/geo-regions/geo-regions.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { GeoRegionsRepository } from './geo-regions.repository';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([GeoRegionsRepository])],
+})
+export class GeoRegionsModule {}

--- a/api/src/modules/geo-regions/geo-regions.repository.ts
+++ b/api/src/modules/geo-regions/geo-regions.repository.ts
@@ -1,0 +1,5 @@
+import { EntityRepository, Repository } from 'typeorm';
+import { GeoRegions } from './geo-regions.entity';
+
+@EntityRepository(GeoRegions)
+export class GeoRegionsRepository extends Repository<GeoRegions> {}

--- a/api/yarn.lock
+++ b/api/yarn.lock
@@ -871,6 +871,11 @@
   resolved "https://registry.yarnpkg.com/@types/faker/-/faker-5.5.3.tgz#80978e52862e5df9e7a96befdfdd8fad882f6350"
   integrity sha512-InxkM6sCFQTI6YQl29M/XGlO19ecv/EHH5X5zLEFdge2/qya8oIT0XkJUKTqheVYWJtGi+FBAfP7hbbunDiOmg==
 
+"@types/geojson@^7946.0.7":
+  version "7946.0.7"
+  resolved "https://registry.yarnpkg.com/@types/geojson/-/geojson-7946.0.7.tgz#c8fa532b60a0042219cdf173ca21a975ef0666ad"
+  integrity sha512-wE2v81i4C4Ol09RtsWFAqg3BUitWbHSpSlIo+bNdsCJijO9sjme+zm+73ZMCa/qMC8UEERxzGbvmr1cffo2SiQ==
+
 "@types/graceful-fs@^4.1.2":
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/@types/graceful-fs/-/graceful-fs-4.1.5.tgz#21ffba0d98da4350db64891f92a9e5db3cdb4e15"


### PR DESCRIPTION
This PR Adds:

`Admin-regions & Geo-regions` nestjs modules
-Entities models
-Repositories
-Defined N to 1 relation Admin-regions -> Geo-Regions

**NOTE**
Dependant on [LANDGRIF-131](https://github.com/Vizzuality/landgriffon/pull/29) changes to sync Active Record entities against DB