### PR TITLE
show visualization mode in the URL

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Calendar Versioning](https://calver.org/).
+
+## 2021.07.14 [Unreleased]
+### Added
+* Show visualization mode in the URL (map, table or chart) [LANDGRIF-119](https://vizzuality.atlassian.net/browse/LANDGRIF-119)

--- a/client/src/containers/analysis-visualization/component.tsx
+++ b/client/src/containers/analysis-visualization/component.tsx
@@ -1,9 +1,12 @@
-import { useCallback } from 'react';
+import { useEffect } from 'react';
+import Link from 'next/link';
+import classNames from 'classnames';
+import { useRouter } from 'next/router';
 import { ChartPieIcon, MapIcon, TableIcon } from '@heroicons/react/outline';
 import { useAppSelector, useAppDispatch } from 'store/hooks';
 import { visualizationMode, setVisualizationMode } from 'store/features/analysis';
+import type { AnalysisState } from 'store/features/analysis';
 import Map from 'components/map';
-import classNames from 'classnames';
 
 const MAPBOX_API_TOKEN = process.env.NEXT_PUBLIC_MAPBOX_API_TOKEN;
 
@@ -12,43 +15,55 @@ const impactFactors = [{ id: '1', name: 'Rice', 2021: 342, 2022: 632, 2023: 1332
 const AnalysisVisualization = () => {
   const currentMode = useAppSelector(visualizationMode);
   const dispatch = useAppDispatch();
+  const { query } = useRouter();
+  const { mode } = query;
 
-  const handleChange = useCallback((event) => {
-    const selectedMode = event.currentTarget.dataset.mode;
+  useEffect(() => {
+    const selectedMode = (mode as AnalysisState['visualizationMode']) || 'map';
     dispatch(setVisualizationMode(selectedMode));
-  }, []);
+  }, [mode]);
 
   return (
     <section className="min-w-0 flex-1 h-full flex flex-col overflow-hidden lg:order-last bg-white">
       {/* Vis selector: map, table or chart */}
       <div className="absolute right-6 top-6 z-10 inline-flex shadow-sm rounded-md">
-        <button
-          type="button"
-          data-mode="map"
-          className={classNames(
-            'relative inline-flex items-center px-4 py-2 rounded-l-md border border-gray-300 bg-white text-sm font-medium text-gray-700 hover:bg-gray-50 focus:z-10 focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500',
-            { 'z-10 outline-none ring-1 ring-indigo-500 border-indigo-500': currentMode === 'map' }
-          )}
-          onClick={handleChange}
+        <Link
+          href={{
+            pathname: '/analysis',
+            query: { ...query, mode: 'map' },
+          }}
         >
-          <MapIcon className="h-6 w-6" aria-hidden="true" />
-        </button>
-        <button
-          type="button"
-          data-mode="table"
-          className="-ml-px relative inline-flex items-center px-4 py-2 border border-gray-300 bg-white text-sm font-medium text-gray-700 hover:bg-gray-50 focus:z-10 focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500"
-          onClick={handleChange}
+          <a
+            className={classNames(
+              'relative inline-flex items-center px-4 py-2 rounded-l-md border border-gray-300 bg-white text-sm font-medium text-gray-700 hover:bg-gray-50 focus:z-10 focus:outline-none focus:ring-1 focus:ring-green-700 focus:border-green-700',
+              {
+                'z-10 outline-none ring-1 ring-green-700 border-green-700': currentMode === 'map',
+              }
+            )}
+          >
+            <MapIcon className="h-6 w-6" aria-hidden="true" />
+          </a>
+        </Link>
+        <Link
+          href={{
+            pathname: '/analysis',
+            query: { ...query, mode: 'table' },
+          }}
         >
-          <TableIcon className="h-6 w-6" aria-hidden="true" />
-        </button>
-        <button
-          type="button"
-          data-mode="chart"
-          className="-ml-px relative inline-flex items-center px-4 py-2 rounded-r-md border border-gray-300 bg-white text-sm font-medium text-gray-700 hover:bg-gray-50 focus:z-10 focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500"
-          onClick={handleChange}
+          <a className="-ml-px relative inline-flex items-center px-4 py-2 border border-gray-300 bg-white text-sm font-medium text-gray-700 hover:bg-gray-50 focus:z-10 focus:outline-none focus:ring-1 focus:ring-green-700 focus:border-green-700">
+            <TableIcon className="h-6 w-6" aria-hidden="true" />
+          </a>
+        </Link>
+        <Link
+          href={{
+            pathname: '/analysis',
+            query: { ...query, mode: 'chart' },
+          }}
         >
-          <ChartPieIcon className="h-6 w-6" aria-hidden="true" />
-        </button>
+          <a className="-ml-px relative inline-flex items-center px-4 py-2 rounded-r-md border border-gray-300 bg-white text-sm font-medium text-gray-700 hover:bg-gray-50 focus:z-10 focus:outline-none focus:ring-1 focus:ring-green-700 focus:border-green-700">
+            <ChartPieIcon className="h-6 w-6" aria-hidden="true" />
+          </a>
+        </Link>
       </div>
 
       {currentMode === 'map' && (

--- a/client/src/containers/analysis-visualization/component.tsx
+++ b/client/src/containers/analysis-visualization/component.tsx
@@ -1,12 +1,7 @@
-import { useEffect } from 'react';
-import Link from 'next/link';
-import classNames from 'classnames';
-import { useRouter } from 'next/router';
-import { ChartPieIcon, MapIcon, TableIcon } from '@heroicons/react/outline';
-import { useAppSelector, useAppDispatch } from 'store/hooks';
-import { visualizationMode, setVisualizationMode } from 'store/features/analysis';
-import type { AnalysisState } from 'store/features/analysis';
+import { useAppSelector } from 'store/hooks';
+import { visualizationMode } from 'store/features/analysis';
 import Map from 'components/map';
+import ModeControl from './mode-control';
 
 const MAPBOX_API_TOKEN = process.env.NEXT_PUBLIC_MAPBOX_API_TOKEN;
 
@@ -14,57 +9,11 @@ const impactFactors = [{ id: '1', name: 'Rice', 2021: 342, 2022: 632, 2023: 1332
 
 const AnalysisVisualization = () => {
   const currentMode = useAppSelector(visualizationMode);
-  const dispatch = useAppDispatch();
-  const { query } = useRouter();
-  const { mode } = query;
-
-  useEffect(() => {
-    const selectedMode = (mode as AnalysisState['visualizationMode']) || 'map';
-    dispatch(setVisualizationMode(selectedMode));
-  }, [mode]);
 
   return (
     <section className="min-w-0 flex-1 h-full flex flex-col overflow-hidden lg:order-last bg-white">
       {/* Vis selector: map, table or chart */}
-      <div className="absolute right-6 top-6 z-10 inline-flex shadow-sm rounded-md">
-        <Link
-          href={{
-            pathname: '/analysis',
-            query: { ...query, mode: 'map' },
-          }}
-        >
-          <a
-            className={classNames(
-              'relative inline-flex items-center px-4 py-2 rounded-l-md border border-gray-300 bg-white text-sm font-medium text-gray-700 hover:bg-gray-50 focus:z-10 focus:outline-none focus:ring-1 focus:ring-green-700 focus:border-green-700',
-              {
-                'z-10 outline-none ring-1 ring-green-700 border-green-700': currentMode === 'map',
-              }
-            )}
-          >
-            <MapIcon className="h-6 w-6" aria-hidden="true" />
-          </a>
-        </Link>
-        <Link
-          href={{
-            pathname: '/analysis',
-            query: { ...query, mode: 'table' },
-          }}
-        >
-          <a className="-ml-px relative inline-flex items-center px-4 py-2 border border-gray-300 bg-white text-sm font-medium text-gray-700 hover:bg-gray-50 focus:z-10 focus:outline-none focus:ring-1 focus:ring-green-700 focus:border-green-700">
-            <TableIcon className="h-6 w-6" aria-hidden="true" />
-          </a>
-        </Link>
-        <Link
-          href={{
-            pathname: '/analysis',
-            query: { ...query, mode: 'chart' },
-          }}
-        >
-          <a className="-ml-px relative inline-flex items-center px-4 py-2 rounded-r-md border border-gray-300 bg-white text-sm font-medium text-gray-700 hover:bg-gray-50 focus:z-10 focus:outline-none focus:ring-1 focus:ring-green-700 focus:border-green-700">
-            <ChartPieIcon className="h-6 w-6" aria-hidden="true" />
-          </a>
-        </Link>
-      </div>
+      <ModeControl />
 
       {currentMode === 'map' && (
         <Map

--- a/client/src/containers/analysis-visualization/mode-control/component.stories.tsx
+++ b/client/src/containers/analysis-visualization/mode-control/component.stories.tsx
@@ -1,0 +1,18 @@
+import type { Story } from '@storybook/react';
+import ModeControl from './component';
+import type { ModeControlProps } from './component';
+
+export default {
+  title: 'Containers/ModeControl',
+  component: ModeControl,
+  argTypes: {},
+};
+
+const Template: Story<ModeControlProps> = (props: ModeControlProps) => <ModeControl {...props} />;
+
+export const Default = Template.bind({});
+
+Default.args = {
+  mode: 'map',
+  query: {},
+};

--- a/client/src/containers/analysis-visualization/mode-control/component.tsx
+++ b/client/src/containers/analysis-visualization/mode-control/component.tsx
@@ -1,0 +1,64 @@
+import Link from 'next/link';
+import classNames from 'classnames';
+import { ChartPieIcon, MapIcon, TableIcon } from '@heroicons/react/outline';
+import type { AnalysisState } from 'store/features/analysis';
+import type { ParsedUrlQuery } from 'querystring';
+
+const CONTROL_ITEM_CLASS_NAMES =
+  'relative inline-flex items-center px-4 py-2 border border-gray-100 bg-white text-sm font-medium text-gray-600 hover:bg-green-50 focus:z-10 focus:outline-none focus:ring-1 focus:ring-green-700 focus:border-green-700';
+const CONTROL_ITEM_ACTIVE_CLASS_NAMES =
+  'z-10 outline-none ring-1 ring-green-700 text-green-700 border-green-700 bg-green-50';
+
+export type ModeControlProps = {
+  query: ParsedUrlQuery;
+  mode: AnalysisState['visualizationMode'];
+};
+
+const ModeControl: React.FC<ModeControlProps> = ({ query, mode }: ModeControlProps) => (
+  <div className="absolute right-6 top-6 z-10 inline-flex shadow-sm rounded-md">
+    <Link
+      href={{
+        pathname: '/analysis',
+        query: { ...query, mode: 'map' },
+      }}
+    >
+      <a
+        className={classNames(CONTROL_ITEM_CLASS_NAMES, 'rounded-l-md', {
+          [CONTROL_ITEM_ACTIVE_CLASS_NAMES]: mode === 'map',
+        })}
+      >
+        <MapIcon className="h-6 w-6" aria-hidden="true" />
+      </a>
+    </Link>
+    <Link
+      href={{
+        pathname: '/analysis',
+        query: { ...query, mode: 'table' },
+      }}
+    >
+      <a
+        className={classNames(CONTROL_ITEM_CLASS_NAMES, '-ml-px', {
+          [CONTROL_ITEM_ACTIVE_CLASS_NAMES]: mode === 'table',
+        })}
+      >
+        <TableIcon className="h-6 w-6" aria-hidden="true" />
+      </a>
+    </Link>
+    <Link
+      href={{
+        pathname: '/analysis',
+        query: { ...query, mode: 'chart' },
+      }}
+    >
+      <a
+        className={classNames(CONTROL_ITEM_CLASS_NAMES, '-ml-px rounded-r-md', {
+          [CONTROL_ITEM_ACTIVE_CLASS_NAMES]: mode === 'chart',
+        })}
+      >
+        <ChartPieIcon className="h-6 w-6" aria-hidden="true" />
+      </a>
+    </Link>
+  </div>
+);
+
+export default ModeControl;

--- a/client/src/containers/analysis-visualization/mode-control/index.tsx
+++ b/client/src/containers/analysis-visualization/mode-control/index.tsx
@@ -1,0 +1,25 @@
+import { useEffect } from 'react';
+import { useRouter } from 'next/router';
+import { useAppSelector, useAppDispatch } from 'store/hooks';
+
+import { visualizationMode, setVisualizationMode } from 'store/features/analysis';
+import type { AnalysisState } from 'store/features/analysis';
+import Component from './component';
+
+const ModeControlContainer = () => {
+  const currentMode = useAppSelector(visualizationMode);
+  const dispatch = useAppDispatch();
+  const { query } = useRouter();
+  const { mode } = query;
+
+  useEffect(() => {
+    if (mode) {
+      const selectedMode = mode as AnalysisState['visualizationMode'];
+      dispatch(setVisualizationMode(selectedMode));
+    }
+  }, [mode]);
+
+  return <Component query={query} mode={currentMode} />;
+};
+
+export default ModeControlContainer;

--- a/client/src/pages/analysis/index.tsx
+++ b/client/src/pages/analysis/index.tsx
@@ -18,8 +18,6 @@ const AnalysisPage: React.FC = () => {
   const { query } = useRouter();
   const { scenarios } = query;
 
-  console.log(query);
-
   const analysisContent = () => ({
     default: <Scenarios />,
     new: <ScenarioNew />,

--- a/client/src/store/features/analysis/index.ts
+++ b/client/src/store/features/analysis/index.ts
@@ -2,7 +2,7 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import type { RootState } from 'store';
 
 // Define a type for the slice state
-interface AnalysisState {
+export interface AnalysisState {
   visualizationMode: 'map' | 'table' | 'chart';
   isSidebarCollapsed: boolean;
   isSubContentCollapsed: boolean;


### PR DESCRIPTION
[LANDGRIF-119]

* Show visualization in the URL. It will have the next format: `/analysis?mode=table`.
* Added CHANGELOG file

UPDATE:
* Created an isolated component ModeControl
* Added ModeControl component to Storybook

[LANDGRIF-119]: https://vizzuality.atlassian.net/browse/LANDGRIF-119