### PR TITLE
BUGFIX: Sourcing Data fixes

### DIFF
--- a/api/src/modules/import-data/sourcing-records/dto-processor.service.ts
+++ b/api/src/modules/import-data/sourcing-records/dto-processor.service.ts
@@ -8,9 +8,10 @@ import { CreateSourcingRecordDto } from 'modules/sourcing-records/dto/create.sou
 import { CreateSourcingLocationDto } from 'modules/sourcing-locations/dto/create.sourcing-location.dto';
 import { Layer } from 'modules/layers/layer.entity';
 import { WorkSheet } from 'xlsx';
+import { SourcingRecord } from 'modules/sourcing-records/sourcing-record.entity';
 
 export interface SourcingData extends CreateSourcingLocationDto {
-  sourcingRecords: CreateSourcingRecordDto[];
+  sourcingRecords: SourcingRecord[];
 }
 
 export interface SourcingRecordsDtos {

--- a/api/src/modules/import-data/sourcing-records/dto-processor.service.ts
+++ b/api/src/modules/import-data/sourcing-records/dto-processor.service.ts
@@ -10,6 +10,10 @@ import { Layer } from 'modules/layers/layer.entity';
 import { WorkSheet } from 'xlsx';
 import { SourcingRecord } from 'modules/sourcing-records/sourcing-record.entity';
 
+/**
+ * @debt: Define a more accurate DTO / Interface / Class for API-DB trades
+ * and spread through typing
+ */
 export interface SourcingData extends CreateSourcingLocationDto {
   sourcingRecords: SourcingRecord[];
 }

--- a/api/src/modules/sourcing-locations/sourcing-locations.service.ts
+++ b/api/src/modules/sourcing-locations/sourcing-locations.service.ts
@@ -61,7 +61,7 @@ export class SourcingLocationsService extends AppBaseService<
     await this.sourcingLocationRepository.delete({});
   }
 
-  async save(entityArray: any[]): Promise<void> {
-    await this.sourcingLocationRepository.save(entityArray);
+  async save(entityArray: any): Promise<any> {
+    return await this.sourcingLocationRepository.save(entityArray);
   }
 }

--- a/api/src/modules/sourcing-locations/sourcing-locations.service.ts
+++ b/api/src/modules/sourcing-locations/sourcing-locations.service.ts
@@ -61,7 +61,12 @@ export class SourcingLocationsService extends AppBaseService<
     await this.sourcingLocationRepository.delete({});
   }
 
-  async save(entityArray: any): Promise<any> {
-    return await this.sourcingLocationRepository.save(entityArray);
+  /**
+   *
+   * @debt Add proper input type when defined. Current workaround
+   * 'SourcingData' mess with Entity typing
+   */
+  async save(sourcingLocation: any): Promise<SourcingLocation> {
+    return await this.sourcingLocationRepository.save(sourcingLocation);
   }
 }

--- a/api/src/modules/sourcing-records/sourcing-record.entity.ts
+++ b/api/src/modules/sourcing-records/sourcing-record.entity.ts
@@ -17,7 +17,7 @@ export const sourcingRecordResource: BaseServiceResource = {
     singular: 'sourcingRecord',
     plural: 'sourcingRecords',
   },
-  entitiesAllowedAsIncludes: [],
+  entitiesAllowedAsIncludes: ['sourcingLocation'],
   columnsAllowedAsFilter: ['tonnage', 'year'],
 };
 
@@ -35,10 +35,14 @@ export class SourcingRecord extends TimestampedBaseEntity {
   @ApiProperty()
   year!: number;
 
-  @ManyToOne(() => SourcingLocation, (srcLoc: SourcingLocation) => srcLoc.id)
-  @JoinColumn()
-  @ApiPropertyOptional()
-  sourcingLocationsId: string;
+  @ManyToOne(() => SourcingLocation, (srcLoc: SourcingLocation) => srcLoc.id, {
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'sourcingLocationId' })
+  sourcingLocation: SourcingLocation;
+
+  @Column({ nullable: true })
+  sourcingLocationId: string;
 
   @Column({ type: 'jsonb', nullable: true })
   @ApiPropertyOptional()
@@ -49,5 +53,5 @@ export class SourcingRecord extends TimestampedBaseEntity {
    */
   @ManyToOne(() => User, (user: User) => user.id)
   @ApiProperty()
-  updatedById?: string;
+  updatedBy?: string;
 }

--- a/api/src/modules/sourcing-records/sourcing-record.entity.ts
+++ b/api/src/modules/sourcing-records/sourcing-record.entity.ts
@@ -35,9 +35,13 @@ export class SourcingRecord extends TimestampedBaseEntity {
   @ApiProperty()
   year!: number;
 
-  @ManyToOne(() => SourcingLocation, (srcLoc: SourcingLocation) => srcLoc.id, {
-    onDelete: 'CASCADE',
-  })
+  @ManyToOne(
+    () => SourcingLocation,
+    (sourcingLocation1: SourcingLocation) => sourcingLocation1.id,
+    {
+      onDelete: 'CASCADE',
+    },
+  )
   @JoinColumn({ name: 'sourcingLocationId' })
   sourcingLocation: SourcingLocation;
 

--- a/api/src/modules/sourcing-records/sourcing-record.entity.ts
+++ b/api/src/modules/sourcing-records/sourcing-record.entity.ts
@@ -42,7 +42,7 @@ export class SourcingRecord extends TimestampedBaseEntity {
   sourcingLocation: SourcingLocation;
 
   @Column({ nullable: true })
-  sourcingLocationId: string;
+  sourcingLocationId!: string;
 
   @Column({ type: 'jsonb', nullable: true })
   @ApiPropertyOptional()

--- a/api/src/modules/sourcing-records/sourcing-records.service.ts
+++ b/api/src/modules/sourcing-records/sourcing-records.service.ts
@@ -36,11 +36,12 @@ export class SourcingRecordsService extends AppBaseService<
       attributes: [
         'tonnage',
         'year',
-        'sourcingLocationsId',
+        'sourcingLocationId',
+        'sourcingLocation',
         'metadata',
         'createdAt',
         'updatedAt',
-        'updatedById',
+        'updatedBy',
       ],
       keyForAttribute: 'camelCase',
     };
@@ -59,7 +60,7 @@ export class SourcingRecordsService extends AppBaseService<
   async clearTable(): Promise<void> {
     await this.sourcingRecordRepository.delete({});
   }
-  async save(entityArray: any[]): Promise<void> {
+  async save(entityArray: SourcingRecord[]): Promise<void> {
     await this.sourcingRecordRepository.save(entityArray);
   }
   async getYears(): Promise<number[]> {

--- a/api/src/modules/sourcing-records/sourcing-records.service.ts
+++ b/api/src/modules/sourcing-records/sourcing-records.service.ts
@@ -60,7 +60,7 @@ export class SourcingRecordsService extends AppBaseService<
   async clearTable(): Promise<void> {
     await this.sourcingRecordRepository.delete({});
   }
-  async save(entityArray: SourcingRecord[]): Promise<void> {
+  async save(entityArray: any[]): Promise<void> {
     await this.sourcingRecordRepository.save(entityArray);
   }
   async getYears(): Promise<number[]> {

--- a/api/test/entity-mocks.ts
+++ b/api/test/entity-mocks.ts
@@ -8,6 +8,7 @@ import { Supplier } from '../src/modules/suppliers/supplier.entity';
 import { SourcingRecord } from '../src/modules/sourcing-records/sourcing-record.entity';
 import { IndicatorRecord } from '../src/modules/indicator-records/indicator-record.entity';
 import { Indicator } from '../src/modules/indicators/indicator.entity';
+import { SourcingLocation } from '../src/modules/sourcing-locations/sourcing-location.entity';
 
 async function createIndicatorCoefficient(
   additionalData: Partial<IndicatorCoefficient> = {},
@@ -144,6 +145,22 @@ async function createScenarioIntervention(
   return scenarioIntervention.save();
 }
 
+async function createSourcingLocation(
+  additionalData: Partial<SourcingLocation> = {},
+): Promise<SourcingLocation> {
+  const sourcingLocation = SourcingLocation.merge(
+    new SourcingLocation(),
+    {
+      title: 'test sourcing location',
+      locationAddressInput: 'pqrst',
+      locationCountryInput: 'uvwxy',
+    },
+    additionalData,
+  );
+
+  return sourcingLocation.save();
+}
+
 async function createSourcingRecord(
   additionalData: Partial<SourcingRecord> = {},
 ): Promise<SourcingRecord> {
@@ -169,5 +186,6 @@ export {
   createSupplier,
   createScenario,
   createScenarioIntervention,
+  createSourcingLocation,
   createSourcingRecord,
 };

--- a/api/test/import-data/xlsx-uploads/sourcing-records-import.spec.ts
+++ b/api/test/import-data/xlsx-uploads/sourcing-records-import.spec.ts
@@ -76,11 +76,11 @@ describe('Sourcing Records import', () => {
     await sourcingLocationRepository.delete({});
     await sourcingRecordRepository.delete({});
     await sourcingLocationGroupRepository.delete({});
-    jest.clearAllTimers();
   });
 
   afterAll(async () => {
     await Promise.all([app.close()]);
+    jest.clearAllTimers();
   });
 
   test('When a file is not sent to the API then it should return a 400 code and the storage folder should be empty', async () => {
@@ -183,7 +183,7 @@ describe('Sourcing Records import', () => {
       sourcingRecords[0].sourcingLocationId,
     );
 
-    expect(sourcingRecords[0].sourcingLocationId).toBeTruthy();
-    expect(sourcingLocation).toBeDefined();
+    expect(sourcingRecords[0]).toMatchObject(new SourcingRecord());
+    expect(sourcingLocation).toMatchObject(new SourcingLocation());
   });
 });

--- a/api/test/sourcing-records/sourcing-records-create.spec.ts
+++ b/api/test/sourcing-records/sourcing-records-create.spec.ts
@@ -4,6 +4,8 @@ import * as request from 'supertest';
 import { AppModule } from 'app.module';
 import { SourcingRecordsModule } from 'modules/sourcing-records/sourcing-records.module';
 import { SourcingRecordRepository } from 'modules/sourcing-records/sourcing-record.repository';
+import { createSourcingLocation } from '../entity-mocks';
+import { SourcingLocation } from '../../src/modules/sourcing-locations/sourcing-location.entity';
 
 describe('Sourcing records - Create', () => {
   let app: INestApplication;


### PR DESCRIPTION
**PLEASE, READ** (It's actually sad I have to put this here)

This PR Fixes:

- Incorrect meta / non-meta prop buildin. Cannot explain when this happened, must have been a dark elf

- Lost coordinates: Lodash's `isEmpty` always evaluating the condition to true, therefore `lat` and `long` always `undefined`

- Little changes in the `sourcing-data building algorithm - dto parsing` to have awareness of `sourcing-location -> sourcing-records relation
`




**KEY NOTES**

-As I already mentioned, I'd say we should try to change N-1 relation to 1-N  to decrease time complexity, and also increase our QoL letting the ORM do the dirty job. I believe I have no other way to know the relation between involved entities in the way that the data comes to us

-Also I think that 'forcing' to validate data against Api-Client contract DTOs, when data-shape before persisting point does not match, does not make any sense.  The `entity definition` itself is the contract between API and persistence layer, so we could either:
  - Use the `entity` itself for both validation and typing, but this would imply to add validation decorators to the entity, and could get messy to read
  - Create specific DTOs for API-DB trades, but this also sounds a bit nasty. I'd rather go for the former
  
 