### PR TITLE
Feature: LANDGRIF-146 - Allow CRUD to link entities

### DIFF
--- a/api/src/modules/materials/material.entity.ts
+++ b/api/src/modules/materials/material.entity.ts
@@ -1,6 +1,7 @@
 import {
   Column,
   Entity,
+  JoinColumn,
   ManyToOne,
   OneToMany,
   PrimaryGeneratedColumn,
@@ -27,7 +28,7 @@ export const materialResource: BaseServiceResource = {
     singular: 'material',
     plural: 'materials',
   },
-  entitiesAllowedAsIncludes: ['children'],
+  entitiesAllowedAsIncludes: ['children', 'layer'],
   columnsAllowedAsFilter: [
     'name',
     'description',
@@ -101,7 +102,11 @@ export class Material extends TimestampedBaseEntity {
   )
   sourcingLocations: SourcingLocation[];
 
-  @ManyToOne(() => Layer, (layer: Layer) => layer.materials, { eager: false })
+  @ManyToOne(() => Layer, (layer: Layer) => layer.materials, {
+    eager: false,
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'layerId' })
   layer: Layer;
 
   /**

--- a/api/src/modules/materials/materials.controller.ts
+++ b/api/src/modules/materials/materials.controller.ts
@@ -57,7 +57,7 @@ export class MaterialsController {
         name: columnName,
       }),
     ),
-    entitiesAllowedAsIncludes: ['children'],
+    entitiesAllowedAsIncludes: materialResource.entitiesAllowedAsIncludes,
   })
   @Get()
   async findAll(
@@ -101,9 +101,15 @@ export class MaterialsController {
   @ApiOkResponse({ type: Material })
   @JSONAPISingleEntityQueryParams()
   @Get(':id')
-  async findOne(@Param('id') id: string): Promise<Material> {
+  async findOne(
+    @ProcessFetchSpecification({
+      allowedFilters: materialResource.columnsAllowedAsFilter,
+    })
+    fetchSpecification: FetchSpecification,
+    @Param('id') id: string,
+  ): Promise<Material> {
     return await this.materialsService.serialize(
-      await this.materialsService.getById(id),
+      await this.materialsService.getById(id, fetchSpecification),
     );
   }
 

--- a/api/src/modules/materials/materials.service.ts
+++ b/api/src/modules/materials/materials.service.ts
@@ -34,6 +34,7 @@ export class MaterialsService extends AppBaseService<
         'name',
         'description',
         'status',
+        'layer',
         'layerId',
         'hsCodeId',
         'earthstatId',

--- a/api/src/modules/sourcing-locations/sourcing-location.entity.ts
+++ b/api/src/modules/sourcing-locations/sourcing-location.entity.ts
@@ -37,7 +37,7 @@ export const sourcingLocationResource: BaseServiceResource = {
     singular: 'sourcingLocation',
     plural: 'sourcingLocations',
   },
-  entitiesAllowedAsIncludes: [],
+  entitiesAllowedAsIncludes: ['sourcingLocationGroup'],
   columnsAllowedAsFilter: ['title'],
 };
 
@@ -101,16 +101,31 @@ export class SourcingLocation extends TimestampedBaseEntity {
   @ManyToOne(() => User, (user: User) => user.sourcingLocations, {
     eager: false,
   })
+  @JoinColumn({ name: 'updatedById' })
   updatedBy: User;
+
+  /**
+   * @debt: Make this required and auto-set once auth is great again
+   */
+  @Column({ nullable: true })
+  updatedById: string;
 
   @ManyToOne(() => Material, (mat: Material) => mat.sourcingLocations, {
     eager: false,
+    onDelete: 'CASCADE',
   })
+  @JoinColumn({ name: 'materialId' })
   material: Material;
+
+  @ApiPropertyOptional()
+  @Column({ nullable: true })
+  materialId: string;
 
   @ManyToOne(() => AdminRegion, (aR: AdminRegion) => aR.sourcingLocations, {
     eager: false,
+    onDelete: 'CASCADE',
   })
+  @JoinColumn({ name: 'adminRegionId' })
   adminRegion: AdminRegion;
 
   @Column({ nullable: true })
@@ -119,14 +134,21 @@ export class SourcingLocation extends TimestampedBaseEntity {
 
   @ManyToOne(() => BusinessUnit, (bu: BusinessUnit) => bu.sourcingLocations, {
     eager: false,
+    onDelete: 'CASCADE',
   })
+  @JoinColumn({ name: 'businessUnitId' })
   businessUnit: BusinessUnit;
+
+  @ApiPropertyOptional()
+  @Column({ nullable: true })
+  businessUnitId: string;
 
   @ManyToOne(
     () => Supplier,
     (supplier: Supplier) => supplier.sourcingLocations,
     {
       eager: false,
+      onDelete: 'CASCADE',
     },
   )
   t1Supplier: Supplier;
@@ -136,6 +158,7 @@ export class SourcingLocation extends TimestampedBaseEntity {
     (supplier: Supplier) => supplier.sourcingLocations,
     {
       eager: false,
+      onDelete: 'CASCADE',
     },
   )
   producer: Supplier;
@@ -148,7 +171,10 @@ export class SourcingLocation extends TimestampedBaseEntity {
       onDelete: 'CASCADE',
     },
   )
-  @JoinColumn()
-  @ApiPropertyOptional()
-  sourcingLocationGroupId: string;
+  @JoinColumn({ name: 'sourcingLocationGroupId' })
+  sourcingLocationGroup: SourcingLocationGroup;
+
+  @Column({ nullable: true })
+  @ApiProperty()
+  sourcingLocationGroupId!: string;
 }

--- a/api/src/modules/sourcing-locations/sourcing-locations.controller.ts
+++ b/api/src/modules/sourcing-locations/sourcing-locations.controller.ts
@@ -53,6 +53,8 @@ export class SourcingLocationsController {
         name: columnName,
       }),
     ),
+    entitiesAllowedAsIncludes:
+      sourcingLocationResource.entitiesAllowedAsIncludes,
   })
   @Get()
   async findAll(
@@ -74,9 +76,15 @@ export class SourcingLocationsController {
   @ApiOkResponse({ type: SourcingLocation })
   @JSONAPISingleEntityQueryParams()
   @Get(':id')
-  async findOne(@Param('id') id: string): Promise<SourcingLocation> {
+  async findOne(
+    @ProcessFetchSpecification({
+      allowedFilters: sourcingLocationResource.columnsAllowedAsFilter,
+    })
+    fetchSpecification: FetchSpecification,
+    @Param('id') id: string,
+  ): Promise<SourcingLocation> {
     return await this.sourcingLocationsService.serialize(
-      await this.sourcingLocationsService.getById(id),
+      await this.sourcingLocationsService.getById(id, fetchSpecification),
     );
   }
 

--- a/api/src/modules/sourcing-locations/sourcing-locations.service.ts
+++ b/api/src/modules/sourcing-locations/sourcing-locations.service.ts
@@ -37,6 +37,8 @@ export class SourcingLocationsService extends AppBaseService<
         'title',
         'locationType',
         'locationAccuracy',
+        'sourcingLocationGroupId',
+        'sourcingLocationGroup',
         'createdAt',
         'updatedAt',
         'metadata',

--- a/api/src/modules/sourcing-records/sourcing-records.controller.ts
+++ b/api/src/modules/sourcing-records/sourcing-records.controller.ts
@@ -96,9 +96,15 @@ export class SourcingRecordsController {
   @ApiOkResponse({ type: SourcingRecord })
   @JSONAPISingleEntityQueryParams()
   @Get(':id')
-  async findOne(@Param('id') id: string): Promise<SourcingRecord> {
+  async findOne(
+    @ProcessFetchSpecification({
+      allowedFilters: sourcingRecordResource.columnsAllowedAsFilter,
+    })
+    fetchSpecification: FetchSpecification,
+    @Param('id') id: string,
+  ): Promise<SourcingRecord> {
     return await this.sourcingRecordsService.serialize(
-      await this.sourcingRecordsService.getById(id),
+      await this.sourcingRecordsService.getById(id, fetchSpecification),
     );
   }
 

--- a/api/test/entity-mocks.ts
+++ b/api/test/entity-mocks.ts
@@ -9,6 +9,7 @@ import { SourcingRecord } from '../src/modules/sourcing-records/sourcing-record.
 import { IndicatorRecord } from '../src/modules/indicator-records/indicator-record.entity';
 import { Indicator } from '../src/modules/indicators/indicator.entity';
 import { SourcingLocation } from '../src/modules/sourcing-locations/sourcing-location.entity';
+import { SourcingLocationGroup } from '../src/modules/sourcing-location-groups/sourcing-location-group.entity';
 
 async function createIndicatorCoefficient(
   additionalData: Partial<IndicatorCoefficient> = {},
@@ -161,6 +162,20 @@ async function createSourcingLocation(
   return sourcingLocation.save();
 }
 
+async function createSourcingLocationGroup(
+  additionalData: Partial<SourcingLocationGroup> = {},
+): Promise<SourcingLocationGroup> {
+  const sourcingLocationGroup = SourcingLocationGroup.merge(
+    new SourcingLocationGroup(),
+    {
+      title: 'test sourcing location group',
+    },
+    additionalData,
+  );
+
+  return sourcingLocationGroup.save();
+}
+
 async function createSourcingRecord(
   additionalData: Partial<SourcingRecord> = {},
 ): Promise<SourcingRecord> {
@@ -187,5 +202,6 @@ export {
   createScenario,
   createScenarioIntervention,
   createSourcingLocation,
+  createSourcingLocationGroup,
   createSourcingRecord,
 };

--- a/api/test/materials/materials-filters.spec.ts
+++ b/api/test/materials/materials-filters.spec.ts
@@ -1,0 +1,60 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { HttpStatus, INestApplication, ValidationPipe } from '@nestjs/common';
+import * as request from 'supertest';
+import { AppModule } from 'app.module';
+import { Material } from 'modules/materials/material.entity';
+import { MaterialsModule } from 'modules/materials/materials.module';
+import { MaterialRepository } from 'modules/materials/material.repository';
+import { createLayer, createMaterial } from '../entity-mocks';
+import { expectedJSONAPIAttributes } from './config';
+import { Layer } from '../../src/modules/layers/layer.entity';
+
+describe('Materials - Filters', () => {
+  let app: INestApplication;
+  let materialRepository: MaterialRepository;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule, MaterialsModule],
+    }).compile();
+
+    materialRepository = moduleFixture.get<MaterialRepository>(
+      MaterialRepository,
+    );
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(
+      new ValidationPipe({
+        transform: true,
+        whitelist: true,
+        forbidNonWhitelisted: true,
+      }),
+    );
+    await app.init();
+  });
+
+  afterEach(async () => {
+    await materialRepository.delete({});
+  });
+
+  afterAll(async () => {
+    await Promise.all([app.close()]);
+  });
+
+  test('When I fetch a material and I include its Layer relation in the query, then I should receive said material and its Layer relation', async () => {
+    const layer: Layer = await createLayer();
+    const material: Material = await createMaterial({ layerId: layer.id });
+
+    const response = await request(app.getHttpServer())
+      .get(`/api/v1/materials/${material.id}?include=layer`)
+      .send()
+      .expect(HttpStatus.OK);
+
+    expect(response.body.data.id).toEqual(material.id);
+    expect(response).toHaveJSONAPIAttributes([
+      ...expectedJSONAPIAttributes,
+      'layer',
+    ]);
+    expect(response.body.data.attributes.layer).toMatchObject(layer);
+  });
+});

--- a/api/test/sourcing-locations/sourcing-locations-filters.spec.ts
+++ b/api/test/sourcing-locations/sourcing-locations-filters.spec.ts
@@ -1,0 +1,70 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { HttpStatus, INestApplication, ValidationPipe } from '@nestjs/common';
+import * as request from 'supertest';
+import { AppModule } from 'app.module';
+import { SourcingLocation } from 'modules/sourcing-locations/sourcing-location.entity';
+import { SourcingLocationsModule } from 'modules/sourcing-locations/sourcing-locations.module';
+import { SourcingLocationRepository } from 'modules/sourcing-locations/sourcing-location.repository';
+import { SourcingLocationGroup } from 'modules/sourcing-location-groups/sourcing-location-group.entity';
+import {
+  createSourcingLocation,
+  createSourcingLocationGroup,
+} from '../entity-mocks';
+
+describe('SourcingLocationsModule (e2e)', () => {
+  let app: INestApplication;
+  let sourcingLocationRepository: SourcingLocationRepository;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule, SourcingLocationsModule],
+    }).compile();
+
+    sourcingLocationRepository = moduleFixture.get<SourcingLocationRepository>(
+      SourcingLocationRepository,
+    );
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(
+      new ValidationPipe({
+        transform: true,
+        whitelist: true,
+        forbidNonWhitelisted: true,
+      }),
+    );
+    await app.init();
+  });
+
+  afterEach(async () => {
+    await sourcingLocationRepository.delete({});
+  });
+
+  afterAll(async () => {
+    await Promise.all([app.close()]);
+  });
+
+  describe('Sourcing locations - Filters', () => {
+    test('When I fetch a sourcing-locationd and I include its relation sourcing-record-group in the query, I should receive said sourcing-location and its related sourcing-record-group', async () => {
+      const sourcingLocationGroup: SourcingLocationGroup = await createSourcingLocationGroup();
+      const sourcingLocation: SourcingLocation = await createSourcingLocation({
+        sourcingLocationGroupId: sourcingLocationGroup.id,
+      });
+      const response = await request(app.getHttpServer())
+        .get(
+          `/api/v1/sourcing-locations/${sourcingLocation.id}?include=sourcingLocationGroup`,
+        )
+        .expect(HttpStatus.OK);
+
+      expect(response.body.data.attributes.sourcingLocationGroupId).toEqual(
+        sourcingLocationGroup.id,
+      );
+      expect(response.body.data.attributes.sourcingLocationGroup).toMatchObject(
+        {
+          ...sourcingLocationGroup,
+          updatedAt: expect.any(String),
+          createdAt: expect.any(String),
+        },
+      );
+    });
+  });
+});

--- a/api/test/sourcing-records/sourcing-records-create.spec.ts
+++ b/api/test/sourcing-records/sourcing-records-create.spec.ts
@@ -34,7 +34,6 @@ describe('Sourcing records - Create', () => {
   afterEach(async () => {
     await sourcingRecordRepository.delete({});
   });
-
   afterAll(async () => {
     await Promise.all([app.close()]);
   });

--- a/api/test/sourcing-records/sourcing-records-filters.spec.ts
+++ b/api/test/sourcing-records/sourcing-records-filters.spec.ts
@@ -6,10 +6,10 @@ import { SourcingRecord } from 'modules/sourcing-records/sourcing-record.entity'
 import { SourcingRecordsModule } from 'modules/sourcing-records/sourcing-records.module';
 import { SourcingRecordRepository } from 'modules/sourcing-records/sourcing-record.repository';
 import { createSourcingLocation, createSourcingRecord } from '../entity-mocks';
-import { SourcingLocation } from '../../src/modules/sourcing-locations/sourcing-location.entity';
-import { SourcingLocationRepository } from '../../src/modules/sourcing-locations/sourcing-location.repository';
+import { SourcingLocation } from 'modules/sourcing-locations/sourcing-location.entity';
+import { SourcingLocationRepository } from 'modules/sourcing-locations/sourcing-location.repository';
 
-describe('Sourcing records - Get by id', () => {
+describe('Sourcing records -Filters', () => {
   let app: INestApplication;
   let sourcingRecordRepository: SourcingRecordRepository;
   let sourcingLocationRepository: SourcingLocationRepository;
@@ -43,17 +43,6 @@ describe('Sourcing records - Get by id', () => {
 
   afterAll(async () => {
     await Promise.all([app.close()]);
-  });
-
-  test('Get a sourcing record by id should be successful (happy case)', async () => {
-    const sourcingRecord: SourcingRecord = await createSourcingRecord();
-
-    const response = await request(app.getHttpServer())
-      .get(`/api/v1/sourcing-records/${sourcingRecord.id}`)
-      .send()
-      .expect(HttpStatus.OK);
-
-    expect(response.body.data.id).toEqual(sourcingRecord.id);
   });
 
   /**


### PR DESCRIPTION
This PR adds:

Capabilities for retrieving relational entities 
**Currently for the data for we know / have relationships**

ON DELETE CASCADE for N->1 relations, again, for the entities we have relations for
**Because allowing inconsistent data will lead us to pain and suffering**

Some tests

**NOTE**
There are still missing pieces for data and relations, I worked with the info I have right now
We are allowing nullable FK when we shouldn't, but it is what it is

**There will be changes here, but FE can start retrieving related stuff** 
