### PR TITLE
Set theGeom column type to MULTIPOLYGON 4326

### DIFF
--- a/api/src/modules/geo-regions/geo-region.entity.ts
+++ b/api/src/modules/geo-regions/geo-region.entity.ts
@@ -33,7 +33,12 @@ export class GeoRegion extends BaseEntity {
   @ApiPropertyOptional()
   name?: string;
 
-  @Column({ type: 'jsonb', nullable: true })
+  @Column({
+    type: 'geometry',
+    spatialFeatureType: 'MULTIPOLYGON',
+    srid: 4326,
+    nullable: true,
+  })
   @ApiPropertyOptional()
   theGeom?: JSON;
 


### PR DESCRIPTION
This PR adds:

Minimal changes at `geo_regions` entity definition, at `theGeom` column decorator, from simple `json` to:

Type: Geometry
Spatial Feature Type: MULTIPOLYGON
SRID: 4326

So LG Data team can INSERT proper geometries from GADM whatever and avoid PostGIS errors