### PR TITLE
Update data-model

### DIFF
--- a/api/src/modules/admin-regions/admin-region.entity.ts
+++ b/api/src/modules/admin-regions/admin-region.entity.ts
@@ -63,6 +63,10 @@ export class AdminRegion extends BaseEntity {
 
   @Column({ nullable: true })
   @ApiPropertyOptional()
+  isoA2?: string;
+
+  @Column({ nullable: true })
+  @ApiPropertyOptional()
   isoA3?: string;
 
   @OneToMany(

--- a/api/src/modules/materials/material.entity.ts
+++ b/api/src/modules/materials/material.entity.ts
@@ -4,6 +4,7 @@ import {
   JoinColumn,
   ManyToOne,
   OneToMany,
+  OneToOne,
   PrimaryGeneratedColumn,
   Tree,
   TreeChildren,
@@ -15,6 +16,7 @@ import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { IndicatorCoefficient } from 'modules/indicator-coefficients/indicator-coefficient.entity';
 import { SourcingLocation } from 'modules/sourcing-locations/sourcing-location.entity';
 import { TimestampedBaseEntity } from 'baseEntities/timestamped-base-entity';
+import { H3Data } from 'modules/h3-data/h3-data.entity';
 
 export enum MATERIALS_STATUS {
   ACTIVE = 'active',
@@ -116,4 +118,8 @@ export class Material extends TimestampedBaseEntity {
   @ApiProperty()
   @Column()
   layerId!: string;
+
+  @OneToOne(() => H3Data)
+  @JoinColumn()
+  h3Grid: H3Data;
 }


### PR DESCRIPTION
This PR adds minimal changes:

- OneToOne relation on Material and H3Data to be able to link a specific grid to a specific material

-isoA2 code field in Admin-Regions due to geocoding requirements