### PR TITLE
FIX: RiskMap Query

### DIFF
--- a/api/src/modules/h3-data/h3-data.controller.ts
+++ b/api/src/modules/h3-data/h3-data.controller.ts
@@ -34,7 +34,7 @@ export class H3DataController {
   async geth3ByIdAndResolution(
     @Query(ValidationPipe)
     queryParams: MaterialH3ByResolutionDto,
-  ): Promise<any> {
+  ): Promise<H3IndexValueData> {
     const { materialId, resolution } = queryParams;
     return await this.h3DataService.getMaterialH3ByResolution(
       materialId,

--- a/api/src/modules/h3-data/h3-data.service.ts
+++ b/api/src/modules/h3-data/h3-data.service.ts
@@ -34,7 +34,7 @@ export class H3DataService {
   async getMaterialH3ByResolution(
     materialId: string,
     resolution: number,
-  ): Promise<unknown> {
+  ): Promise<H3IndexValueData> {
     const material = await this.materialService.getMaterialById(materialId);
     if (!material.h3Grid)
       throw new NotFoundException(
@@ -51,7 +51,6 @@ export class H3DataService {
     materialH3Data: H3Data,
     calculusFactor: number,
   ): Promise<H3IndexValueData> {
-    this.logger.log(`Generating Risk Map...`);
     return await this.h3DataRepository.calculateRiskMapByMaterialAndIndicator(
       indicatorH3Data,
       materialH3Data,

--- a/api/src/modules/risk-map/risk-map.service.ts
+++ b/api/src/modules/risk-map/risk-map.service.ts
@@ -51,6 +51,7 @@ export class RiskMapService {
       material.h3Grid,
       unitConversion.factor as number,
     );
+
     return {
       indicator: indicator.name,
       material: material.name,

--- a/api/test/risk-map/risk-map.spec.ts
+++ b/api/test/risk-map/risk-map.spec.ts
@@ -171,7 +171,6 @@ describe('Risk Map Test Suite (e2e)', () => {
       name: unit.name,
       symbol: unit.symbol,
     });
-    // TODO: Uncomment this assertion as soons as finish risk-map implementation. This is commented out to unblock FE
-    //expect(Object.entries(response.body.riskMap).length).toEqual(384);
+    expect(Object.entries(response.body.riskMap).length).toEqual(384);
   });
 });


### PR DESCRIPTION
Fixed wrong query to calculate a retrieve a RIskmap, given a material and a indicator

I decided to not use streams for retrieving this data, since the amount retrieved is reasonable in terms of time and weight

Also this let us to manipulate the retrieved data server-side, so we can return a single hash-map plus attach more required info so FE has all that is needed in a single request

Anyways, if we decide to go with streams with this implementation, switching it is a painless change, although it would have some caveats that we can discuss