### PR TITLE
Refactor H3 Response shape

### DIFF
--- a/api/src/modules/h3-data/h3-data.controller.ts
+++ b/api/src/modules/h3-data/h3-data.controller.ts
@@ -34,7 +34,7 @@ export class H3DataController {
   async geth3ByIdAndResolution(
     @Query(ValidationPipe)
     queryParams: MaterialH3ByResolutionDto,
-  ): Promise<Array<H3IndexValueData>> {
+  ): Promise<H3IndexValueData[]> {
     const { materialId, resolution } = queryParams;
     return await this.h3DataService.getMaterialH3ByResolution(
       materialId,

--- a/api/src/modules/h3-data/h3-data.controller.ts
+++ b/api/src/modules/h3-data/h3-data.controller.ts
@@ -4,7 +4,6 @@ import { H3DataService } from 'modules/h3-data/h3-data.service';
 import { H3Data, H3IndexValueData } from 'modules/h3-data/h3-data.entity';
 import { MaterialH3ByResolutionDto } from 'modules/h3-data/dto/h3-by-resolution.dto';
 import { GetRiskMapDto } from 'modules/risk-map/dto/get-risk-map.dto';
-import { RiskMapResponseDTO } from 'modules/risk-map/dto/response-risk-map.dto';
 import { RiskMapService } from 'modules/risk-map/risk-map.service';
 
 @Controller('api/v1/h3')
@@ -48,7 +47,7 @@ export class H3DataController {
   @Get('risk-map')
   async getRiskMap(
     @Query(ValidationPipe) queryParams: GetRiskMapDto,
-  ): Promise<RiskMapResponseDTO> {
+  ): Promise<H3IndexValueData[]> {
     const { materialId, indicatorId } = queryParams;
     return await this.riskMapService.calculateRiskMapByMaterialAndIndicator(
       materialId,

--- a/api/src/modules/h3-data/h3-data.controller.ts
+++ b/api/src/modules/h3-data/h3-data.controller.ts
@@ -20,7 +20,7 @@ export class H3DataController {
   async findOneByName(
     @Param('h3TableName') h3TableName: string,
     @Param('h3ColumnName') h3ColumnName: string,
-  ): Promise<{ data: H3IndexValueData }> {
+  ): Promise<{ data: H3IndexValueData[] }> {
     const h3Data = await this.h3DataService.findH3ByName(
       h3TableName,
       h3ColumnName,
@@ -34,7 +34,7 @@ export class H3DataController {
   async geth3ByIdAndResolution(
     @Query(ValidationPipe)
     queryParams: MaterialH3ByResolutionDto,
-  ): Promise<H3IndexValueData> {
+  ): Promise<Array<H3IndexValueData>> {
     const { materialId, resolution } = queryParams;
     return await this.h3DataService.getMaterialH3ByResolution(
       materialId,

--- a/api/src/modules/h3-data/h3-data.entity.ts
+++ b/api/src/modules/h3-data/h3-data.entity.ts
@@ -6,6 +6,11 @@ import {
   PrimaryGeneratedColumn,
 } from 'typeorm';
 
+/**
+ * @note: Interface props are marked as 'h' and 'v' because that is what the DB returns when querying a h3 maps
+ * So we avoid doing transformations within the API and let the DB handle the heavy job
+ */
+
 export interface H3IndexValueData {
   //H3 index
   h: string;

--- a/api/src/modules/h3-data/h3-data.entity.ts
+++ b/api/src/modules/h3-data/h3-data.entity.ts
@@ -7,7 +7,10 @@ import {
 } from 'typeorm';
 
 export interface H3IndexValueData {
-  [key: string]: number;
+  //H3 index
+  h: string;
+  // Values for an h3 index
+  v: number;
 }
 
 @Entity('h3_data')

--- a/api/src/modules/h3-data/h3-data.repository.ts
+++ b/api/src/modules/h3-data/h3-data.repository.ts
@@ -1,7 +1,11 @@
 import { EntityRepository, Repository, getManager } from 'typeorm';
 import { H3Data, H3IndexValueData } from 'modules/h3-data/h3-data.entity';
 import { NotFoundException, ServiceUnavailableException } from '@nestjs/common';
-import { h3Reducer } from 'modules/h3-data/helpers/h3reducer.helper';
+
+/**
+ * @note: Column aliases are marked as 'h' and 'v' so that DB returns data in the format the consumer needs to be
+ * So we avoid doing transformations within the API and let the DB handle the heavy job
+ */
 
 @EntityRepository(H3Data)
 export class H3DataRepository extends Repository<H3Data> {
@@ -10,22 +14,22 @@ export class H3DataRepository extends Repository<H3Data> {
    * @param h3ColumnName: Name of the column inside the dynamically generated table
    * @param h3TableName: Name of the dynamically generated table
    *
-   * @returns: Single object with the h3Index as property key, and its value
    */
   async findH3ByName(
     h3TableName: string,
     h3ColumnName: string,
-  ): Promise<H3IndexValueData> {
-    try {
-      const h3DataResult = await this.query(
-        `SELECT h3index, ${h3ColumnName} FROM ${h3TableName}`,
-      );
-      return h3Reducer(h3DataResult, 'h3index', h3ColumnName);
-    } catch (err) {
+  ): Promise<H3IndexValueData[]> {
+    const h3DataResult = await this.createQueryBuilder()
+      .select('h3index', 'h')
+      .addSelect(`${h3ColumnName}`, 'v')
+      .getRawOne();
+
+    if (!h3DataResult) {
       throw new NotFoundException(
         `H3 ${h3ColumnName} data in ${h3TableName} could not been found`,
       );
     }
+    return h3DataResult;
   }
 
   /** Retrieves single crop data by a given resolution
@@ -34,16 +38,9 @@ export class H3DataRepository extends Repository<H3Data> {
    * @param resolution: An interger between 1 (min resolution) and 6 (max resolution).
    * Resolution validation done at route handler
    *
-   * @returns: Single object with the h3Index as property key, and its value
-   *
-   * @debt: This should be done on a single raw sql query, but I couldn't make it work
-   * Super Senior powers requested
    */
 
-  async getH3ByIdAndResolution(
-    h3Id: string,
-    resolution: number,
-  ): Promise<H3IndexValueData> {
+  async getH3ByIdAndResolution(h3Id: string, resolution: number): Promise<any> {
     const h3Info = await this.createQueryBuilder('h3')
       .select('"h3tableName"')
       .addSelect('"h3columnName"')
@@ -54,22 +51,14 @@ export class H3DataRepository extends Repository<H3Data> {
       throw new NotFoundException(
         `Requested H3 with ID: ${h3Id} could not been found`,
       );
-    /**
-     * @debt: Make this query with queryBuilder. In this case we can uses entity extended query builder,
-     * and we should, since this query points to an entity mapped by TypeORM
-     */
-    try {
-      const h3data = await this.query(
-        `select h3_to_parent(h3index, ${resolution}) as h3_to_parent, sum(${h3Info.h3columnName})
-               from ${h3Info.h3tableName} hgsvrgp group by h3_to_parent`,
-      );
 
-      return h3Reducer(h3data, 'h3_to_parent', 'sum');
-    } catch (err) {
-      throw new ServiceUnavailableException(
-        `H3 indexes with ID: ${h3Id} could not been calculated to resolution ${resolution}`,
-      );
-    }
+    return await getManager()
+      .createQueryBuilder()
+      .select(`h3_to_parent(h3index, ${resolution})`, 'h')
+      .addSelect(`sum(${h3Info.h3columnName})`, 'v')
+      .from(`${h3Info.h3tableName}`, 'h3table')
+      .groupBy('h')
+      .getRawMany();
   }
 
   /**
@@ -83,19 +72,13 @@ export class H3DataRepository extends Repository<H3Data> {
     indicatorH3Data: H3Data,
     materialH3Data: H3Data,
     calculusFactor: number,
-  ): Promise<H3IndexValueData> {
-    /**
-     * @note Using query in order to parse the resultant array into a single hash-map
-     * so the frontend has a constant time complexity when manipulating this data
-     * also, wee need to attach + info about the map: measure unit in which the values should be shown, indicator data, etc..
-     * We could not do this using streams
-     */
+  ): Promise<H3IndexValueData[]> {
     const riskmap = await getManager()
       .createQueryBuilder()
-      .select('materialh3.h3index')
+      .select('materialh3.h3index', 'h')
       .addSelect(
         `indicatorh3.${indicatorH3Data.h3columnName} * ${materialH3Data.h3columnName} / ${calculusFactor} `,
-        'value',
+        'v',
       )
       .from(materialH3Data.h3tableName, 'materialh3')
       .addFrom(indicatorH3Data.h3tableName, 'indicatorh3')
@@ -107,6 +90,6 @@ export class H3DataRepository extends Repository<H3Data> {
         'RiskMap could not been calculated',
       );
     }
-    return h3Reducer(riskmap, 'h3index', 'value');
+    return riskmap;
   }
 }

--- a/api/src/modules/h3-data/h3-data.repository.ts
+++ b/api/src/modules/h3-data/h3-data.repository.ts
@@ -19,17 +19,17 @@ export class H3DataRepository extends Repository<H3Data> {
     h3TableName: string,
     h3ColumnName: string,
   ): Promise<H3IndexValueData[]> {
-    const h3DataResult = await this.createQueryBuilder()
-      .select('h3index', 'h')
-      .addSelect(`${h3ColumnName}`, 'v')
-      .getRawOne();
-
-    if (!h3DataResult) {
-      throw new NotFoundException(
-        `H3 ${h3ColumnName} data in ${h3TableName} could not been found`,
-      );
-    }
-    return h3DataResult;
+    try {
+      return await getManager()
+        .createQueryBuilder()
+        .select('h3index', 'h')
+        .addSelect(`${h3ColumnName}`, 'v')
+        .from(`${h3TableName}`, 'h3')
+        .getRawOne();
+    } catch (err) {}
+    throw new NotFoundException(
+      `H3 ${h3ColumnName} data in ${h3TableName} could not been found`,
+    );
   }
 
   /** Retrieves single crop data by a given resolution
@@ -40,7 +40,10 @@ export class H3DataRepository extends Repository<H3Data> {
    *
    */
 
-  async getH3ByIdAndResolution(h3Id: string, resolution: number): Promise<any> {
+  async getH3ByIdAndResolution(
+    h3Id: string,
+    resolution: number,
+  ): Promise<H3IndexValueData[]> {
     const h3Info = await this.createQueryBuilder('h3')
       .select('"h3tableName"')
       .addSelect('"h3columnName"')

--- a/api/src/modules/h3-data/h3-data.service.ts
+++ b/api/src/modules/h3-data/h3-data.service.ts
@@ -27,14 +27,14 @@ export class H3DataService {
   async findH3ByName(
     h3TableName: string,
     h3ColumnName: string,
-  ): Promise<H3IndexValueData> {
+  ): Promise<H3IndexValueData[]> {
     return await this.h3DataRepository.findH3ByName(h3TableName, h3ColumnName);
   }
 
   async getMaterialH3ByResolution(
     materialId: string,
     resolution: number,
-  ): Promise<H3IndexValueData> {
+  ): Promise<Array<H3IndexValueData>> {
     const material = await this.materialService.getMaterialById(materialId);
     if (!material.h3Grid)
       throw new NotFoundException(
@@ -50,7 +50,7 @@ export class H3DataService {
     indicatorH3Data: H3Data,
     materialH3Data: H3Data,
     calculusFactor: number,
-  ): Promise<H3IndexValueData> {
+  ): Promise<H3IndexValueData[]> {
     return await this.h3DataRepository.calculateRiskMapByMaterialAndIndicator(
       indicatorH3Data,
       materialH3Data,

--- a/api/src/modules/indicators/indicator.entity.ts
+++ b/api/src/modules/indicators/indicator.entity.ts
@@ -26,7 +26,7 @@ export const indicatorResource: BaseServiceResource = {
     singular: 'indicator',
     plural: 'indicators',
   },
-  entitiesAllowedAsIncludes: [],
+  entitiesAllowedAsIncludes: ['unit'],
   columnsAllowedAsFilter: ['name', 'description', 'status'],
 };
 

--- a/api/src/modules/indicators/indicators.controller.ts
+++ b/api/src/modules/indicators/indicators.controller.ts
@@ -69,9 +69,15 @@ export class IndicatorsController {
   @ApiOkResponse({ type: Indicator })
   @JSONAPISingleEntityQueryParams()
   @Get(':id')
-  async findOne(@Param('id') id: string): Promise<Indicator> {
+  async findOne(
+    @Param('id') id: string,
+    @ProcessFetchSpecification({
+      allowedFilters: indicatorResource.columnsAllowedAsFilter,
+    })
+    fetchSpecification: FetchSpecification,
+  ): Promise<Indicator> {
     return await this.indicatorsService.serialize(
-      await this.indicatorsService.getById(id),
+      await this.indicatorsService.getById(id, fetchSpecification),
     );
   }
 

--- a/api/src/modules/materials/material.entity.ts
+++ b/api/src/modules/materials/material.entity.ts
@@ -133,4 +133,7 @@ export class Material extends TimestampedBaseEntity {
    */
   @Column({ nullable: true })
   h3GridId!: string;
+
+  // TODO: Hardcoded value to unblock FE. Remove this ASA Science team can provide this data
+  unit: any;
 }

--- a/api/src/modules/materials/materials.controller.ts
+++ b/api/src/modules/materials/materials.controller.ts
@@ -33,6 +33,7 @@ import { UpdateMaterialDto } from 'modules/materials/dto/update.material.dto';
 import { MaterialRepository } from 'modules/materials/material.repository';
 import { ApiOkTreeResponse } from 'decorators/api-tree-response.decorator';
 import { ParseOptionalIntPipe } from 'pipes/parse-optional-int.pipe';
+import { Unit } from 'modules/units/unit.entity';
 
 @Controller(`/api/v1/materials`)
 @ApiTags(materialResource.className)
@@ -106,10 +107,18 @@ export class MaterialsController {
     })
     fetchSpecification: FetchSpecification,
     @Param('id') id: string,
-  ): Promise<Material> {
-    return await this.materialsService.serialize(
-      await this.materialsService.getById(id, fetchSpecification),
+  ): Promise<Material & Pick<Unit, 'name'> & Pick<Unit, 'symbol'>> {
+    const material = await this.materialsService.getById(
+      id,
+      fetchSpecification,
     );
+    // TODO: Hardcoded value to unblock FE. Remove this ASA Science can provide this data
+    const materialWithUnit = {
+      ...material,
+      unit: { symbol: 'tons' },
+    };
+
+    return await this.materialsService.serialize(materialWithUnit);
   }
 
   @ApiOperation({ description: 'Create a material' })

--- a/api/src/modules/materials/materials.service.ts
+++ b/api/src/modules/materials/materials.service.ts
@@ -45,6 +45,7 @@ export class MaterialsService extends AppBaseService<
         'createdAt',
         'updatedAt',
         'h3GridId',
+        'unit',
       ],
       keyForAttribute: 'camelCase',
     };

--- a/api/src/modules/risk-map/dto/response-risk-map.dto.ts
+++ b/api/src/modules/risk-map/dto/response-risk-map.dto.ts
@@ -10,5 +10,5 @@ export class RiskMapResponseDTO {
     name: string;
     symbol: string;
   };
-  riskMap: H3IndexValueData;
+  riskMap: H3IndexValueData[];
 }

--- a/api/src/modules/risk-map/risk-map.service.ts
+++ b/api/src/modules/risk-map/risk-map.service.ts
@@ -8,8 +8,8 @@ import { MaterialsService } from 'modules/materials/materials.service';
 import { IndicatorsService } from 'modules/indicators/indicators.service';
 import { IndicatorSourcesService } from 'modules/indicator-sources/indicator-sources.service';
 import { H3DataService } from 'modules/h3-data/h3-data.service';
-import { RiskMapResponseDTO } from 'modules/risk-map/dto/response-risk-map.dto';
 import { UnitConversionsService } from 'modules/unit-conversions/unit-conversions.service';
+import { H3IndexValueData } from 'modules/h3-data/h3-data.entity';
 
 /**
  * @note: Formula for Waterfootprint calculus:
@@ -31,7 +31,7 @@ export class RiskMapService {
   async calculateRiskMapByMaterialAndIndicator(
     materialId: string,
     indicatorId: string,
-  ): Promise<RiskMapResponseDTO> {
+  ): Promise<H3IndexValueData[]> {
     const indicator = await this.indicatorService.getIndicatorById(indicatorId);
     if (!indicator.h3Grid)
       throw new NotFoundException(
@@ -46,17 +46,10 @@ export class RiskMapService {
       indicator.unit.id,
     );
 
-    const riskMap = await this.h3dataService.calculateRiskMapByMaterialAndIndicator(
+    return await this.h3dataService.calculateRiskMapByMaterialAndIndicator(
       indicator.h3Grid,
       material.h3Grid,
       unitConversion.factor as number,
     );
-
-    return {
-      indicator: indicator.name,
-      material: material.name,
-      unit: { name: indicator.unit.name, symbol: indicator.unit.symbol },
-      riskMap,
-    };
   }
 }

--- a/api/test/h3-data/h3-data.spec.ts
+++ b/api/test/h3-data/h3-data.spec.ts
@@ -104,7 +104,7 @@ describe('H3-Data Module (e2e)', () => {
       );
     });
 
-    test('When I query H3 data at minimal resolution, then I should get 8 h3indexes', async () => {
+    test.only('When I query H3 data at minimal resolution, then I should get 8 h3indexes', async () => {
       const h3GridId = await createFakeH3Data(
         fakeTable,
         fakeColumn,
@@ -115,16 +115,16 @@ describe('H3-Data Module (e2e)', () => {
         `/api/v1/h3/material?materialId=${material.id}&resolution=1`,
       );
 
-      expect(response.body).toEqual({
-        '81123ffffffffff': 1000,
-        '8112fffffffffff': 0,
-        '8128bffffffffff': 0,
-        '8127bffffffffff': 0,
-        '8112bffffffffff': 0,
-        '81273ffffffffff': 0,
-        '8128fffffffffff': 0,
-        '81127ffffffffff': 0,
-      });
+      expect(response.body).toEqual([
+        { h: '81123ffffffffff', v: 1000 },
+        { h: '8112fffffffffff', v: 0 },
+        { h: '8128bffffffffff', v: 0 },
+        { h: '8127bffffffffff', v: 0 },
+        { h: '8112bffffffffff', v: 0 },
+        { h: '81273ffffffffff', v: 0 },
+        { h: '8128fffffffffff', v: 0 },
+        { h: '81127ffffffffff', v: 0 },
+      ]);
     });
   });
 });

--- a/api/test/h3-data/h3-data.spec.ts
+++ b/api/test/h3-data/h3-data.spec.ts
@@ -53,21 +53,24 @@ describe('H3-Data Module (e2e)', () => {
   });
 
   describe('H3 Data Module E2E Test Suite', () => {
-    test('Given the H3 Data table is empty, when I query the API, then I should be acknowledged that no requested H3 Data has been found ', async () => {
+    test.only('Given the H3 Data table is empty, when I query the API, then I should be acknowledged that no requested H3 Data has been found ', async () => {
       const response = await request(app.getHttpServer())
         .get(`/api/v1/h3/data/${fakeTable}/${fakeColumn}`)
         .expect(HttpStatus.NOT_FOUND);
+
+      console.log(response.body);
       expect(response.body.errors[0].title).toEqual(
         `H3 ${fakeColumn} data in ${fakeTable} could not been found`,
       );
     });
-    test('Given the H3 Data table is populated, when I query the API, then I should get its data in with h3index as key, and column values as value', async () => {
+    test.only('Given the H3 Data table is populated, when I query the API, then I should get its data in with h3index as key, and column values as value', async () => {
       await createFakeH3Data(fakeTable, fakeColumn);
 
       const response = await request(app.getHttpServer())
         .get(`/api/v1/h3/data/${fakeTable}/${fakeColumn}`)
         .expect(HttpStatus.OK);
-      expect(response.body).toEqual({ data: { '861203a4fffffff': 1000 } });
+
+      expect(response.body.data).toEqual({ h: '861203a4fffffff', v: 1000 });
     });
     test('When I query a material H3 with a non available resolution, then I should get a proper error message', async () => {
       const response = await request(app.getHttpServer()).get(
@@ -104,7 +107,7 @@ describe('H3-Data Module (e2e)', () => {
       );
     });
 
-    test.only('When I query H3 data at minimal resolution, then I should get 8 h3indexes', async () => {
+    test('When I query H3 data at minimal resolution, then I should get 8 h3indexes', async () => {
       const h3GridId = await createFakeH3Data(
         fakeTable,
         fakeColumn,

--- a/api/test/h3-data/mocks/create-fake-h3-data.ts
+++ b/api/test/h3-data/mocks/create-fake-h3-data.ts
@@ -1,10 +1,9 @@
 import { getManager } from 'typeorm';
-import { H3IndexValueData } from '../../../src/modules/h3-data/h3-data.entity';
 
 export const createFakeH3Data = async (
   h3TableName: string,
   h3ColumnName: string,
-  aditionalH3Data?: H3IndexValueData,
+  aditionalH3Data?: Record<any, unknown>,
 ): Promise<string> => {
   await getManager().query(
     `CREATE TABLE ${h3TableName} (h3index h3index, ${h3ColumnName} float4);` +

--- a/api/test/materials/config.ts
+++ b/api/test/materials/config.ts
@@ -11,4 +11,5 @@ export const expectedJSONAPIAttributes: string[] = [
   'createdAt',
   'updatedAt',
   'h3GridId',
+  'unit',
 ];

--- a/api/test/risk-map/risk-map.spec.ts
+++ b/api/test/risk-map/risk-map.spec.ts
@@ -171,6 +171,6 @@ describe('Risk Map Test Suite (e2e)', () => {
       name: unit.name,
       symbol: unit.symbol,
     });
-    expect(Object.entries(response.body.riskMap).length).toEqual(384);
+    expect(response.body.riskMap.length).toEqual(384);
   });
 });

--- a/api/test/risk-map/risk-map.spec.ts
+++ b/api/test/risk-map/risk-map.spec.ts
@@ -165,12 +165,6 @@ describe('Risk Map Test Suite (e2e)', () => {
       `/api/v1/h3/risk-map?materialId=${material.id}&indicatorId=${indicator.id}&year=2020`,
     );
 
-    expect(response.body.indicator).toEqual(indicator.name);
-    expect(response.body.material).toEqual(material.name);
-    expect(response.body.unit).toEqual({
-      name: unit.name,
-      symbol: unit.symbol,
-    });
-    expect(response.body.riskMap.length).toEqual(384);
+    expect(response.body.length).toEqual(384);
   });
 });


### PR DESCRIPTION
This PR adds:

Refactoring H3 Response shape from a single object with:

`{'H3Index': 'valueForIndex'}`
To:
```
[
  {h: 'h3index', v: 'Value'}
]
```
Also introduces refactor for h3-repository to use queryBuilder and delete leftover raw query calls

Tests updated accordingly