### PR TITLE
Feature: LANDGRIF-320 Add riskmap deforestation and carbon emissions

### DIFF
--- a/api/src/modules/h3-data/h3-data.repository.ts
+++ b/api/src/modules/h3-data/h3-data.repository.ts
@@ -143,6 +143,57 @@ export class H3DataRepository extends Repository<H3Data> {
     return riskMap;
   }
 
+  async getDeforestationLossRiskMapByResolution(
+    indicatorH3Data: H3Data,
+    materialH3Data: H3Data,
+    resolution: number,
+  ): Promise<H3IndexValueData[]> {
+    // TODO: Check with Data if calculus if accurate
+    const riskMap = await getManager()
+      .createQueryBuilder()
+      .select(`h3_to_parent(materialh3.h3index, ${resolution})`, 'h')
+      .addSelect(
+        `sum(indicatorh3.${indicatorH3Data.h3columnName} * materialh3.${materialH3Data.h3columnName})`,
+        'v',
+      )
+      .from(materialH3Data.h3tableName, 'materialh3')
+      .addFrom(indicatorH3Data.h3tableName, 'indicatorh3')
+      .where(`indicatorh3.h3index = materialh3.h3index`)
+      .andWhere(`materialh3.${materialH3Data.h3columnName} is not null`)
+      .andWhere(`indicatorh3.${indicatorH3Data.h3columnName} is not null`)
+      .groupBy('h')
+      .getRawMany();
+    this.logger.log('Deforestation Loss Map generated');
+
+    return riskMap;
+  }
+
+  async getCarbonEmissionsRiskMapByResolution(
+    indicatorH3Data: H3Data,
+    materialH3Data: H3Data,
+    calculusFactor: number,
+    resolution: number,
+  ): Promise<H3IndexValueData[]> {
+    // TODO: Check with Data if calculus if accurate
+    const riskMap = await getManager()
+      .createQueryBuilder()
+      .select(`h3_to_parent(materialh3.h3index, ${resolution})`, 'h')
+      .addSelect(
+        `sum(indicatorh3.${indicatorH3Data.h3columnName} * (materialh3.${materialH3Data.h3columnName} * (${calculusFactor}/19)))`,
+        'v',
+      )
+      .from(materialH3Data.h3tableName, 'materialh3')
+      .addFrom(indicatorH3Data.h3tableName, 'indicatorh3')
+      .where(`indicatorh3.h3index = materialh3.h3index`)
+      .andWhere(`materialh3.${materialH3Data.h3columnName} is not null`)
+      .andWhere(`indicatorh3.${indicatorH3Data.h3columnName} is not null`)
+      .groupBy('h')
+      .getRawMany();
+    this.logger.log('Carbon Emissions Map generated');
+
+    return riskMap;
+  }
+
   /**
    * @debt: Refactor this to use queryBuilder. Even tho all values are previously validated, this isn't right, but
    * has been don for the time being to unblock FE. Check with Data if calculus is accurate

--- a/api/src/modules/h3-data/h3-data.service.ts
+++ b/api/src/modules/h3-data/h3-data.service.ts
@@ -91,7 +91,6 @@ export class H3DataService {
     /**
      * @note To generate a Risk Map, a harvestId and h3Data by indicatorId are required
      */
-
     const indicatorH3Data = await this.h3DataRepository.findOne({
       where: { indicatorId: indicatorId },
     });
@@ -142,7 +141,20 @@ export class H3DataService {
         );
         break;
       case INDICATOR_TYPES.DEFORESTATION:
+        riskMap = await this.h3DataRepository.getDeforestationLossRiskMapByResolution(
+          indicatorH3Data,
+          materialH3Data as H3Data,
+          resolution,
+        );
+        break;
       case INDICATOR_TYPES.CARBON_EMISSIONS:
+        riskMap = await this.h3DataRepository.getCarbonEmissionsRiskMapByResolution(
+          indicatorH3Data,
+          materialH3Data as H3Data,
+          factor as number,
+          resolution,
+        );
+        break;
       case INDICATOR_TYPES.BIODIVERSITY_LOSS:
         riskMap = await this.h3DataRepository.getBiodiversityLossRiskMapByResolution(
           indicatorH3Data,

--- a/api/test/h3-data/h3-risk-map.spec.ts
+++ b/api/test/h3-data/h3-risk-map.spec.ts
@@ -22,6 +22,10 @@ import { UnitConversionRepository } from '../../src/modules/unit-conversions/uni
  * Tests for the H3DataModule.
  */
 
+/**
+ * @debt: Add more elaborated fixtures and more accurate assertions with Data to check that the calculus of all risk-maps are correct (Smoke Tests)
+ */
+
 describe('H3 Data Module (e2e) - Risk map', () => {
   let app: INestApplication;
   let h3DataRepository: H3DataRepository;
@@ -187,6 +191,79 @@ describe('H3 Data Module (e2e) - Risk map', () => {
     expect(
       h3DataRepository.getBiodiversityLossRiskMapByResolution,
     ).toHaveBeenCalledWith(h3Data, h3Data, unitConversion.factor, 6);
+    expect(response.body.data).toEqual([
+      {
+        h: '861203a4fffffff',
+        v: 1000000,
+      },
+    ]);
+    expect(response.body.metadata).toEqual({
+      quantiles: [1000, 1000, 1000, 1000, 1000, 1000, 1000],
+      unit: 'tonnes',
+    });
+  });
+  // TODO: Update assertion as soon as actual calculus is validated
+  test('When I get a calculated H3 Carbon Emission Risk Map with the necessary input values, then I should get the h3 data (happy case)', async () => {
+    const {
+      material,
+      indicator,
+      h3Data,
+      unitConversion,
+    } = await createWorldForRiskMapGeneration({
+      indicatorType: INDICATOR_TYPES.CARBON_EMISSIONS,
+      fakeTable,
+      fakeColumn,
+    });
+    jest.spyOn(h3DataRepository, 'getCarbonEmissionsRiskMapByResolution');
+
+    const response = await request(app.getHttpServer())
+      .get(`/api/v1/h3/risk-map`)
+      .query({
+        indicatorId: indicator.id,
+        year: 2020,
+        materialId: material.id,
+        resolution: 6,
+      });
+
+    expect(
+      h3DataRepository.getCarbonEmissionsRiskMapByResolution,
+    ).toHaveBeenCalledWith(h3Data, h3Data, unitConversion.factor, 6);
+    expect(response.body.data).toEqual([
+      {
+        h: '861203a4fffffff',
+        v: 0,
+      },
+    ]);
+    expect(response.body.metadata).toEqual({
+      quantiles: [1000, 1000, 1000, 1000, 1000, 1000, 1000],
+      unit: 'tonnes',
+    });
+  });
+  // TODO: Update assertion as soon as actual calculus is validated
+  test('When I get a calculated H3 Deforestation Loss Risk Map with the necessary input values, then I should get the h3 data (happy case)', async () => {
+    const {
+      material,
+      indicator,
+      h3Data,
+    } = await createWorldForRiskMapGeneration({
+      indicatorType: INDICATOR_TYPES.DEFORESTATION,
+      fakeTable,
+      fakeColumn,
+    });
+    jest.spyOn(h3DataRepository, 'getDeforestationLossRiskMapByResolution');
+
+    const response = await request(app.getHttpServer())
+      .get(`/api/v1/h3/risk-map`)
+      .query({
+        indicatorId: indicator.id,
+        year: 2020,
+        materialId: material.id,
+        resolution: 6,
+      });
+
+    expect(
+      h3DataRepository.getDeforestationLossRiskMapByResolution,
+    ).toHaveBeenCalledWith(h3Data, h3Data, 6);
     expect(response.body.data).toEqual([
       {
         h: '861203a4fffffff',


### PR DESCRIPTION
This PR adds:

Calculus for retrieving remaining indicators risk-maps: Deforestation Loss and Carbon Emissions:

IMPORTANT NOTE: Calculus has been done according to my interpretation of the formula, which can be totally inaccurate

But with this PR we can return maps for all indicators and unblock FE. We can fix the calculation later on with Data.

Also I added a note on the h3 risk map test suite to update the fixtures and make more strict assertions as I think those should be smoke tests (core functionality check)

