### PR TITLE
Fix: Get available years by layer type

### DIFF
--- a/api/src/modules/h3-data/h3-data.entity.ts
+++ b/api/src/modules/h3-data/h3-data.entity.ts
@@ -61,13 +61,6 @@ export class H3Data extends BaseEntity {
   @Column({ nullable: true })
   indicatorId: string;
 
-  @Column({
-    type: 'enum',
-    enum: H3_DATA_TYPES,
-    nullable: true,
-  })
-  dataType: H3_DATA_TYPES;
-
   @Column({ type: 'json', nullable: true })
   metadata?: JSON;
 }

--- a/api/src/modules/h3-data/h3-data.repository.ts
+++ b/api/src/modules/h3-data/h3-data.repository.ts
@@ -1,6 +1,5 @@
 import { EntityRepository, getManager, Repository } from 'typeorm';
 import {
-  H3_DATA_TYPES,
   H3Data,
   H3IndexValueData,
   LAYER_TYPES,
@@ -227,6 +226,7 @@ export class H3DataRepository extends Repository<H3Data> {
     const queryBuilder = this.createQueryBuilder('h')
       .select('year')
       .distinct(true)
+      .where('year is not null')
       .orderBy('year', 'ASC');
     // If a indicatorId is provided, filter results by it
     if (yearsRequestParams.indicatorId) {
@@ -247,11 +247,11 @@ export class H3DataRepository extends Repository<H3Data> {
     }
     // Filter by data type
     if (yearsRequestParams.layerType !== LAYER_TYPES.RISK) {
-      queryBuilder.andWhere(`"dataType" != '${H3_DATA_TYPES.INDICATOR}'`);
+      queryBuilder.andWhere(`"indicatorId" is null`);
     } else {
-      queryBuilder.andWhere(`"dataType" = '${H3_DATA_TYPES.INDICATOR}'`);
+      queryBuilder.andWhere(`"indicatorId" is not null`);
     }
     const availableYears = await queryBuilder.getRawMany();
-    return availableYears.map((elem: { year: number }) => elem.year).sort();
+    return availableYears.map((elem: { year: number }) => elem.year);
   }
 }

--- a/api/test/h3-data/h3-data.spec.ts
+++ b/api/test/h3-data/h3-data.spec.ts
@@ -15,10 +15,7 @@ import {
   createMaterial,
   createSourcingRecord,
 } from '../entity-mocks';
-import {
-  H3_DATA_TYPES,
-  H3Data,
-} from '../../src/modules/h3-data/h3-data.entity';
+import { H3Data } from '../../src/modules/h3-data/h3-data.entity';
 import { Material } from '../../src/modules/materials/material.entity';
 import { Indicator } from '../../src/modules/indicators/indicator.entity';
 
@@ -107,7 +104,6 @@ describe('H3-Data Module (e2e) - Get H3 data', () => {
         h3columnName: createRandomNamesForH3TableAndColumns(),
         h3resolution: 6,
         year,
-        dataType: H3_DATA_TYPES.PRODUCTION,
       });
       await h3DataRepository.save(fakeH3MasterData);
     }
@@ -127,7 +123,6 @@ describe('H3-Data Module (e2e) - Get H3 data', () => {
         h3columnName: createRandomNamesForH3TableAndColumns(),
         h3resolution: 6,
         year,
-        dataType: H3_DATA_TYPES.PRODUCTION,
       });
       const savedH3DataRows: H3Data[] = await h3DataRepository.save(
         fakeH3MasterData,
@@ -161,7 +156,6 @@ describe('H3-Data Module (e2e) - Get H3 data', () => {
         h3resolution: 6,
         year,
         indicatorId: id,
-        dataType: H3_DATA_TYPES.INDICATOR,
       });
     }
     await h3DataRepository.save(fakeH3MasterData);
@@ -183,7 +177,6 @@ describe('H3-Data Module (e2e) - Get H3 data', () => {
         h3resolution: 6,
         year,
         indicatorId: savedIndicator.id,
-        dataType: H3_DATA_TYPES.INDICATOR,
       });
     }
     await h3DataRepository.save(fakeH3MasterData);


### PR DESCRIPTION
This PR adds;

A fix to retrieve available years by requested layerType.

We were using h3Data.dataType to determine which years from which rows we should retrieve. This column is no longer used in the initial data seed, therefore is no longer being populated.

We can also determine which years to retrieve if depending on h3Data.indicatorId is null or not

Also, said h3Data.dataType has been deleted from the entity and it will be deleted from the datamodel as soon as new version is deployed