### PR TITLE
BUGFIX: LANDGRIF-343 Calculate quantiles over riskmap result

### DIFF
--- a/api/src/modules/h3-data/dto/get-material-h3-by-resolution.dto.ts
+++ b/api/src/modules/h3-data/dto/get-material-h3-by-resolution.dto.ts
@@ -1,5 +1,11 @@
 import { Type } from 'class-transformer';
-import { IsEnum, IsNotEmpty, IsNumber, IsUUID } from 'class-validator';
+import {
+  IsEnum,
+  IsNotEmpty,
+  IsNumber,
+  IsOptional,
+  IsUUID,
+} from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 
 /**

--- a/api/src/modules/h3-data/h3-data.service.ts
+++ b/api/src/modules/h3-data/h3-data.service.ts
@@ -148,17 +148,21 @@ export class H3DataService {
         );
         break;
       case INDICATOR_TYPES.CARBON_EMISSIONS:
+        const deforestationH3DataForCarbonEmissions = await this.indicatorService.getDeforestationH3Data();
         riskMap = await this.h3DataRepository.getCarbonEmissionsRiskMapByResolution(
           indicatorH3Data,
           materialH3Data as H3Data,
+          deforestationH3DataForCarbonEmissions,
           factor as number,
           resolution,
         );
         break;
       case INDICATOR_TYPES.BIODIVERSITY_LOSS:
+        const deforestationH3DataForBiodiversityLoss = await this.indicatorService.getDeforestationH3Data();
         riskMap = await this.h3DataRepository.getBiodiversityLossRiskMapByResolution(
           indicatorH3Data,
           materialH3Data as H3Data,
+          deforestationH3DataForBiodiversityLoss,
           factor as number,
           resolution,
         );

--- a/api/src/modules/h3-data/services/h3-filter-years-by-layer.service.ts
+++ b/api/src/modules/h3-data/services/h3-filter-years-by-layer.service.ts
@@ -26,13 +26,6 @@ export class H3FilterYearsByLayerService {
     materialId?: string,
     indicatorId?: string,
   ): Promise<number[]> {
-    /**
-     * @debt: If layerType equals to 'impact', we can retrieve available years in sourcing-records entity
-     * For the rest of layer types, we currently send a hardcoded value since there is nothing yet filling this data
-     * and it will always return an empty array
-     * H3Data table updated to store years, implement the real thing as soons as data-import process can provide said data
-     *
-     */
     switch (layerType) {
       case LAYER_TYPES.IMPACT:
         //TODO: Clarify with Data why Impact year range can be retrieved from sourcing-record available years

--- a/api/src/modules/indicators/indicators.service.ts
+++ b/api/src/modules/indicators/indicators.service.ts
@@ -6,12 +6,15 @@ import {
 } from 'utils/app-base.service';
 import {
   Indicator,
+  INDICATOR_TYPES,
   indicatorResource,
 } from 'modules/indicators/indicator.entity';
 import { AppInfoDTO } from 'dto/info.dto';
 import { IndicatorRepository } from 'modules/indicators/indicator.repository';
 import { CreateIndicatorDto } from 'modules/indicators/dto/create.indicator.dto';
 import { UpdateIndicatorDto } from 'modules/indicators/dto/update.indicator.dto';
+import { H3Data } from 'modules/h3-data/h3-data.entity';
+import { getManager } from 'typeorm';
 
 @Injectable()
 export class IndicatorsService extends AppBaseService<
@@ -46,5 +49,34 @@ export class IndicatorsService extends AppBaseService<
     }
 
     return found;
+  }
+
+  async getDeforestationH3Data(): Promise<H3Data> {
+    /**
+     * @note: For at least 2 types of risk maps, retrieving a fixed Indicator's data
+     * is required to perform the query, and no data to retrieve this Indicator is provided
+     * in the client's request
+     */
+
+    const deforestationIndicator = await this.indicatorRepository.findOne({
+      nameCode: INDICATOR_TYPES.DEFORESTATION,
+    });
+    if (!deforestationIndicator)
+      throw new NotFoundException(
+        'No Deforestation Indicator data found in database',
+      );
+    const deforestationH3Data = await getManager()
+      .createQueryBuilder()
+      .select()
+      .from('h3_data', 'h3_data')
+      .where('"indicatorId" = :indicatorId', {
+        indicatorId: deforestationIndicator.id,
+      })
+      .getRawOne();
+    if (!deforestationH3Data)
+      throw new NotFoundException(
+        'No Deforestation Indicator H3 data found in database, required to retrieve Biodiversity Loss and Carbon Risk-Maps',
+      );
+    return deforestationH3Data;
   }
 }

--- a/api/test/h3-data/h3-material-map.spec.ts
+++ b/api/test/h3-data/h3-material-map.spec.ts
@@ -90,7 +90,7 @@ describe('H3 Data Module (e2e) - Material map', () => {
     );
   });
 
-  test('When I query H3 data at minimal resolution, then I should get 8 h3indexes', async () => {
+  test('When I query H3 data at minimal resolution, then I should 2 h3indexes and no 0 as value', async () => {
     const h3Data = await createFakeH3Data(
       fakeTable,
       fakeColumn,
@@ -103,13 +103,7 @@ describe('H3 Data Module (e2e) - Material map', () => {
 
     expect(response.body.data).toEqual([
       { h: '81123ffffffffff', v: 1000 },
-      { h: '8112fffffffffff', v: 0 },
-      { h: '8128bffffffffff', v: 0 },
-      { h: '8127bffffffffff', v: 0 },
-      { h: '8112bffffffffff', v: 0 },
-      { h: '81273ffffffffff', v: 0 },
-      { h: '8128fffffffffff', v: 0 },
-      { h: '81127ffffffffff', v: 0 },
+      { h: '8112fffffffffff', v: 1000 },
     ]);
 
     expect(response.body.metadata).toEqual({

--- a/api/test/h3-data/h3-risk-map.spec.ts
+++ b/api/test/h3-data/h3-risk-map.spec.ts
@@ -165,7 +165,15 @@ describe('H3 Data Module (e2e) - Risk map', () => {
       },
     ]);
     expect(response.body.metadata).toEqual({
-      quantiles: [1000, 1000, 1000, 1000, 1000, 1000, 1000],
+      quantiles: [
+        1000000,
+        1000000,
+        1000000,
+        1000000,
+        1000000,
+        1000000,
+        1000000,
+      ],
       unit: 'tonnes',
     });
   });
@@ -217,7 +225,15 @@ describe('H3 Data Module (e2e) - Risk map', () => {
       },
     ]);
     expect(response.body.metadata).toEqual({
-      quantiles: [1000, 1000, 1000, 1000, 1000, 1000, 1000],
+      quantiles: [
+        3612905210000,
+        3612905210000,
+        3612905210000,
+        3612905210000,
+        3612905210000,
+        3612905210000,
+        3612905210000,
+      ],
       unit: 'tonnes',
     });
   });
@@ -268,7 +284,15 @@ describe('H3 Data Module (e2e) - Risk map', () => {
       },
     ]);
     expect(response.body.metadata).toEqual({
-      quantiles: [1000, 1000, 1000, 1000, 1000, 1000, 1000],
+      quantiles: [
+        3612905210000,
+        3612905210000,
+        3612905210000,
+        3612905210000,
+        3612905210000,
+        3612905210000,
+        3612905210000,
+      ],
       unit: 'tonnes',
     });
   });
@@ -304,7 +328,15 @@ describe('H3 Data Module (e2e) - Risk map', () => {
       },
     ]);
     expect(response.body.metadata).toEqual({
-      quantiles: [1000, 1000, 1000, 1000, 1000, 1000, 1000],
+      quantiles: [
+        3612905210,
+        3612905210,
+        3612905210,
+        3612905210,
+        3612905210,
+        3612905210,
+        3612905210,
+      ],
       unit: 'tonnes',
     });
   });

--- a/api/test/h3-data/mocks/h3-fixtures.ts
+++ b/api/test/h3-data/mocks/h3-fixtures.ts
@@ -1,5 +1,5 @@
 export const h3MaterialFixtures = {
-  '8612e1a2fffffff': 0,
+  '8612e1a2fffffff': 1000,
   '86125d767ffffff': 0,
   '86278455fffffff': 0,
   '86124a0f7ffffff': 0,


### PR DESCRIPTION
Quantiles are currently calculated over the provided material's full dataset

The expected behaviour would be to calculate them over the result of the risk-map (resultant "v" column values)

Current approach:

Using tmp tables to store riskmap calculus results to:
1-retrieve the response
2-calculate the quantiles over the generated tmp results

**NOTE:**
This implementation is built on top of [RISK-MAP QUERY VALIDATION PR](https://github.com/Vizzuality/landgriffon/pull/152) as having the (most likely) right queries is mandatory for this fix to be succesful in terms of data, performance etc...

