### PR TITLE
removes unnecessary bio datasets and updates harvested area

### DIFF
--- a/api/src/modules/geo-regions/geo-region.entity.ts
+++ b/api/src/modules/geo-regions/geo-region.entity.ts
@@ -30,6 +30,9 @@ export class GeoRegion extends BaseEntity {
   @Column({ type: 'text', array: true, nullable: true })
   h3Compact?: string[];
 
+  @Column({ type: 'text', array: true, nullable: true })
+  h3Flat?: string[];
+
   @Column({ type: 'text', unique: true, nullable: true })
   @ApiPropertyOptional()
   name?: string;

--- a/data/Makefile
+++ b/data/Makefile
@@ -17,12 +17,12 @@ seed-data: seed-source-data seed-gadm seed-h3-tables
 
 seed-source-data:
 	@echo "Importing source data... "
-	cd /base_data_importer && make -j 4
+	cd ./base_data_importer && make -j 4
 
 seed-gadm:
 	@echo "Importing GADM data... "
-	cd /data_download && make -j 4
+	cd ./data_download && make -j 4
 
 seed-h3-tables:
 	@echo "Starting seeding h3 tables... "
-	cd /h3_raster_importer && make
+	cd ./h3_raster_importer && make

--- a/data/data_download/populate_admin_regions.sql
+++ b/data/data_download/populate_admin_regions.sql
@@ -5,10 +5,13 @@ CREATE EXTENSION IF NOT EXISTS ltree;
 TRUNCATE TABLE geo_region CASCADE;
 
 INSERT INTO geo_region
-("name", "h3Compact", "theGeom")
+("name", "h3Flat", "h3Compact", "theGeom")
 
 SELECT
 mpath,
+array(
+    SELECT h3_polyfill(wkb_geometry, 6)
+) AS "h3Flat",
 array(
     SELECT h3_compact(array(
         SELECT h3_polyfill(wkb_geometry, 6)

--- a/data/h3_raster_importer/Makefile
+++ b/data/h3_raster_importer/Makefile
@@ -40,7 +40,7 @@ download-mapspam-crop-production:
 #Download MapSPAM crop harvest area
 download-mapspam-crop-harvest:
 	mkdir -p $(WORKDIR_MAPSPAM)
-	wget -q -O $(WORKDIR_MAPSPAM)/spam2010v2r0_global_phys_area.geotiff.zip https://s3.amazonaws.com/mapspam/2010/v2.0/geotiff/spam2010v2r0_global_phys_area.geotiff.zip
+	wget -q -O $(WORKDIR_MAPSPAM)/spam2010v2r0_global_harv_area.geotiff.zip https://s3.amazonaws.com/mapspam/2010/v2.0/geotiff/spam2010v2r0_global_harv_area.geotiff.zip
 
 #EXTRACT DATASETS:
 # <tiff_folder>: <zipfile>
@@ -52,13 +52,7 @@ extract-mapspam-crop-production: download-mapspam-crop-production
 
 extract-mapspam-crop-harvest: download-mapspam-crop-harvest
 	mkdir -p $(WORKDIR_MAPSPAM)/spam2010v2r0_global_ha
-	unzip -u $(WORKDIR_MAPSPAM)/spam2010v2r0_global_phys_area.geotiff.zip *_A.tif -d $(WORKDIR_MAPSPAM)/spam2010v2r0_global_ha
-	for tiffile in $(WORKDIR_MAPSPAM)/spam2010v2r0_global_ha/*.tif; do \
-		table_name=`basename -s .tif "$$tiffile" | tr -d ' \t\n\r' | tr [:upper:] [:lower:]`; \
-		output_file="$(WORKDIR_MAPSPAM)/spam2010v2r0_global_ha/spam2010_global_$${table_name}.tif";\
-		gdal_calc.py --calc "A/10000" --format GTiff --type Float32 -A "$${tiffile}" --A_band 1 --outfile "$${output_file}"; \
-		rm -f "$${tiffile}";\
-	done
+	unzip -u $(WORKDIR_MAPSPAM)/spam2010v2r0_global_harv_area.geotiff.zip *_A.tif -d $(WORKDIR_MAPSPAM)/spam2010v2r0_global_ha
 
 #CONVERT DATASETS:
 # <table>: <tiff_folder>
@@ -95,7 +89,7 @@ extract-earthstat-crop-production: download-earthstat-crop-production
 # Only extract the files that contain harvest area fraction. Set the no data to 0 as the mapspam datasets.
 extract-earthstat-crop-harvest: download-earthstat-crop-production
 	mkdir -p $(WORKDIR_EARTHSTAT)/earthstat2000_global_ha
-	unzip -j -o -u $(WORKDIR_EARTHSTAT)/HarvestedAreaYield175Crops_Geotiff.zip *_HarvestedAreaFraction.tif -d $(WORKDIR_EARTHSTAT)/earthstat2000_global_ha
+	unzip -j -o -u $(WORKDIR_EARTHSTAT)/HarvestedAreaYield175Crops_Geotiff.zip *_HarvestedArea.tif -d $(WORKDIR_EARTHSTAT)/earthstat2000_global_ha
 	for tiffile in $(WORKDIR_EARTHSTAT)/earthstat2000_global_ha/*.tif; do \
 		table_name=`basename -s .tif "$$tiffile" | tr -d ' \t\n\r' | tr [:upper:] [:lower:]`; \
 		output_file="$(WORKDIR_EARTHSTAT)/earthstat2000_global_ha/earthstat2000_global_$${table_name}.tif";\
@@ -158,12 +152,7 @@ preprocess-biodiversity: extract-biodiversity
 # rasterize biodiversity dataset
 rasterize-biodiversity: preprocess-biodiversity
 	mkdir -p $(WORKDIR_BIODIVERSITY)/6kcchn7e3u_official_teow/lcia_psl_regional
-	make rasterize-biodiversity-file ATTRIBUTE_NAME=Annual_cro TIF=lcia_psl_r_annual_crops.tif & \
 	make rasterize-biodiversity-file ATTRIBUTE_NAME=Permanent_ TIF=lcia_psl_r_permanent_crops.tif & \
-	make rasterize-biodiversity-file ATTRIBUTE_NAME=Pasture TIF=lcia_psl_r_pasture.tif & \
-	make rasterize-biodiversity-file ATTRIBUTE_NAME=Urban TIF=lcia_psl_r_urban.tif & \
-	make rasterize-biodiversity-file ATTRIBUTE_NAME=Extensive_ TIF=lcia_psl_r_extensive_forestry.tif & \
-	make rasterize-biodiversity-file ATTRIBUTE_NAME=Intensive_ TIF=lcia_psl_r_intensive_forestry.tif & \
 	wait
 
 rasterize-biodiversity-file:
@@ -249,6 +238,9 @@ extract-cropland: download-cropland
 	gdal_translate -a_nodata 0 -of GTiff $(WORKDIR_EARTHSTAT)/CroplandPastureArea2000_global_ha/Pasture2000_5m.tif \
 	$(WORKDIR_EARTHSTAT)/CroplandPastureArea2000_global_ha/es_pasture_global.tif
 	rm -f $(WORKDIR_EARTHSTAT)/CroplandPastureArea2000_global_ha/Pasture2000_5m.tif
+	gdal_calc.py --calc "A*10000*(A>0)" --format GTiff --type Float32 -A $(WORKDIR_EARTHSTAT)/CroplandPastureArea2000_global_ha/es_pasture_global.tif \
+	 --A_band 1 --outfile $(WORKDIR_EARTHSTAT)/CroplandPastureArea2000_global_ha/Pasture2000_5m_ha.tif;
+	rm -f $(WORKDIR_EARTHSTAT)/CroplandPastureArea2000_global_ha/es_pasture_global.tif
 
 # and import to a table called "h3_grid_earthstat2000_global_ha"
 convert-cropland: extract-cropland


### PR DESCRIPTION
Removes the unnecessary biodiversity datasets from import data so we end up with just one uuid for the biodiversity indicator. Apart from that I update the ingestion on harvest area to account for the new formula changes (instead of harvest area fraction we are now ingesting just harvest area). 