### PR TITLE
fix earthstat import when adding pasture

### DIFF
--- a/data/h3_raster_importer/Makefile
+++ b/data/h3_raster_importer/Makefile
@@ -239,7 +239,7 @@ extract-cropland: download-cropland
 	$(WORKDIR_EARTHSTAT)/CroplandPastureArea2000_global_ha/es_pasture_global.tif
 	rm -f $(WORKDIR_EARTHSTAT)/CroplandPastureArea2000_global_ha/Pasture2000_5m.tif
 	gdal_calc.py --calc "A*10000*(A>0)" --format GTiff --type Float32 -A $(WORKDIR_EARTHSTAT)/CroplandPastureArea2000_global_ha/es_pasture_global.tif \
-	 --A_band 1 --outfile $(WORKDIR_EARTHSTAT)/CroplandPastureArea2000_global_ha/Pasture2000_5m_ha.tif;
+	 --A_band 1 --outfile $(WORKDIR_EARTHSTAT)/CroplandPastureArea2000_global_ha/global2000_pasture_ha.tif;
 	rm -f $(WORKDIR_EARTHSTAT)/CroplandPastureArea2000_global_ha/es_pasture_global.tif
 
 # and import to a table called "h3_grid_earthstat2000_global_ha"

--- a/data/h3_raster_importer/tiff_folder_to_h3_table.py
+++ b/data/h3_raster_importer/tiff_folder_to_h3_table.py
@@ -210,10 +210,15 @@ def load_raster_list_to_h3_table(raster_list, table, dataType, dataset, year, h3
     cursor = conn.cursor()
     # remove link from materials entity for dropping h3 master table
     if dataset == 'es':
-        if dataType == 'production':
+        if dataType == 'production' and table != 'h3_grid_pasture_production':
             cursor.execute(f"""update {MATERIALS_TABLE} set "producerId" = NULL where "datasetId" like 'es_%'""")
-        if dataType == 'harvest_area':
+        if dataType == 'harvest_area' and table != 'h3_grid_pasture_ha':
             cursor.execute(f"""update {MATERIALS_TABLE} set "harvestId" = NULL where "datasetId" like 'es_%'""")
+        if dataType == 'production' and table == 'h3_grid_pasture_production':
+            cursor.execute(f"""update {MATERIALS_TABLE} set "producerId" = NULL where "datasetId" = 'es_pasture'""")
+        if dataType == 'harvest_area' and table == 'h3_grid_pasture_ha':
+            cursor.execute(f"""update {MATERIALS_TABLE} set "harvestId" = NULL where "datasetId" = 'es_pasture'""")
+
     if dataset == 'spam':
         if dataType == 'production':
             cursor.execute(f"""update {MATERIALS_TABLE} set "producerId" = NULL where "datasetId" like 'spam_%'""")


### PR DESCRIPTION
This should fix the issue that we have when importing all the earthstat datasets at once. Basically we were dropping all the harvestId and datasetId from materials when importing the new pasture data. 

If you're happy with this, please re-import