### PR TITLE
Add nearest future year data to risk map fallback

### DIFF
--- a/api/src/modules/h3-data/h3-data.service.ts
+++ b/api/src/modules/h3-data/h3-data.service.ts
@@ -167,14 +167,19 @@ export class H3DataService {
     const availableIndicatorYears: number[] =
       await this.getAvailableYearsForH3IndicatorData(indicatorId);
 
-    const indicatorDataYear: number | undefined =
+    let indicatorDataYear: number | undefined =
       availableIndicatorYears.includes(year)
         ? year
         : availableIndicatorYears.find((el: number) => el < year);
 
     if (!indicatorDataYear)
+      indicatorDataYear = availableIndicatorYears
+        .reverse()
+        .find((el) => el > year);
+
+    if (!indicatorDataYear)
       throw new NotFoundException(
-        `There is no H3 Data registered for Indicator with ID ${indicatorId} for the year ${year} or any year before ${year}`,
+        `There is no H3 Data registered for Indicator with ID ${indicatorId} for year ${year} or any other year`,
       );
     const indicatorH3Data: H3Data | undefined =
       await this.h3DataRepository.findOne({
@@ -192,14 +197,19 @@ export class H3DataService {
         MATERIAL_TO_H3_TYPE.HARVEST,
       );
 
-    const harvestDataYear: number | undefined =
+    let harvestDataYear: number | undefined =
       availableHarvestDataYears.includes(year)
         ? year
         : availableHarvestDataYears.find((el: number) => el < year);
 
     if (!harvestDataYear)
+      harvestDataYear = availableHarvestDataYears
+        .reverse()
+        .find((el) => el > year);
+
+    if (!harvestDataYear)
       throw new NotFoundException(
-        `There is no H3 Harvest data registered for Material with ID ${materialId} for the year ${year} or any year before ${year}`,
+        `There is no H3 Harvest data registered for Material with ID ${materialId} for year ${year} or any other year`,
       );
 
     const harvestMaterialH3Data: H3Data | undefined =
@@ -220,14 +230,19 @@ export class H3DataService {
         MATERIAL_TO_H3_TYPE.PRODUCER,
       );
 
-    const producerDataYear: number | undefined =
+    let producerDataYear: number | undefined =
       availableProducerDataYears.includes(year)
         ? year
         : availableProducerDataYears.find((el: number) => el < year);
 
     if (!producerDataYear)
+      producerDataYear = availableProducerDataYears
+        .reverse()
+        .find((el) => el > year);
+
+    if (!producerDataYear)
       throw new NotFoundException(
-        `There is no H3 Producer data registered for Material with ID ${materialId} for the year ${year} or any year before ${year}`,
+        `There is no H3 Producer data registered for Material with ID ${materialId} for year ${year} or any other year`,
       );
 
     const producerMaterialH3Data: H3Data | undefined =

--- a/api/src/modules/h3-data/h3-data.service.ts
+++ b/api/src/modules/h3-data/h3-data.service.ts
@@ -175,7 +175,7 @@ export class H3DataService {
     if (!indicatorDataYear)
       indicatorDataYear = availableIndicatorYears
         .reverse()
-        .find((el) => el > year);
+        .find((el: number) => el > year);
 
     if (!indicatorDataYear)
       throw new NotFoundException(
@@ -205,7 +205,7 @@ export class H3DataService {
     if (!harvestDataYear)
       harvestDataYear = availableHarvestDataYears
         .reverse()
-        .find((el) => el > year);
+        .find((el: number) => el > year);
 
     if (!harvestDataYear)
       throw new NotFoundException(
@@ -238,7 +238,7 @@ export class H3DataService {
     if (!producerDataYear)
       producerDataYear = availableProducerDataYears
         .reverse()
-        .find((el) => el > year);
+        .find((el: number) => el > year);
 
     if (!producerDataYear)
       throw new NotFoundException(

--- a/api/test/e2e/h3-data/mocks/h3-risk-map-calculation-results.ts
+++ b/api/test/e2e/h3-data/mocks/h3-risk-map-calculation-results.ts
@@ -63,6 +63,18 @@ export const riskMapCalculationResults = {
     producerDataYear: 2020,
   },
 
+  waterRiskRes6Quantiles2002: {
+    quantiles: [
+      0.00001091405159779818, 0.00002730695811495449, 0.00005457026002189147,
+      0.00006821282401091406, 0.00008187722016812016, 0.01376261937244203,
+      0.08185538881309687,
+    ],
+    unit: 'tonnes',
+    harvestDataYear: 2002,
+    indicatorDataYear: 2003,
+    producerDataYear: 2002,
+  },
+
   waterRiskRes3Values: [
     { h: '831080fffffffff', v: 0.00022919509371826467 },
     { h: '837400fffffffff', v: 0.0004502046360325521 },


### PR DESCRIPTION
This PR adds fix to previously implemented years fallback strategy for risk maps. 
Now if there is no h3 data for the requested year or any other year before the requested, but there is data for the years after the requested one (for example, map is requested for year 2000, but there is data only for 2005) - h3 data for the nearest higher year will be used for calculations