### PR TITLE
Add Tasks endpoint

### DIFF
--- a/api/src/modules/tasks/dto/create-task.dto.ts
+++ b/api/src/modules/tasks/dto/create-task.dto.ts
@@ -1,11 +1,24 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsOptional, IsString, IsUUID } from 'class-validator';
 import { TASK_STATUS, TASK_TYPE } from 'modules/tasks/task.entity';
 
 export class CreateTaskDto {
+  @ApiProperty()
+  @IsNotEmpty()
+  @IsString()
   type!: TASK_TYPE;
 
+  @ApiProperty()
+  @IsNotEmpty()
+  @IsString()
   status!: TASK_STATUS;
 
+  @ApiProperty()
+  @IsNotEmpty()
+  @IsUUID()
   createdBy: string;
 
+  @ApiProperty()
+  @IsOptional()
   data!: Record<string, any>;
 }

--- a/api/src/modules/tasks/dto/update-task-with-controller.dto.ts
+++ b/api/src/modules/tasks/dto/update-task-with-controller.dto.ts
@@ -1,0 +1,23 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsNotEmpty, IsOptional, IsString, IsUUID } from 'class-validator';
+import { TASK_STATUS } from 'modules/tasks/task.entity';
+
+export class UpdateTaskWithControllerDto {
+  @ApiProperty()
+  @IsNotEmpty()
+  @IsUUID()
+  taskId: string;
+
+  @ApiProperty()
+  @IsNotEmpty()
+  @IsString()
+  newStatus: TASK_STATUS;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  newData?: Record<string, any>;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  newErrors?: Error;
+}

--- a/api/src/modules/tasks/task.entity.ts
+++ b/api/src/modules/tasks/task.entity.ts
@@ -1,6 +1,7 @@
 import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
 import { TimestampedBaseEntity } from 'baseEntities/timestamped-base-entity';
 import { BaseServiceResource } from 'types/resource.interface';
+import { ApiProperty } from '@nestjs/swagger';
 
 export const taskResource: BaseServiceResource = {
   className: 'Task',
@@ -9,7 +10,7 @@ export const taskResource: BaseServiceResource = {
     plural: 'tasks',
   },
   entitiesAllowedAsIncludes: [],
-  columnsAllowedAsFilter: ['status', 'data'],
+  columnsAllowedAsFilter: ['status', 'data', 'createdBy'],
 };
 
 export enum TASK_STATUS {
@@ -26,9 +27,11 @@ export enum TASK_TYPE {
 
 @Entity()
 export class Task extends TimestampedBaseEntity {
+  @ApiProperty()
   @PrimaryGeneratedColumn('uuid')
   id!: string;
 
+  @ApiProperty()
   @Column({
     type: 'enum',
     enum: TASK_TYPE,
@@ -36,12 +39,15 @@ export class Task extends TimestampedBaseEntity {
   })
   type!: string;
 
+  @ApiProperty()
   @Column({ type: 'uuid' })
   createdBy!: string;
 
+  @ApiProperty()
   @Column({ type: 'enum', enum: TASK_STATUS, default: TASK_STATUS.PROCESSING })
   status!: TASK_STATUS;
 
+  @ApiProperty()
   @Column({ type: 'json' })
   data!: Record<string, any>;
 
@@ -49,9 +55,11 @@ export class Task extends TimestampedBaseEntity {
    * @debt: Define proper typing for the fields below. Add logging to import-process
    */
 
+  @ApiProperty()
   @Column('jsonb', { array: false, default: () => "'[]'" })
   logs!: Array<Record<string, any>>;
 
+  @ApiProperty()
   @Column('jsonb', { array: false, default: () => "'[]'" })
   errors!: Array<Record<string, any>>;
 }

--- a/api/src/modules/tasks/tasks.controller.ts
+++ b/api/src/modules/tasks/tasks.controller.ts
@@ -1,4 +1,104 @@
-import { Controller } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Post,
+  Put,
+  UsePipes,
+  ValidationPipe,
+} from '@nestjs/common';
+import {
+  ApiBadRequestResponse,
+  ApiForbiddenResponse,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger';
+import {
+  FetchSpecification,
+  ProcessFetchSpecification,
+} from 'nestjs-base-service';
+import { PaginationMeta } from 'utils/app-base.service';
+import { Task, taskResource } from 'modules/tasks/task.entity';
+import { TasksService } from 'modules/tasks/tasks.service';
+import { UpdateTaskWithControllerDto } from 'modules/tasks/dto/update-task-with-controller.dto';
+import { CreateTaskDto } from 'modules/tasks/dto/create-task.dto';
 
-@Controller('tasks')
-export class TasksController {}
+@Controller('/api/v1/tasks')
+@ApiTags(taskResource.className)
+export class TasksController {
+  constructor(protected readonly taskService: TasksService) {}
+
+  @ApiOperation({ description: 'Find all tasks' })
+  @ApiOkResponse({ type: Task })
+  @ApiBadRequestResponse()
+  @ApiUnauthorizedResponse()
+  @ApiForbiddenResponse()
+  @Get()
+  async findAll(
+    // To implement once Auth is merged:
+    //@Req() request: Request,
+    @ProcessFetchSpecification({
+      allowedFilters: taskResource.columnsAllowedAsFilter,
+    })
+    fetchSpecification: FetchSpecification,
+  ): Promise<Task> {
+    // To implement once Auth is merged:
+    // fetchSpecification.filter
+    //   ? (fetchSpecification.filter.createdBy = [request.user.id])
+    //   : (fetchSpecification.filter = {
+    //       createdBy: [request.user.id],
+    //     });
+    const results: {
+      data: (Partial<Task> | undefined)[];
+      metadata: PaginationMeta | undefined;
+    } = await this.taskService.findAllPaginated(fetchSpecification);
+    return this.taskService.serialize(results.data, results.metadata);
+  }
+
+  @ApiOperation({ description: 'Find task by id' })
+  @ApiOkResponse({ type: Task })
+  @ApiBadRequestResponse()
+  @ApiUnauthorizedResponse()
+  @ApiForbiddenResponse()
+  @Get(':id')
+  async findOne(@Param('id') id: string): Promise<Task> {
+    return await this.taskService.serialize(await this.taskService.getById(id));
+  }
+
+  @ApiOperation({ description: 'Create a Task' })
+  @ApiOkResponse({ type: Task })
+  @ApiBadRequestResponse({
+    description: 'Bad Request. Incorrect or missing parameters',
+  })
+  @Post()
+  @UsePipes(ValidationPipe)
+  async create(@Body() dto: CreateTaskDto): Promise<Task> {
+    return await this.taskService.serialize(await this.taskService.create(dto));
+  }
+
+  @ApiOperation({ description: 'Updates a task' })
+  @ApiNotFoundResponse({ description: 'Task not found' })
+  @ApiOkResponse({ type: Task })
+  @Put()
+  async update(
+    @Body(new ValidationPipe())
+    dto: UpdateTaskWithControllerDto,
+  ): Promise<Task> {
+    return await this.taskService.serialize(
+      await this.taskService.updateImportJobEvent(dto),
+    );
+  }
+
+  @ApiOperation({ description: 'Deletes a task' })
+  @ApiNotFoundResponse({ description: 'Task not found' })
+  @ApiOkResponse()
+  @Delete(':id')
+  async delete(@Param('id') id: string): Promise<void> {
+    return await this.taskService.remove(id);
+  }
+}

--- a/api/src/modules/tasks/tasks.service.ts
+++ b/api/src/modules/tasks/tasks.service.ts
@@ -35,7 +35,7 @@ export class TasksService extends AppBaseService<
 
   get serializerConfig(): JSONAPISerializerConfig<Task> {
     return {
-      attributes: ['timestamp', 'topic', 'status', 'data'],
+      attributes: ['timestamp', 'topic', 'status', 'data', 'errors', 'logs'],
       keyForAttribute: 'camelCase',
     };
   }

--- a/api/test/e2e/tasks/tasks.spec.ts
+++ b/api/test/e2e/tasks/tasks.spec.ts
@@ -1,0 +1,217 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { HttpStatus, INestApplication, ValidationPipe } from '@nestjs/common';
+import * as request from 'supertest';
+import { AppModule } from 'app.module';
+import { Task, TASK_STATUS, TASK_TYPE } from 'modules/tasks/task.entity';
+import { TasksModule } from 'modules/tasks/tasks.module';
+import { TasksRepository } from 'modules/tasks/tasks.repository';
+
+/**
+ * Tests for Tasks Module.
+ */
+
+describe('Tasks Module (e2e)', () => {
+  let app: INestApplication;
+  let tasksRepository: TasksRepository;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule, TasksModule],
+    }).compile();
+
+    tasksRepository = moduleFixture.get<TasksRepository>(TasksRepository);
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(
+      new ValidationPipe({
+        transform: true,
+        whitelist: true,
+        forbidNonWhitelisted: true,
+      }),
+    );
+    await app.init();
+  });
+
+  afterEach(async () => {
+    await tasksRepository.delete({});
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  describe('Tasks - Create', () => {
+    test('Creating a new task (happy case)', async () => {
+      const response = await request(app.getHttpServer())
+        .post('/api/v1/tasks')
+        .send({
+          type: TASK_TYPE.SOURCING_DATA_IMPORT,
+          status: TASK_STATUS.PROCESSING,
+          createdBy: '2a833cc7-5a6f-492d-9a60-0d6d056923ea',
+          data: {
+            filename: 'fakeFile.xlsx',
+          },
+        })
+        .expect(HttpStatus.CREATED);
+
+      const createdTask = await tasksRepository.findOne(response.body.data.id);
+
+      if (!createdTask) {
+        throw new Error('Error loading created Task');
+      }
+
+      expect(createdTask.createdBy).toEqual(
+        '2a833cc7-5a6f-492d-9a60-0d6d056923ea',
+      );
+      expect(createdTask.data.filename).toEqual('fakeFile.xlsx');
+    });
+  });
+
+  test('Creating a task without required fields should return a 400 error', async () => {
+    const response = await request(app.getHttpServer())
+      .post('/api/v1/tasks')
+      .send()
+      .expect(HttpStatus.BAD_REQUEST);
+
+    expect(response).toHaveErrorMessage(
+      HttpStatus.BAD_REQUEST,
+      'Bad Request Exception',
+      [
+        'type must be a string',
+        'type should not be empty',
+        'status must be a string',
+        'status should not be empty',
+        'createdBy must be a UUID',
+        'createdBy should not be empty',
+      ],
+    );
+  });
+
+  describe('Tasks - Update', () => {
+    test('Updating a task should be successful (happy case)', async () => {
+      const task: Task = new Task();
+      task.createdBy = '2a833cc7-5a6f-492d-9a60-0d6d056923ea';
+      task.type = TASK_TYPE.SOURCING_DATA_IMPORT;
+      task.status = TASK_STATUS.PROCESSING;
+      task.data = {
+        filename: 'fakeFile.xlsx',
+      };
+      await task.save();
+
+      const response = await request(app.getHttpServer())
+        .put(`/api/v1/tasks`)
+        .send({
+          taskId: task.id,
+          newStatus: TASK_STATUS.FAILED,
+          newErrors: {
+            name: 'FakeError',
+            message: 'Fake Error Added',
+          },
+        })
+        .expect(HttpStatus.OK);
+
+      expect(response.body.data.attributes.status).toEqual('failed');
+      expect(response.body.data.attributes.errors[0].FakeError).toEqual(
+        'Fake Error Added',
+      );
+    });
+
+    test('Updating a task without task id and new status should return proper error message', async () => {
+      const task: Task = new Task();
+      task.createdBy = '2a833cc7-5a6f-492d-9a60-0d6d056923ea';
+      task.type = TASK_TYPE.SOURCING_DATA_IMPORT;
+      task.status = TASK_STATUS.PROCESSING;
+      task.data = {
+        filename: 'fakeFile.xlsx',
+      };
+      await task.save();
+
+      const response = await request(app.getHttpServer())
+        .put(`/api/v1/tasks`)
+        .send()
+        .expect(HttpStatus.BAD_REQUEST);
+
+      expect(response).toHaveErrorMessage(
+        HttpStatus.BAD_REQUEST,
+        'Bad Request Exception',
+        [
+          'taskId must be a UUID',
+          'taskId should not be empty',
+          'newStatus must be a string',
+          'newStatus should not be empty',
+        ],
+      );
+    });
+  });
+
+  describe('Task - Delete', () => {
+    test('Deleting a task should be successful (happy case)', async () => {
+      const task: Task = new Task();
+      task.createdBy = '2a833cc7-5a6f-492d-9a60-0d6d056923ea';
+      task.type = TASK_TYPE.SOURCING_DATA_IMPORT;
+      task.status = TASK_STATUS.PROCESSING;
+      task.data = {
+        filename: 'fakeFile.xlsx',
+      };
+      await task.save();
+
+      await request(app.getHttpServer())
+        .delete(`/api/v1/tasks/${task.id}`)
+        .send()
+        .expect(HttpStatus.OK);
+
+      expect(await tasksRepository.findOne(task.id)).toBeUndefined();
+    });
+  });
+
+  describe('Task - Find all', () => {
+    test('Retrieving should be successful (happy case)', async () => {
+      const task1: Task = new Task();
+      task1.createdBy = '2a833cc7-5a6f-492d-9a60-0d6d056923ea';
+      task1.type = TASK_TYPE.SOURCING_DATA_IMPORT;
+      task1.status = TASK_STATUS.PROCESSING;
+      task1.data = {
+        filename: 'fakeFile.xlsx',
+      };
+      await task1.save();
+
+      const task2: Task = new Task();
+      task2.createdBy = '2a833cc7-5a6f-492d-9a60-0d6d056923bb';
+      task2.type = TASK_TYPE.SOURCING_DATA_IMPORT;
+      task2.status = TASK_STATUS.PROCESSING;
+      task2.data = {
+        filename: 'fakeFile2.xlsx',
+      };
+      await task2.save();
+
+      const response = await request(app.getHttpServer())
+        .get(`/api/v1/tasks`)
+        .send()
+        .expect(HttpStatus.OK);
+
+      expect(response.body.data[0].id).toEqual(task1.id);
+      expect(response.body.data[1].id).toEqual(task2.id);
+    });
+  });
+
+  describe('Task - Get by id', () => {
+    test('Retrieving a task by id should be successful (happy case)', async () => {
+      const task: Task = new Task();
+      task.createdBy = '2a833cc7-5a6f-492d-9a60-0d6d056923ea';
+      task.type = TASK_TYPE.SOURCING_DATA_IMPORT;
+      task.status = TASK_STATUS.ABORTED;
+      task.data = {
+        filename: 'fakeFile.xlsx',
+      };
+      await task.save();
+
+      const response = await request(app.getHttpServer())
+        .get(`/api/v1/tasks/${task.id}`)
+        .send()
+        .expect(HttpStatus.OK);
+
+      expect(response.body.data.id).toEqual(task.id);
+      expect(response.body.data.attributes.status).toEqual(TASK_STATUS.ABORTED);
+    });
+  });
+});


### PR DESCRIPTION
This PR adds:
- Basic full CRUD for Tasks module.
- Creates new dto for updating a Task via controller, since the existing one has limited properties and is already used in the import process, probably we can unite them at some point.
- The properties which user can update in a Task or add, when creating new Tasks, are quite random, it can be easily changed if suggested
- Test for Tasks endpoints
Filtering tasks by User Id is not implemented yet, waiting for the Auth PR to be merged