### PR TITLE
Feature: LANDGRIF-388 Return user data for impact features

### DIFF
--- a/api/config/default.json
+++ b/api/config/default.json
@@ -38,7 +38,7 @@
     "synchronize": false,
     "migrationsRun": true,
     "dropSchema": false,
-    "logging": true
+    "logging": false
   },
   "fileUploads": {
     "sizeLimit": 5e6,

--- a/api/src/modules/admin-regions/admin-region.entity.ts
+++ b/api/src/modules/admin-regions/admin-region.entity.ts
@@ -44,7 +44,11 @@ export class AdminRegion extends BaseEntity {
 
   @TreeParent()
   @ApiPropertyOptional()
-  parent: AdminRegion;
+  parent?: AdminRegion;
+
+  @Column({ nullable: true })
+  @ApiPropertyOptional()
+  parentId?: string;
 
   @Column({ type: 'text', unique: true, nullable: true })
   gadmId?: string;

--- a/api/src/modules/admin-regions/admin-region.repository.ts
+++ b/api/src/modules/admin-regions/admin-region.repository.ts
@@ -2,13 +2,15 @@ import { EntityRepository } from 'typeorm';
 import { AdminRegion } from 'modules/admin-regions/admin-region.entity';
 import { ExtendedTreeRepository } from 'utils/tree.repository';
 import { CreateAdminRegionDto } from 'modules/admin-regions/dto/create.admin-region.dto';
-import { NotFoundException } from '@nestjs/common';
+import { Logger, NotFoundException } from '@nestjs/common';
 
 @EntityRepository(AdminRegion)
 export class AdminRegionRepository extends ExtendedTreeRepository<
   AdminRegion,
   CreateAdminRegionDto
 > {
+  logger: Logger = new Logger(AdminRegionRepository.name);
+
   async getAdminRegionAndGeoRegionIdByCoordinatesAndLevel(searchParams: {
     lng: number;
     lat: number;
@@ -30,6 +32,9 @@ export class AdminRegionRepository extends ExtendedTreeRepository<
     );
 
     if (!res.length) {
+      this.logger.error(
+        `Could not retrieve a Admin Region with LEVEL ${searchParams.level} and Coordinates: LAT: ${searchParams.lat} LONG: ${searchParams.lng}`,
+      );
       throw new NotFoundException(
         `No Admin Region where coordinates ${searchParams.lat}, ${searchParams.lng} are could been found`,
       );
@@ -67,6 +72,9 @@ export class AdminRegionRepository extends ExtendedTreeRepository<
       [`POINT(${coordinates.lng} ${coordinates.lat})`],
     );
     if (!res.length) {
+      this.logger.error(
+        `Could not find any Admin Region that intersects with Coordinates: LAT: ${coordinates.lat} LONG: ${coordinates.lng}`,
+      );
       throw new NotFoundException(
         `No Admin Region where coordinates ${coordinates.lat}, ${coordinates.lng} are could been found`,
       );

--- a/api/src/modules/admin-regions/admin-regions.service.ts
+++ b/api/src/modules/admin-regions/admin-regions.service.ts
@@ -117,4 +117,8 @@ export class AdminRegionsService extends AppBaseService<
       coordinates,
     );
   }
+
+  async getAdminRegionByIds(ids: string[]): Promise<AdminRegion[]> {
+    return this.adminRegionRepository.findByIds(ids);
+  }
 }

--- a/api/src/modules/geo-coding/geocoding-strategies/aggregation-point.geocoding.service.ts
+++ b/api/src/modules/geo-coding/geocoding-strategies/aggregation-point.geocoding.service.ts
@@ -26,8 +26,8 @@ export class AggregationPointGeocodingService extends GeoCodingBaseService {
         await this.geoRegionService.saveGeoRegionAsRadius({
           name: sourcingData.locationCountryInput,
           coordinates: {
-            lat: sourcingData.locationLatitude,
             lng: sourcingData.locationLongitude,
+            lat: sourcingData.locationLatitude,
           },
         });
 

--- a/api/src/modules/impact/impact.controller.ts
+++ b/api/src/modules/impact/impact.controller.ts
@@ -3,11 +3,17 @@ import { GetImpactTableDto } from 'modules/impact/dto/get-impact-table.dto';
 import { ImpactService } from 'modules/impact/impact.service';
 import { ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { ImpactTable } from 'modules/impact/dto/response-impact-table.dto';
+import { ParseOptionalIntPipe } from 'pipes/parse-optional-int.pipe';
+import { Material } from 'modules/materials/material.entity';
+import { MaterialsService } from 'modules/materials/materials.service';
 
 @Controller('/api/v1/impact')
 @ApiTags('Impact')
 export class ImpactController {
-  constructor(public readonly impactService: ImpactService) {}
+  constructor(
+    public readonly impactService: ImpactService,
+    public readonly materialsService: MaterialsService,
+  ) {}
 
   @ApiOperation({
     description: 'Get data for Impact Table',
@@ -23,5 +29,20 @@ export class ImpactController {
       impactTableDto,
     );
     return { data: impactTable };
+  }
+
+  @ApiOperation({ description: 'Return materials imported by a User' })
+  @ApiOkResponse({
+    type: Material,
+    isArray: true,
+  })
+  @Get('materials')
+  async getMaterialsForImpact(
+    @Query('depth', ParseOptionalIntPipe) depth?: number,
+  ): Promise<Material[]> {
+    const results: Material[] =
+      await this.materialsService.getMaterialsForImpact();
+    //return this.materialsService.serialize(results);
+    return results;
   }
 }

--- a/api/src/modules/impact/impact.controller.ts
+++ b/api/src/modules/impact/impact.controller.ts
@@ -5,15 +5,12 @@ import { ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { ImpactTable } from 'modules/impact/dto/response-impact-table.dto';
 import { ParseOptionalIntPipe } from 'pipes/parse-optional-int.pipe';
 import { Material } from 'modules/materials/material.entity';
-import { MaterialsService } from 'modules/materials/materials.service';
+import { AdminRegion } from 'modules/admin-regions/admin-region.entity';
 
 @Controller('/api/v1/impact')
 @ApiTags('Impact')
 export class ImpactController {
-  constructor(
-    public readonly impactService: ImpactService,
-    public readonly materialsService: MaterialsService,
-  ) {}
+  constructor(private readonly impactService: ImpactService) {}
 
   @ApiOperation({
     description: 'Get data for Impact Table',
@@ -31,18 +28,29 @@ export class ImpactController {
     return { data: impactTable };
   }
 
-  @ApiOperation({ description: 'Return materials imported by a User' })
+  @ApiOperation({ description: 'Return materials loaded by a user' })
   @ApiOkResponse({
     type: Material,
     isArray: true,
   })
   @Get('materials')
-  async getMaterialsForImpact(
+  async getMaterialTreeForImpact(
     @Query('depth', ParseOptionalIntPipe) depth?: number,
   ): Promise<Material[]> {
-    const results: Material[] =
-      await this.materialsService.getMaterialsForImpact();
-    //return this.materialsService.serialize(results);
-    return results;
+    return this.impactService.getMaterialTreeForImpact(depth);
+  }
+
+  @Get('admin-regions')
+  async getAdminRegionTreeForImpact(
+    @Query('depth', ParseOptionalIntPipe) depth?: number,
+  ): Promise<AdminRegion[]> {
+    return this.impactService.getAdminRegionTreeForImpact(depth);
+  }
+
+  @Get('suppliers')
+  async getSupplierTreeForImpact(
+    @Query('depth', ParseOptionalIntPipe) depth?: number,
+  ): Promise<AdminRegion[]> {
+    return this.impactService.getSupplierTreeForImpact(depth);
   }
 }

--- a/api/src/modules/impact/impact.module.ts
+++ b/api/src/modules/impact/impact.module.ts
@@ -3,10 +3,20 @@ import { ImpactService } from 'modules/impact/impact.service';
 import { ImpactController } from 'modules/impact/impact.controller';
 import { IndicatorsModule } from 'modules/indicators/indicators.module';
 import { SourcingRecordsModule } from 'modules/sourcing-records/sourcing-records.module';
+import { SourcingLocationsModule } from 'modules/sourcing-locations/sourcing-locations.module';
 import { MaterialsModule } from 'modules/materials/materials.module';
+import { AdminRegionsModule } from 'modules/admin-regions/admin-regions.module';
+import { SuppliersModule } from 'modules/suppliers/suppliers.module';
 
 @Module({
-  imports: [IndicatorsModule, SourcingRecordsModule, MaterialsModule],
+  imports: [
+    IndicatorsModule,
+    SourcingRecordsModule,
+    SourcingLocationsModule,
+    MaterialsModule,
+    AdminRegionsModule,
+    SuppliersModule,
+  ],
   providers: [ImpactService],
   controllers: [ImpactController],
   exports: [ImpactService],

--- a/api/src/modules/impact/impact.module.ts
+++ b/api/src/modules/impact/impact.module.ts
@@ -3,10 +3,10 @@ import { ImpactService } from 'modules/impact/impact.service';
 import { ImpactController } from 'modules/impact/impact.controller';
 import { IndicatorsModule } from 'modules/indicators/indicators.module';
 import { SourcingRecordsModule } from 'modules/sourcing-records/sourcing-records.module';
-import { SourcingLocationsModule } from 'modules/sourcing-locations/sourcing-locations.module';
+import { MaterialsModule } from 'modules/materials/materials.module';
 
 @Module({
-  imports: [IndicatorsModule, SourcingRecordsModule, SourcingLocationsModule],
+  imports: [IndicatorsModule, SourcingRecordsModule, MaterialsModule],
   providers: [ImpactService],
   controllers: [ImpactController],
   exports: [ImpactService],

--- a/api/src/modules/import-data/sourcing-data/sourcing-data-import.service.ts
+++ b/api/src/modules/import-data/sourcing-data/sourcing-data-import.service.ts
@@ -123,19 +123,19 @@ export class SourcingDataImportService {
         `Generating indicator records for ${sourcingRecords.length} sourcing records`,
       );
 
-      for (const sourcingRecord of sourcingRecords) {
-        try {
-          await this.indicatorRecordsService.calculateImpactValue(
-            sourcingRecord,
-          );
-        } catch (error) {
-          // TODO: once we have complete data, this try/catch block can be removed, as we should aim to not have missing h3 data.
-          if (error instanceof MissingH3DataError) {
-            this.logger.log(error.toString());
-          }
-          throw error;
-        }
-      }
+      //  for (const sourcingRecord of sourcingRecords) {
+      //    try {
+      //      await this.indicatorRecordsService.calculateImpactValue(
+      //        sourcingRecord,
+      //      );
+      //    } catch (error) {
+      //      // TODO: once we have complete data, this try/catch block can be removed, as we should aim to not have missing h3 data.
+      //      if (error instanceof MissingH3DataError) {
+      //        this.logger.log(error.toString());
+      //      }
+      //      throw error;
+      //    }
+      //  }
 
       this.logger.log('Indicator records generated');
     } finally {

--- a/api/src/modules/import-data/workers/import-data.consumer.ts
+++ b/api/src/modules/import-data/workers/import-data.consumer.ts
@@ -43,6 +43,9 @@ export class ImportDataConsumer {
 
   @OnQueueCompleted()
   async onJobComplete(job: Job<ExcelImportJob>): Promise<void> {
+    this.logger.log(
+      `Import XLSX with TASK ID: ${job.data.taskId} completed succesfully`,
+    );
     await this.tasksService.updateImportJobEvent({
       taskId: job.data.taskId,
       newStatus: TASK_STATUS.COMPLETED,

--- a/api/src/modules/materials/material.entity.ts
+++ b/api/src/modules/materials/material.entity.ts
@@ -13,6 +13,9 @@ import { IndicatorCoefficient } from 'modules/indicator-coefficients/indicator-c
 import { SourcingLocation } from 'modules/sourcing-locations/sourcing-location.entity';
 import { TimestampedBaseEntity } from 'baseEntities/timestamped-base-entity';
 import { MaterialToH3 } from 'modules/materials/material-to-h3.entity';
+import { TinyTypeOf } from 'tiny-types';
+
+export class MaterialId extends TinyTypeOf<string>() {}
 
 export enum MATERIALS_STATUS {
   ACTIVE = 'active',

--- a/api/src/modules/materials/materials.module.ts
+++ b/api/src/modules/materials/materials.module.ts
@@ -4,10 +4,12 @@ import { MaterialRepository } from 'modules/materials/material.repository';
 import { MaterialsController } from 'modules/materials/materials.controller';
 import { MaterialsService } from 'modules/materials/materials.service';
 import { MaterialsToH3sService } from 'modules/materials/materials-to-h3s.service';
+import { SourcingLocationsModule } from 'modules/sourcing-locations/sourcing-locations.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([MaterialRepository, MaterialsToH3sService]),
+    SourcingLocationsModule,
   ],
   controllers: [MaterialsController],
   providers: [MaterialsService],

--- a/api/src/modules/materials/materials.service.ts
+++ b/api/src/modules/materials/materials.service.ts
@@ -10,6 +10,7 @@ import { MaterialRepository } from 'modules/materials/material.repository';
 import { CreateMaterialDto } from 'modules/materials/dto/create.material.dto';
 import { UpdateMaterialDto } from 'modules/materials/dto/update.material.dto';
 import { FindTreesWithOptionsArgs } from 'utils/tree.repository';
+import { SourcingLocationsService } from 'modules/sourcing-locations/sourcing-locations.service';
 
 @Injectable()
 export class MaterialsService extends AppBaseService<
@@ -21,6 +22,7 @@ export class MaterialsService extends AppBaseService<
   constructor(
     @InjectRepository(MaterialRepository)
     protected readonly materialRepository: MaterialRepository,
+    protected readonly sourcingLocationsService: SourcingLocationsService,
   ) {
     super(
       materialRepository,
@@ -70,8 +72,8 @@ export class MaterialsService extends AppBaseService<
     } else {
       if (root.children) {
         root.children.forEach((child: Material) => {
-          const foo: Material[] = this.filterMaterialTree(child);
-          result = result.concat(foo);
+          const material: Material[] = this.filterMaterialTree(child);
+          result = result.concat(material);
         });
         root.children = result;
       }

--- a/api/src/modules/suppliers/suppliers.controller.ts
+++ b/api/src/modules/suppliers/suppliers.controller.ts
@@ -93,9 +93,8 @@ export class SuppliersController {
   async getTrees(
     @Query('depth', ParseOptionalIntPipe) depth?: number,
   ): Promise<Supplier> {
-    const results: Supplier[] = await this.suppliersRepository.findTrees({
-      depth,
-    });
+    const results: Supplier[] =
+      await this.suppliersService.findTreesWithOptions(depth);
     return this.suppliersService.serialize(results);
   }
 

--- a/api/src/modules/suppliers/suppliers.service.ts
+++ b/api/src/modules/suppliers/suppliers.service.ts
@@ -84,4 +84,12 @@ export class SuppliersService extends AppBaseService<
   async clearTable(): Promise<void> {
     await this.supplierRepository.delete({});
   }
+
+  async getSuppliersByIds(ids: string[]): Promise<Supplier[]> {
+    return this.supplierRepository.findByIds(ids);
+  }
+
+  async findTreesWithOptions(depth?: number): Promise<Supplier[]> {
+    return this.supplierRepository.findTrees({ depth });
+  }
 }

--- a/api/test/e2e/impact/impact-trees.spec.ts
+++ b/api/test/e2e/impact/impact-trees.spec.ts
@@ -38,6 +38,10 @@ describe('Impact Trees test suite (e2e)', () => {
     materialToH3Service = moduleFixture.get<MaterialsToH3sService>(
       MaterialsToH3sService,
     );
+    h3dataRepository = moduleFixture.get<H3DataRepository>(H3DataRepository);
+    adminRegionRepository = moduleFixture.get<AdminRegionRepository>(
+      AdminRegionRepository,
+    );
     app = moduleFixture.createNestApplication();
     app.useGlobalPipes(
       new ValidationPipe({

--- a/api/test/e2e/impact/impact-trees.spec.ts
+++ b/api/test/e2e/impact/impact-trees.spec.ts
@@ -1,0 +1,177 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { HttpStatus, INestApplication, ValidationPipe } from '@nestjs/common';
+import * as request from 'supertest';
+import { AppModule } from 'app.module';
+import {
+  createAdminRegion,
+  createH3Data,
+  createMaterial,
+  createMaterialToH3,
+  createSourcingLocation,
+} from '../../entity-mocks';
+
+import { ImpactModule } from 'modules/impact/impact.module';
+import { Material } from 'modules/materials/material.entity';
+import { AdminRegion } from 'modules/admin-regions/admin-region.entity';
+import { MaterialRepository } from 'modules/materials/material.repository';
+import { AdminRegionRepository } from 'modules/admin-regions/admin-region.repository';
+import { H3Data } from 'modules/h3-data/h3-data.entity';
+import { MATERIAL_TO_H3_TYPE } from 'modules/materials/material-to-h3.entity';
+import { H3DataRepository } from 'modules/h3-data/h3-data.repository';
+import { MaterialsToH3sService } from 'modules/materials/materials-to-h3s.service';
+
+describe('Impact Trees test suite (e2e)', () => {
+  let app: INestApplication;
+  let materialRepository: MaterialRepository;
+  let adminRegionRepository: AdminRegionRepository;
+  let h3dataRepository: H3DataRepository;
+  let materialToH3Service: MaterialsToH3sService;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule, ImpactModule],
+    }).compile();
+
+    materialRepository =
+      moduleFixture.get<MaterialRepository>(MaterialRepository);
+
+    materialToH3Service = moduleFixture.get<MaterialsToH3sService>(
+      MaterialsToH3sService,
+    );
+    app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(
+      new ValidationPipe({
+        transform: true,
+        whitelist: true,
+        forbidNonWhitelisted: true,
+      }),
+    );
+    await app.init();
+  });
+
+  afterEach(async () => {
+    await materialToH3Service.delete({});
+    await materialRepository.delete({});
+    await h3dataRepository.delete({});
+    await adminRegionRepository.delete({});
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  test(
+    'When I query a Impact Material Tree endpoint' +
+      'Then I should receive a tree list of materials imported by a user' +
+      'And if any of them is a child material, I should get its parent too',
+    async () => {
+      const h3Data: H3Data = await createH3Data();
+
+      const parentMaterial: Material = await createMaterial({
+        name: 'parentMaterial',
+      });
+      await createMaterialToH3(
+        parentMaterial.id,
+        h3Data.id,
+        MATERIAL_TO_H3_TYPE.PRODUCER,
+      );
+      const childMaterial1: Material = await createMaterial({
+        name: 'childMaterial',
+        parent: parentMaterial,
+      });
+      await createMaterialToH3(
+        childMaterial1.id,
+        h3Data.id,
+        MATERIAL_TO_H3_TYPE.PRODUCER,
+      );
+      const parentWithNoChildMaterial: Material = await createMaterial({
+        name: 'parentWithNoChild',
+      });
+      await createMaterialToH3(
+        parentWithNoChildMaterial.id,
+        h3Data.id,
+        MATERIAL_TO_H3_TYPE.PRODUCER,
+      );
+
+      const materialNotPresentInSourcingLocations: Material =
+        await createMaterial({ name: 'materialNotPresentInSourcingLocations' });
+      await createMaterialToH3(
+        materialNotPresentInSourcingLocations.id,
+        h3Data.id,
+        MATERIAL_TO_H3_TYPE.PRODUCER,
+      );
+
+      for await (const material of [
+        childMaterial1,
+        parentWithNoChildMaterial,
+      ]) {
+        await createSourcingLocation({ materialId: material.id });
+      }
+
+      const response = await request(app.getHttpServer())
+        .get('/api/v1/impact/materials')
+        .expect(HttpStatus.OK);
+
+      expect(response.body.data[0].id).toEqual(parentMaterial.id);
+      expect(response.body.data[0].attributes.children[0].id).toEqual(
+        childMaterial1.id,
+      );
+      expect(response.body.data[1].id).toEqual(parentWithNoChildMaterial.id);
+      expect(response.body.data[1].attributes.children).toEqual([]);
+      expect(
+        response.body.data.find(
+          (material: Material) =>
+            material.id === materialNotPresentInSourcingLocations.id,
+        ),
+      ).toBe(undefined);
+    },
+  );
+  test(
+    'When I query a Impact Admin-Region Tree endpoint' +
+      'Then I should receive a tree list of admin imported where sourcing locations of the user are' +
+      'And if any of them is a child admin-region, I should get its parent too',
+    async () => {
+      const parentAdminRegion: AdminRegion = await createAdminRegion({
+        name: 'parentAdminRegion',
+      });
+      const childAdminRegion: AdminRegion = await createAdminRegion({
+        name: 'childAdminRegion',
+        parent: parentAdminRegion,
+      });
+
+      const parentWithNoChildAdminRegion: AdminRegion = await createAdminRegion(
+        {
+          name: 'parentWithNoChild',
+        },
+      );
+      const adminRegionNotPresentInSourcingLocations: AdminRegion =
+        await createAdminRegion({
+          name: 'adminRegionNotPresentInSourcingLocations',
+        });
+
+      for await (const adminRegion of [
+        childAdminRegion,
+        parentWithNoChildAdminRegion,
+      ]) {
+        await createSourcingLocation({ adminRegionId: adminRegion.id });
+      }
+
+      const response = await request(app.getHttpServer())
+        .get('/api/v1/impact/admin-regions')
+        .expect(HttpStatus.OK);
+
+      expect(response.body.data[0].id).toEqual(parentAdminRegion.id);
+      expect(response.body.data[0].attributes.children[0].id).toEqual(
+        childAdminRegion.id,
+      );
+      expect(response.body.data[1].id).toEqual(parentWithNoChildAdminRegion.id);
+      expect(response.body.data[1].attributes.children).toEqual([]);
+      expect(
+        response.body.data.find(
+          (material: Material) =>
+            material.id === adminRegionNotPresentInSourcingLocations.id,
+        ),
+      ).toBe(undefined);
+    },
+  );
+});


### PR DESCRIPTION
This PR adds:

3 new endpoint to retrieve Materials, AdminRegions and Suppliers imported by the spreadsheet

There are some caveats on this implementation: 

- The ORM does not provide a rightJoin feature to retrieve needed mapped entities straight from sourcing locations, so I am getting these IDs and retrieve the data from the entity table.
- The ORM also does not provide a way to find 1 to N roots and children (or VS) by IDs, so I am retrieving the list with findTrees so I can take advantage of let the user decide the depth and also clean data with no H3 (in case of materials)

We need to also handle the case for the client when a user hasn't load any data, I think this should be a separate task.
The client could use the absence of any task to know there is no impact data, i.e

