### PR TITLE
Landgrif 481 filter by range of years for table and chart

### DIFF
--- a/client/src/components/select/component.tsx
+++ b/client/src/components/select/component.tsx
@@ -134,13 +134,15 @@ const ScenariosComparison: React.FC<SelectProps> = (props: SelectProps) => {
                 {optionsResult.map((option) => (
                   <Listbox.Option
                     key={option.value}
-                    className={({ active, selected }) =>
+                    className={({ active, selected, disabled }) =>
                       classNames(
                         active ? 'bg-green-50 text-green-700' : 'text-gray-900',
                         selected && 'bg-green-50 text-green-700',
                         'cursor-pointer select-none relative py-2 pl-4 pr-4',
+                        disabled && 'text-opacity-50 cursor-none',
                       )
                     }
+                    disabled={option.disabled}
                     value={option}
                   >
                     {({ selected }) => (

--- a/client/src/components/select/types.d.ts
+++ b/client/src/components/select/types.d.ts
@@ -1,6 +1,7 @@
 export type SelectOption = {
   label: string;
   value: string | number;
+  disabled?: boolean;
 };
 
 export type SelectOptions = SelectOption[];

--- a/client/src/containers/analysis-visualization/analysis-filters/years/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-filters/years/component.tsx
@@ -42,9 +42,9 @@ const YearsFilter: React.FC = () => {
       data?.map((year) => ({
         label: year.toString(),
         value: year,
-        disabled: endYear <= year,
+        disabled: visualizationMode !== 'map' && endYear <= year + 4, // results should  show a minimun of 5 years window
       })),
-    [data, endYear],
+    [data, endYear, visualizationMode],
   );
 
   const optionsEndYear: SelectOptions = useMemo(() => {
@@ -53,9 +53,9 @@ const YearsFilter: React.FC = () => {
     return result.map((year) => ({
       label: year.toString(),
       value: year,
-      disabled: year <= startYear,
+      disabled: visualizationMode !== 'map' && year - 4 <= startYear, // results should  show a minimun of 5 years window
     }));
-  }, [data, additionalYear, startYear]);
+  }, [data, additionalYear, startYear, visualizationMode]);
 
   const currentStartYearValue: SelectOption = useMemo(
     () => optionsStartYear?.find((option) => option.value === startYear),

--- a/client/src/containers/analysis-visualization/analysis-filters/years/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-filters/years/component.tsx
@@ -18,21 +18,17 @@ const YearsFilter: React.FC = () => {
   const { visualizationMode, filters, layer } = useAppSelector(analysis);
   const { startYear, endYear, materials, indicator } = filters;
   const [additionalYear, setAdditionalYear] = useState<number>(null);
-
   const { data, isLoading } = useYears(layer, materials, indicator);
-
   const dataWithAdditionalYear: number[] = useMemo(() => {
     const result = [...(data || [])];
     if (additionalYear) result.push(additionalYear);
     return result;
   }, [data, additionalYear]);
-
   const handleAdditionalYear: SelectProps['onSearch'] = useCallback(
     (searchTerm) => {
       if (!isFinite(toNumber(searchTerm)) || toNumber(searchTerm) <= data[0]) {
         return;
       }
-
       const existsMatch = data.some((year) => `${year}`.includes(searchTerm));
       if (!existsMatch) {
         setAdditionalYear(toNumber(searchTerm));
@@ -41,37 +37,14 @@ const YearsFilter: React.FC = () => {
     [data],
   );
 
-  const onChangeStartYear = useCallback(
-    (selected) => {
-      dispatch(
-        setFilter({
-          id: 'startYear',
-          value: selected.value,
-        }),
-      );
-    },
-    [dispatch],
-  );
-
-  const onChangeEndYear = useCallback(
-    (selected) => {
-      dispatch(
-        setFilter({
-          id: 'endYear',
-          value: selected.value,
-        }),
-      );
-    },
-    [dispatch],
-  );
-
   const optionsStartYear: SelectOptions = useMemo(
     () =>
       data?.map((year) => ({
         label: year.toString(),
         value: year,
+        disabled: endYear <= year,
       })),
-    [data],
+    [data, endYear],
   );
 
   const optionsEndYear: SelectOptions = useMemo(() => {
@@ -80,21 +53,65 @@ const YearsFilter: React.FC = () => {
     return result.map((year) => ({
       label: year.toString(),
       value: year,
+      disabled: year <= startYear,
     }));
-  }, [data, additionalYear]);
+  }, [data, additionalYear, startYear]);
 
   const currentStartYearValue: SelectOption = useMemo(
     () => optionsStartYear?.find((option) => option.value === startYear),
     [optionsStartYear, startYear],
   );
-
   const currentEndYearValue: SelectOption = useMemo(
     () => optionsEndYear?.find((option) => option.value === endYear),
     [endYear, optionsEndYear],
   );
-
+  const onChangeStartYear = useCallback(
+    (selected) => {
+      // prevent user from select an start year after the start selected year
+      if (selected.value >= currentEndYearValue?.value) {
+        const nextEndYearAvailable = optionsEndYear.find(
+          (option) => option.value === selected.value + 1,
+        );
+        dispatch(
+          setFilter({
+            id: 'endYear',
+            value: nextEndYearAvailable?.value || currentStartYearValue.value,
+          }),
+        );
+      }
+      dispatch(
+        setFilter({
+          id: 'startYear',
+          value: selected.value,
+        }),
+      );
+    },
+    [dispatch, currentEndYearValue, currentStartYearValue, optionsEndYear],
+  );
+  const onChangeEndYear = useCallback(
+    (selected) => {
+      // prevent user from select an end year previous to the start year selected
+      if (selected?.value <= currentStartYearValue?.value) {
+        const nextStartYearAvailable = optionsStartYear.find(
+          (option) => option.value === selected.value - 1,
+        );
+        dispatch(
+          setFilter({
+            id: 'startYear',
+            value: nextStartYearAvailable?.value || currentEndYearValue.value,
+          }),
+        );
+      }
+      dispatch(
+        setFilter({
+          id: 'endYear',
+          value: selected.value,
+        }),
+      );
+    },
+    [dispatch, currentEndYearValue, currentStartYearValue, optionsStartYear],
+  );
   const handleToggleOpen = useCallback(() => setIsOpen(!isOpen), [isOpen]);
-
   useEffect(() => {
     if (!isLoading && dataWithAdditionalYear) {
       onChangeStartYear({
@@ -102,12 +119,19 @@ const YearsFilter: React.FC = () => {
           ? dataWithAdditionalYear.find((year) => year === startYear) ?? dataWithAdditionalYear[0]
           : dataWithAdditionalYear[0],
       });
-      onChangeEndYear({
-        value: endYear
-          ? dataWithAdditionalYear.find((year) => year === endYear) ??
-            dataWithAdditionalYear?.[dataWithAdditionalYear.length - 1]
-          : dataWithAdditionalYear?.[dataWithAdditionalYear.length - 1],
-      });
+      if (startYear === endYear && !!optionsEndYear.length && visualizationMode !== 'map') {
+        onChangeEndYear({
+          value: optionsEndYear[optionsEndYear.length - 1].value,
+        });
+      }
+      if (visualizationMode === 'map') {
+        onChangeEndYear({
+          value: endYear
+            ? dataWithAdditionalYear.find((year) => year === endYear) ??
+              dataWithAdditionalYear?.[dataWithAdditionalYear.length - 1]
+            : dataWithAdditionalYear?.[dataWithAdditionalYear.length - 1],
+        });
+      }
     }
   }, [
     dataWithAdditionalYear,
@@ -119,8 +143,9 @@ const YearsFilter: React.FC = () => {
     onChangeEndYear,
     startYear,
     endYear,
+    optionsEndYear,
+    visualizationMode,
   ]);
-
   if (visualizationMode === 'map') {
     return (
       <Select
@@ -175,7 +200,7 @@ const YearsFilter: React.FC = () => {
                   current={currentStartYearValue}
                   options={optionsStartYear}
                   showSearch={false}
-                  onChange={onChangeEndYear}
+                  onChange={onChangeStartYear}
                   onSearch={handleAdditionalYear}
                 />
                 <div>To</div>

--- a/client/src/hooks/impact/index.ts
+++ b/client/src/hooks/impact/index.ts
@@ -40,7 +40,8 @@ export function useImpactData(): ImpactDataResponse {
   const { data: indicators } = useIndicators();
   const { layer } = useAppSelector(analysis);
   const filters = filtersForTabularAPI(store.getState());
-  const isEnable = !!filters?.indicatorId && !!indicators?.length;
+  const isEnable =
+    !!filters?.indicatorId && !!indicators?.length && !!filters.startYear && !!filters.endYear;
 
   const indicatorIds = indicators.map(({ id }) => id);
 


### PR DESCRIPTION
**DESCRIPTION**

This PR disables options of years selection on the impact page.

Expected behavior:
- Map - user should be able to select any year.
- Chart and Table:
       - When entering user should see the full range of dates.
       - User only will be able to filter data by a minimum of 5 years window. The rest of the options should appear as disabled
       
**JIRA**
https://vizzuality.atlassian.net/browse/LANDGRIF-481?atlOrigin=eyJpIjoiZDU4NGMyZDMyMDI4NGQ1Yjk0YThiYmI1MDQ4MmU3YTQiLCJwIjoiaiJ9