### PR TITLE
Showing actual material sourcing data (from the API endpoint) in the Admin page

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -79,6 +79,7 @@
     "react-spring": "^9.4.2",
     "sharp": "^0.29.3",
     "tailwindcss": "^3.0.2",
+    "uuid": "^8.3.2",
     "webpack": "^5.64.0"
   },
   "devDependencies": {

--- a/client/src/components/pagination/button/component.tsx
+++ b/client/src/components/pagination/button/component.tsx
@@ -1,0 +1,28 @@
+import classNames from 'classnames';
+
+import { ButtonProps } from './types';
+
+const Table: React.FC<ButtonProps> = ({
+  className,
+  active = false,
+  disabled = false,
+  children,
+  ...props
+}: ButtonProps) => (
+  <div
+    className={classNames(
+      'flex justify-center items-center text-sm min-w-[2.5rem] h-10',
+      className,
+      {
+        'border-b border-green-700': active,
+        'cursor-pointer': !disabled,
+        'opacity-30': disabled,
+      },
+    )}
+    {...props}
+  >
+    {children}
+  </div>
+);
+
+export default Table;

--- a/client/src/components/pagination/button/index.ts
+++ b/client/src/components/pagination/button/index.ts
@@ -1,0 +1,2 @@
+export { default } from './component';
+export type { ButtonProps } from './types';

--- a/client/src/components/pagination/button/types.d.ts
+++ b/client/src/components/pagination/button/types.d.ts
@@ -1,0 +1,8 @@
+export type ButtonProps = PropsWithChildren & {
+  /** Classnames to apply to the button */
+  className?: string;
+  /** Whether the button is active */
+  active?: boolean;
+  /** Whether the button is disabled */
+  disabled?: boolean;
+};

--- a/client/src/components/pagination/component.tsx
+++ b/client/src/components/pagination/component.tsx
@@ -1,0 +1,102 @@
+import { useCallback } from 'react';
+import classNames from 'classnames';
+import {
+  ChevronDoubleLeftIcon,
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  ChevronDoubleRightIcon,
+} from '@heroicons/react/solid';
+
+import Button from './button';
+import { PaginationProps } from './types';
+
+const Table: React.FC<PaginationProps> = ({
+  className,
+  numItems,
+  currentPage,
+  totalPages,
+  totalItems,
+  numNumberButtons = 8,
+  onPageClick = () => {
+    // noOp
+  },
+}: PaginationProps) => {
+  const calcPagingRange = useCallback(() => {
+    // https://codereview.stackexchange.com/a/183472
+    const min = 1;
+    let length = numNumberButtons;
+
+    if (length > totalPages) length = totalPages;
+
+    let start = currentPage - Math.floor(length / 2);
+    start = Math.max(start, min);
+    start = Math.min(start, min + totalPages - length);
+
+    return Array.from({ length: length }, (el, i) => start + i);
+  }, [currentPage, numNumberButtons, totalPages]);
+
+  const rangeButtons = calcPagingRange();
+
+  const handleFirstClick = () => {
+    onPageClick(1);
+  };
+
+  const handlePreviousClick = () => {
+    if (currentPage <= 1) return;
+    onPageClick(currentPage - 1);
+  };
+
+  const handleRangeButtonClick = (pageNumber) => {
+    onPageClick(pageNumber);
+  };
+
+  const handleNextClick = () => {
+    if (currentPage >= totalPages) return;
+    onPageClick(currentPage + 1);
+  };
+
+  const handleLastClick = () => {
+    onPageClick(totalPages);
+  };
+
+  return (
+    <div
+      className={classNames(
+        className,
+        'flex flex-col md:flex-row gap-2 md:gap-0 justify-between items-center',
+      )}
+    >
+      <div className="text-xs text-gray-500 font-bold">
+        {numItems} of {totalItems} entries
+      </div>
+
+      <div className="flex items-center">
+        <Button disabled={currentPage <= 1} onClick={handleFirstClick}>
+          <ChevronDoubleLeftIcon className="w-4 h-4" />
+        </Button>
+        <Button disabled={currentPage <= 1} onClick={handlePreviousClick}>
+          <ChevronLeftIcon className="w-5 h-5" />
+        </Button>
+        {rangeButtons.map((buttonNumber) => (
+          <Button
+            key={buttonNumber}
+            active={buttonNumber === currentPage}
+            onClick={() => {
+              handleRangeButtonClick(buttonNumber);
+            }}
+          >
+            {buttonNumber}
+          </Button>
+        ))}
+        <Button disabled={currentPage >= totalPages} onClick={handleNextClick}>
+          <ChevronRightIcon className="w-5 h-5" />
+        </Button>
+        <Button disabled={currentPage >= totalPages} onClick={handleLastClick}>
+          <ChevronDoubleRightIcon className="w-4 h-4" />
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default Table;

--- a/client/src/components/pagination/index.ts
+++ b/client/src/components/pagination/index.ts
@@ -1,0 +1,2 @@
+export { default } from './component';
+export type { PaginationProps } from './types';

--- a/client/src/components/pagination/types.d.ts
+++ b/client/src/components/pagination/types.d.ts
@@ -1,0 +1,16 @@
+export type PaginationProps = {
+  /** Classnames to be applied */
+  className?: string;
+  /** Number of items being displayed */
+  numItems: number;
+  /** Current page number */
+  currentPage: number;
+  /** Total number of pages */
+  totalPages: number;
+  /** Total number of items/records */
+  totalItems: number;
+  /** Number of Number buttons to display. defaults to 8 */
+  numNumberButtons?: number;
+  /** Callback for when the user chooses a page */
+  onPageClick?: (page: number) => void;
+};

--- a/client/src/containers/analysis-visualization/analysis-table/multiple-indicator-table/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-table/multiple-indicator-table/component.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { DataType } from 'ka-table/enums';
+import { DataType, SortingMode } from 'ka-table/enums';
 import { uniq } from 'lodash';
 
 import { DATA_NUMBER_FORMAT } from 'containers/analysis-visualization/constants';
@@ -130,6 +130,7 @@ const MultipleIndicatorTable: React.FC<{ data: ImpactTableData[] }> = ({ data })
           ),
         },
       },
+      sortingMode: SortingMode.Single,
     };
   }, [years, tableData, yearsSum]);
 

--- a/client/src/containers/analysis-visualization/analysis-table/single-indicator-table/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-table/single-indicator-table/component.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { DataType } from 'ka-table/enums';
+import { DataType, SortingMode } from 'ka-table/enums';
 
 import { DATA_NUMBER_FORMAT } from 'containers/analysis-visualization/constants';
 import Table from 'containers/table';
@@ -104,6 +104,7 @@ const AnalysisTable: React.FC<{ data: ImpactTableData }> = ({ data }) => {
           ),
         },
       },
+      sortingMode: SortingMode.Single,
     };
   }, [yearsSum, years, indicatorId, columnValues, dataValues]);
 

--- a/client/src/containers/table/component.tsx
+++ b/client/src/containers/table/component.tsx
@@ -15,7 +15,7 @@ const defaultProps: TableProps = {
   columns: [],
   data: [],
   rowKeyField: 'id',
-  sortingMode: SortingMode.Single,
+  sortingMode: SortingMode.None,
 };
 
 const Table: React.FC<TableProps> = ({

--- a/client/src/hooks/sourcing-locations/index.ts
+++ b/client/src/hooks/sourcing-locations/index.ts
@@ -1,0 +1,70 @@
+import { useMemo } from 'react';
+import { useQuery, UseQueryOptions, UseQueryResult } from 'react-query';
+import { v4 as uuidv4 } from 'uuid';
+
+import { apiWithMetadataService } from 'services/api';
+import { SourcingLocation, APIMetadataPagination } from 'types';
+
+type SourcingLocationsAPIResponse = {
+  data: SourcingLocation[];
+  metadata: APIMetadataPagination;
+};
+
+type SourcingLocationsDataResponse = UseQueryResult & SourcingLocationsAPIResponse;
+
+export type SourcingLocationsParams = {
+  materialsData?: boolean;
+  'page[number]'?: number;
+  'page[size]'?: number;
+};
+
+const DEFAULT_QUERY_OPTIONS: UseQueryOptions = {
+  placeholderData: [],
+  retry: false,
+  keepPreviousData: false,
+  refetchOnWindowFocus: false,
+};
+
+export function useSourcingLocations(
+  params: SourcingLocationsParams,
+): SourcingLocationsDataResponse {
+  // const [session] = useSession();
+
+  const query = useQuery(
+    ['sourcingLocations', params],
+    async () =>
+      apiWithMetadataService
+        .request({
+          method: 'GET',
+          url: '/sourcing-locations',
+          params,
+          headers: {
+            // Authorization: `Bearer ${session.accessToken}`,
+          },
+        })
+        .then((response) => response.data),
+    {
+      ...DEFAULT_QUERY_OPTIONS,
+    },
+  );
+
+  const { data: response } = query;
+
+  return useMemo<SourcingLocationsDataResponse>(
+    () =>
+      ({
+        ...query,
+        data:
+          // The endpoint is not returning ids, and we cannot use `materialId` because there
+          // are duplicates. This causes issues with our tables, not only errors but also
+          // duplicate rows when updating the table data. A workaround is to generate uuids.
+          // We won't be loading many rows at once so it shouldn't be a huge performance hit.
+          ((response as SourcingLocationsAPIResponse).data || []).map((data) => ({
+            id: uuidv4(),
+            ...data,
+          })) || DEFAULT_QUERY_OPTIONS.placeholderData,
+        metadata: (response as SourcingLocationsAPIResponse).metadata || {},
+      } as SourcingLocationsDataResponse),
+    [query, response],
+  );
+}

--- a/client/src/hooks/sourcing-locations/index.ts
+++ b/client/src/hooks/sourcing-locations/index.ts
@@ -5,15 +5,15 @@ import { v4 as uuidv4 } from 'uuid';
 import { apiWithMetadataService } from 'services/api';
 import { SourcingLocation, APIMetadataPagination } from 'types';
 
-type SourcingLocationsAPIResponse = {
+type SourcingLocationsMaterialsAPIResponse = {
   data: SourcingLocation[];
   metadata: APIMetadataPagination;
 };
 
-type SourcingLocationsDataResponse = UseQueryResult & SourcingLocationsAPIResponse;
+type SourcingLocationsMaterialsDataResponse = UseQueryResult &
+  SourcingLocationsMaterialsAPIResponse;
 
 export type SourcingLocationsParams = {
-  materialsData?: boolean;
   'page[number]'?: number;
   'page[size]'?: number;
 };
@@ -24,19 +24,18 @@ const DEFAULT_QUERY_OPTIONS: UseQueryOptions = {
   keepPreviousData: false,
   refetchOnWindowFocus: false,
 };
-
-export function useSourcingLocations(
+export function useSourcingLocationsMaterials(
   params: SourcingLocationsParams,
-): SourcingLocationsDataResponse {
+): SourcingLocationsMaterialsDataResponse {
   // const [session] = useSession();
 
   const query = useQuery(
-    ['sourcingLocations', params],
+    ['sourcingLocationsMaterials', params],
     async () =>
       apiWithMetadataService
         .request({
           method: 'GET',
-          url: '/sourcing-locations',
+          url: '/sourcing-locations/materials',
           params,
           headers: {
             // Authorization: `Bearer ${session.accessToken}`,
@@ -50,7 +49,7 @@ export function useSourcingLocations(
 
   const { data: response } = query;
 
-  return useMemo<SourcingLocationsDataResponse>(
+  return useMemo<SourcingLocationsMaterialsDataResponse>(
     () =>
       ({
         ...query,
@@ -59,12 +58,12 @@ export function useSourcingLocations(
           // are duplicates. This causes issues with our tables, not only errors but also
           // duplicate rows when updating the table data. A workaround is to generate uuids.
           // We won't be loading many rows at once so it shouldn't be a huge performance hit.
-          ((response as SourcingLocationsAPIResponse).data || []).map((data) => ({
+          ((response as SourcingLocationsMaterialsAPIResponse).data || []).map((data) => ({
             id: uuidv4(),
             ...data,
           })) || DEFAULT_QUERY_OPTIONS.placeholderData,
-        metadata: (response as SourcingLocationsAPIResponse).metadata || {},
-      } as SourcingLocationsDataResponse),
+        metadata: (response as SourcingLocationsMaterialsAPIResponse).metadata || {},
+      } as SourcingLocationsMaterialsDataResponse),
     [query, response],
   );
 }

--- a/client/src/pages/admin/data.tsx
+++ b/client/src/pages/admin/data.tsx
@@ -4,7 +4,7 @@ import { /*debounce,*/ flatten, merge, uniq } from 'lodash';
 // import { ExclamationIcon, FilterIcon } from '@heroicons/react/solid';
 
 import useModal from 'hooks/modals';
-import { useSourcingLocations } from 'hooks/sourcing-locations';
+import { useSourcingLocationsMaterials } from 'hooks/sourcing-locations';
 import AdminLayout, { ADMIN_TABS } from 'layouts/admin';
 import NoData from 'containers/admin/no-data';
 import UploadDataSourceModal from 'containers/admin/upload-data-source-modal';
@@ -19,8 +19,7 @@ const AdminDataPage: React.FC = () => {
     data: sourcingData,
     metadata: sourcingMetadata,
     isFetching: isFetchingSourcingData,
-  } = useSourcingLocations({
-    materialsData: true,
+  } = useSourcingLocationsMaterials({
     'page[size]': 10,
     'page[number]': currentPage,
   });
@@ -125,10 +124,10 @@ const AdminDataPage: React.FC = () => {
       {hasData && (
         <>
           {/*
-          <div className="flex flex-col-reverse md:flex-row justify-between items-center">
-            <div className="flex w-full md:w-auto gap-2">
+          <div className="flex flex-col-reverse items-center justify-between md:flex-row">
+            <div className="flex w-full gap-2 md:w-auto">
               <input
-                className="w-full md:w-auto bg-white border border-gray-300 rounded-md shadow-sm text-left focus:outline-none focus:ring-1 focus:ring-green-700 focus:border-green-700 text-sm font-medium"
+                className="w-full text-sm font-medium text-left bg-white border border-gray-300 rounded-md shadow-sm md:w-auto focus:outline-none focus:ring-1 focus:ring-green-700 focus:border-green-700"
                 type="search"
                 placeholder="Search table"
                 defaultValue=""

--- a/client/src/services/api.ts
+++ b/client/src/services/api.ts
@@ -17,6 +17,19 @@ export const apiService = axios.create({
   },
 });
 
+export const apiWithMetadataService = axios.create({
+  baseURL: `${process.env.NEXT_PUBLIC_API_URL}/api/v1`,
+  headers: { 'Content-Type': 'application/json' },
+  transformResponse: (response) => {
+    try {
+      const parsedData = JSON.parse(response);
+      return { data: dataFormatter.deserialize(parsedData), metadata: parsedData.meta };
+    } catch (error) {
+      return response;
+    }
+  },
+});
+
 export const apiRawService = axios.create({
   baseURL: `${process.env.NEXT_PUBLIC_API_URL}/api/v1`,
   headers: { 'Content-Type': 'application/json' },

--- a/client/src/types.d.ts
+++ b/client/src/types.d.ts
@@ -4,6 +4,13 @@ export type HEXColor = string;
 
 export type ColorRamps = Record<string, HEXColor[]>;
 
+export type APIMetadataPagination = {
+  page: number;
+  size: number;
+  totalItems: number;
+  totalPages: number;
+};
+
 export type H3Item = {
   c: RGBColor;
   h: string;
@@ -64,6 +71,23 @@ export type Material = {
   id: string;
   name: string;
   children: Material[];
+};
+
+export type SourcingLocation = {
+  materialId: string;
+  materialName: string;
+  t1Supplier: string;
+  producer: string;
+  businessUnit: string;
+  country: string;
+  locationType: string;
+  purchases: Record<string, integer>;
+};
+
+export type SourcingLocationsParams = {
+  materialsData?: boolean;
+  'page[size]'?: number;
+  'page[number]'?: number;
 };
 
 export type Supplier = {


### PR DESCRIPTION
## Description

**In this PR:**
- New generic `Pagination` component  
  _It takes pretty much the same pagination information API endpoints return, and accepts a callback telling the wrapper component which page to get._  
- New `apiWithMetadataService` api service  
  _Returns the same deserialized data `apiService`_ does, but also returns the `metadata`, for pagination purposes._
  _It may be that in the future it can be merged with the regular one, but I've left it separate for now to prevent confusion/unintended bugs in other parts of the application._
- New `sourcing-locations` hook  
  _Which returns not only the data, but also the metadata (for pagination purposes)_
- `Admin / Data` page changes:  
    - Now displays data from the respective API endpoint, including material tonnage per year    
    - Pagination works  
    - Hid search/sorting/filtering (temporarily)
        _These need to be handled by the API. It made sense to temporarily hide them until the endpoint is ready & we make it work with the API in the frontend, so we don't think features are implemented when they aren't; for instance sorting seemed to work, only because it was a frontend implementation_
- `Table` component (`ka-table` wrapper)  
    - Disabled frontend sorting by default  
        _For the majority of tables we will need sorting to be done in the API, so hopefully this prevents us from thinking it works when it doesn't. I've added it manually to the Analysis section tables, as it works well there given they're not paginated. _

## JIRA  
[LANDGRIF-507 (Admin/Data should display data from the endpoint)](https://vizzuality.atlassian.net/browse/LANDGRIF-507)
[LANDGRIF-504 (Admin/Data table should be paginated)](https://vizzuality.atlassian.net/browse/LANDGRIF-504)

## Screenshot  

<img width="1534" alt="Screenshot 2022-02-10 at 12 07 38" src="https://user-images.githubusercontent.com/6273795/153405783-c8ec6985-47c8-4546-b4b6-f95c7d3d2b46.png">


## Video    

https://user-images.githubusercontent.com/6273795/153406276-3739eeca-87f9-4fce-bfb5-4aec9a5f7268.mp4


