### PR TITLE
Adding search & years range filters to Admin/data

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -78,6 +78,7 @@
     "react-query": "^3.16.0",
     "react-redux": "^7.2.4",
     "react-spring": "^9.4.2",
+    "rooks": "^5.10.0",
     "sharp": "^0.29.3",
     "tailwindcss": "^3.0.2",
     "uuid": "^8.3.2",

--- a/client/package.json
+++ b/client/package.json
@@ -33,6 +33,7 @@
     "@react-aria/button": "^3.3.2",
     "@react-aria/dialog": "^3.1.4",
     "@react-aria/overlays": "^3.6.3",
+    "@react-aria/searchfield": "^3.2.2",
     "@react-hook/debounce": "^4.0.0",
     "@reduxjs/toolkit": "^1.5.1",
     "@tailwindcss/forms": "^0.4.0",

--- a/client/src/components/search/component.tsx
+++ b/client/src/components/search/component.tsx
@@ -23,7 +23,7 @@ export const Search: FC<SearchProps> = ({ ...props }: SearchProps) => {
         ref={ref}
         placeholder={placeholder}
         type="search"
-        className="py-3 pl-10 pr-8 text-sm font-medium leading-4 text-left bg-white border-none rounded-md shadow-sm md:w-auto focus:outline-none focus:ring-1 focus:ring-green-700 focus:border-green-700"
+        className="h-full py-2 pl-10 pr-8 text-sm font-medium leading-4 text-left bg-white border border-gray-300 rounded-md shadow-sm md:w-auto focus:outline-none focus:ring-1 focus:ring-green-700 focus:border-green-700"
       />
 
       {state.value !== '' && (

--- a/client/src/components/search/component.tsx
+++ b/client/src/components/search/component.tsx
@@ -1,0 +1,43 @@
+import { FC, useRef } from 'react';
+import { SearchIcon, XIcon } from '@heroicons/react/solid';
+import { useButton } from '@react-aria/button';
+import { useSearchField } from '@react-aria/searchfield';
+import { useSearchFieldState } from '@react-stately/searchfield';
+
+import type { SearchProps } from './types';
+
+export const Search: FC<SearchProps> = ({ ...props }: SearchProps) => {
+  const { placeholder } = props;
+  const state = useSearchFieldState(props);
+
+  const ref = useRef();
+  const { inputProps, clearButtonProps } = useSearchField(props, state, ref);
+  const { buttonProps } = useButton(clearButtonProps, null);
+
+  return (
+    <div className="relative flex items-center w-full">
+      <SearchIcon className="absolute w-5 h-5 text-gray-400 transform -translate-y-1/2 top-1/2 left-3" />
+
+      <input
+        {...inputProps}
+        ref={ref}
+        placeholder={placeholder}
+        type="search"
+        className="py-3 pl-10 pr-8 text-sm font-medium leading-4 text-left bg-white border-none rounded-md shadow-sm md:w-auto focus:outline-none focus:ring-1 focus:ring-green-700 focus:border-green-700"
+      />
+
+      {state.value !== '' && (
+        <button
+          {...buttonProps}
+          tabIndex="clear"
+          className="absolute z-10 flex items-center self-center justify-center w-5 h-5 right-3 r-2"
+          type="button"
+        >
+          <XIcon className="w-4 h-4 text-gray-400" />
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default Search;

--- a/client/src/components/search/index.ts
+++ b/client/src/components/search/index.ts
@@ -1,0 +1,1 @@
+export { default } from './component';

--- a/client/src/components/search/types.d.ts
+++ b/client/src/components/search/types.d.ts
@@ -1,0 +1,4 @@
+// react types
+import { AriaSearchFieldProps as SearchProps } from '@react-types/searchfield';
+
+export type { SearchProps };

--- a/client/src/components/select/component.tsx
+++ b/client/src/components/select/component.tsx
@@ -141,7 +141,7 @@ const ScenariosComparison: React.FC<SelectProps> = (props: SelectProps) => {
                         active ? 'bg-green-50 text-green-700' : 'text-gray-900',
                         selected && 'bg-green-50 text-green-700',
                         'cursor-pointer select-none relative py-2 pl-4 pr-4',
-                        disabled && 'text-opacity-50 cursor-none',
+                        disabled && 'text-opacity-50 cursor-default',
                       )
                     }
                     disabled={option.disabled}

--- a/client/src/components/select/component.tsx
+++ b/client/src/components/select/component.tsx
@@ -69,23 +69,15 @@ const ScenariosComparison: React.FC<SelectProps> = (props: SelectProps) => {
       {({ open }) => (
         <>
           <div className="relative">
-            <Listbox.Button
-              className={cx(
-                'bg-white relative w-full flex align-center rounded-md pl-3 pr-10 py-2 text-left focus:outline-none focus:ring-1  text-sm cursor-pointer font-medium',
-                {
-                  'shadow-sm border border-gray-300 focus:ring-green-700 focus:border-green-700':
-                    styles.border,
-                },
-              )}
-            >
+            <Listbox.Button className="relative flex w-full py-2 pl-3 pr-10 text-sm font-medium text-left bg-white border border-gray-300 rounded-md shadow-sm cursor-pointer align-center focus:outline-none focus:ring-1 focus:ring-green-700 focus:border-green-700">
               {loading ? (
                 <div className="p-4">
-                  <Loading className="text-green-700 -ml-1 mr-3" />
+                  <Loading className="mr-3 -ml-1 text-green-700" />
                 </div>
               ) : (
                 <>
                   {label && (
-                    <span className="inline-block truncate mr-1 text-gray-400">{label}</span>
+                    <span className="inline-block mr-1 text-gray-400 truncate">{label}</span>
                   )}
                   {placeholder && !selected?.label && (
                     <span className="text-gray-300 truncate">{placeholder}</span>
@@ -93,9 +85,9 @@ const ScenariosComparison: React.FC<SelectProps> = (props: SelectProps) => {
                   {selected && <span className="inline-block truncate">{selected?.label}</span>}
                   <span className="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
                     {open ? (
-                      <ChevronUpIcon className="h-4 w-4 text-gray-900" aria-hidden="true" />
+                      <ChevronUpIcon className="w-4 h-4 text-gray-900" aria-hidden="true" />
                     ) : (
-                      <ChevronDownIcon className="h-4 w-4 text-gray-900" aria-hidden="true" />
+                      <ChevronDownIcon className="w-4 h-4 text-gray-900" aria-hidden="true" />
                     )}
                   </span>
                 </>
@@ -124,19 +116,19 @@ const ScenariosComparison: React.FC<SelectProps> = (props: SelectProps) => {
               >
                 {showSearch && (
                   <div className="relative flex items-center border-b border-b-gray-400">
-                    <div className="pl-2 py-1">
-                      <SearchIcon className="block h-4 w-4 text-gray-400" />
+                    <div className="py-1 pl-2">
+                      <SearchIcon className="block w-4 h-4 text-gray-400" />
                     </div>
                     <input
                       type="search"
                       value={searchTerm}
                       placeholder={searchPlaceholder}
-                      className="block w-24 text-sm border-0 rounded-t-md focus:ring-0 focus:border-green-700 flex-1"
+                      className="flex-1 block w-24 text-sm border-0 rounded-t-md focus:ring-0 focus:border-green-700"
                       onChange={handleSearch}
                     />
                     {searchTerm && (
                       <button type="button" onClick={resetSearch} className="px-2 py-1">
-                        <XIcon className="h-4 w-4 text-gray-400" />
+                        <XIcon className="w-4 h-4 text-gray-400" />
                       </button>
                     )}
                   </div>

--- a/client/src/components/select/index.ts
+++ b/client/src/components/select/index.ts
@@ -1,1 +1,2 @@
 export { default } from './component';
+export type { SelectOption } from './types';

--- a/client/src/components/select/index.ts
+++ b/client/src/components/select/index.ts
@@ -1,2 +1,2 @@
 export { default } from './component';
-export type { SelectOption } from './types';
+export type { SelectOption, SelectProps } from './types';

--- a/client/src/containers/admin/no-results/component.tsx
+++ b/client/src/containers/admin/no-results/component.tsx
@@ -1,0 +1,8 @@
+const AdminNoResults: React.FC = () => (
+  <div className="absolute w-full p-4 text-center -translate-x-1/2 -translate-y-1/2 left-1/2 top-1/2 md:max-w-xs">
+    <p className="mb-3 text-sm font-medium">No results</p>
+    <p className="mb-8 text-gray-500 text-md">Please try a different search text and/or filters</p>
+  </div>
+);
+
+export default AdminNoResults;

--- a/client/src/containers/admin/no-results/index.ts
+++ b/client/src/containers/admin/no-results/index.ts
@@ -1,0 +1,1 @@
+export { default } from './component';

--- a/client/src/containers/analysis-visualization/analysis-filters/years/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-filters/years/component.tsx
@@ -1,224 +1,59 @@
-import React, { useCallback, useEffect, useState, useMemo, Fragment } from 'react';
-import { toNumber, isFinite } from 'lodash';
-import { Transition } from '@headlessui/react';
-import { ChevronDownIcon, ChevronUpIcon } from '@heroicons/react/solid';
+import React, { useEffect, useMemo } from 'react';
 
 import { useAppDispatch, useAppSelector } from 'store/hooks';
 import { analysis, setFilter } from 'store/features/analysis';
 
 import { useYears } from 'hooks/years';
 
+import YearsRangeFilter, { useYearsRange } from 'containers/filters/years-range';
 import Select from 'components/select';
-
-import type { SelectProps, SelectOptions, SelectOption } from 'components/select/types';
 
 const YearsFilter: React.FC = () => {
   const dispatch = useAppDispatch();
-  const [isOpen, setIsOpen] = useState<boolean>(false);
+
   const { visualizationMode, filters, layer } = useAppSelector(analysis);
-  const { startYear, endYear, materials, indicator } = filters;
-  const [additionalYear, setAdditionalYear] = useState<number>(null);
-  const { data, isLoading } = useYears(layer, materials, indicator);
-  const dataWithAdditionalYear: number[] = useMemo(() => {
-    const result = [...(data || [])];
-    if (additionalYear) result.push(additionalYear);
-    return result;
-  }, [data, additionalYear]);
-  const handleAdditionalYear: SelectProps['onSearch'] = useCallback(
-    (searchTerm) => {
-      if (!isFinite(toNumber(searchTerm)) || toNumber(searchTerm) <= data[0]) {
-        return;
-      }
-      const existsMatch = data.some((year) => `${year}`.includes(searchTerm));
-      if (!existsMatch) {
-        setAdditionalYear(toNumber(searchTerm));
-      }
-    },
-    [data],
-  );
+  const { materials, indicator } = filters;
+  const { data: allYears, isLoading } = useYears(layer, materials, indicator);
 
-  const optionsStartYear: SelectOptions = useMemo(
-    () =>
-      data?.map((year) => ({
-        label: year.toString(),
-        value: year,
-        disabled: visualizationMode !== 'map' && endYear <= year + 4, // results should  show a minimum of 5 years window
-      })),
-    [data, endYear, visualizationMode],
-  );
+  const { startYear, endYear, yearsGap, setYearsRange } = useYearsRange({
+    years: allYears,
+    yearsGap: 5,
+    ...filters,
+  });
 
-  const optionsEndYear: SelectOptions = useMemo(() => {
-    const result = [...(data || [])];
-    if (additionalYear) result.push(additionalYear);
-    return result.map((year) => ({
-      label: year.toString(),
-      value: year,
-      disabled: visualizationMode !== 'map' && year - 4 <= startYear, // results should  show a minimum of 5 years window
-    }));
-  }, [data, additionalYear, startYear, visualizationMode]);
-
-  const currentStartYearValue: SelectOption = useMemo(
-    () => optionsStartYear?.find((option) => option.value === startYear),
-    [optionsStartYear, startYear],
-  );
-  const currentEndYearValue: SelectOption = useMemo(
-    () => optionsEndYear?.find((option) => option.value === endYear),
-    [endYear, optionsEndYear],
-  );
-  const onChangeStartYear = useCallback(
-    (selected) => {
-      // prevent user from select an start year after the start selected year
-      if (selected.value >= currentEndYearValue?.value) {
-        const nextEndYearAvailable = optionsEndYear.find(
-          (option) => option.value === selected.value + 1,
-        );
-        dispatch(
-          setFilter({
-            id: 'endYear',
-            value: nextEndYearAvailable?.value || currentStartYearValue?.value,
-          }),
-        );
-      }
-      dispatch(
-        setFilter({
-          id: 'startYear',
-          value: selected.value,
-        }),
-      );
-    },
-    [dispatch, currentEndYearValue, currentStartYearValue, optionsEndYear],
-  );
-  const onChangeEndYear = useCallback(
-    (selected) => {
-      // prevent user from select an end year previous to the start year selected
-      if (selected?.value <= currentStartYearValue?.value) {
-        const nextStartYearAvailable = optionsStartYear.find(
-          (option) => option.value === selected.value - 1,
-        );
-        dispatch(
-          setFilter({
-            id: 'startYear',
-            value: nextStartYearAvailable?.value || currentEndYearValue.value,
-          }),
-        );
-      }
-      dispatch(
-        setFilter({
-          id: 'endYear',
-          value: selected.value,
-        }),
-      );
-    },
-    [dispatch, currentEndYearValue, currentStartYearValue, optionsStartYear],
-  );
-  const handleToggleOpen = useCallback(() => setIsOpen(!isOpen), [isOpen]);
   useEffect(() => {
-    if (!isLoading && dataWithAdditionalYear) {
-      onChangeStartYear({
-        value: startYear
-          ? dataWithAdditionalYear.find((year) => year === startYear) ?? dataWithAdditionalYear[0]
-          : dataWithAdditionalYear[0],
-      });
-      if (startYear === endYear && !!optionsEndYear.length && visualizationMode !== 'map') {
-        onChangeEndYear({
-          value: optionsEndYear[optionsEndYear.length - 1].value,
-        });
-      }
-      if (visualizationMode === 'map') {
-        onChangeEndYear({
-          value: endYear
-            ? dataWithAdditionalYear.find((year) => year === endYear) ??
-              dataWithAdditionalYear?.[dataWithAdditionalYear.length - 1]
-            : dataWithAdditionalYear?.[dataWithAdditionalYear.length - 1],
-        });
-      }
-    }
-  }, [
-    dataWithAdditionalYear,
-    isLoading,
-    layer,
-    materials,
-    indicator,
-    onChangeStartYear,
-    onChangeEndYear,
-    startYear,
-    endYear,
-    optionsEndYear,
-    visualizationMode,
-  ]);
-  if (visualizationMode === 'map') {
-    return (
-      <Select
-        loading={isLoading}
-        current={currentEndYearValue}
-        options={optionsEndYear}
-        placeholder="Year"
-        showSearch
-        onChange={onChangeEndYear}
-        onSearch={handleAdditionalYear}
-      />
-    );
-  }
+    dispatch(setFilter({ id: 'startYear', value: startYear }));
+    dispatch(setFilter({ id: 'endYear', value: endYear }));
+  }, [startYear, endYear, dispatch]);
 
-  return (
-    <div className="relative">
-      <button
-        className="relative w-full py-2 pl-3 pr-10 text-left bg-white border border-gray-300 rounded-md shadow-sm cursor-default focus:outline-none focus:ring-1 focus:ring-green-700 focus:border-green-700 sm:text-sm"
-        onClick={handleToggleOpen}
-      >
-        <span className="block h-5 truncate">
-          <span className="mr-1 text-gray-600">from</span>
-          <span>
-            {currentStartYearValue?.label}-{currentEndYearValue?.label}
-          </span>
-        </span>
-        <span className="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
-          {open ? (
-            <ChevronUpIcon className="w-5 h-5 text-gray-900" aria-hidden="true" />
-          ) : (
-            <ChevronDownIcon className="w-5 h-5 text-gray-900" aria-hidden="true" />
-          )}
-        </span>
-      </button>
-      <Transition
-        show={isOpen}
-        as={Fragment}
-        enter="transition ease-out duration-200"
-        enterFrom="opacity-0 translate-y-1"
-        enterTo="opacity-100 translate-y-0"
-        leave="transition ease-in duration-150"
-        leaveFrom="opacity-100 translate-y-0"
-        leaveTo="opacity-0 translate-y-1"
-      >
-        <div className="absolute z-20 mt-1 w-60">
-          <div className="rounded-lg shadow-lg ring-1 ring-black ring-opacity-5">
-            <div className="relative p-4 bg-white rounded-lg">
-              <div className="grid grid-cols-1 gap-2">
-                <div>From</div>
-                <Select
-                  loading={isLoading}
-                  current={currentStartYearValue}
-                  options={optionsStartYear}
-                  showSearch={false}
-                  onChange={onChangeStartYear}
-                  onSearch={handleAdditionalYear}
-                />
-                <div>To</div>
-                <Select
-                  loading={isLoading}
-                  current={currentEndYearValue}
-                  options={optionsEndYear}
-                  showSearch
-                  searchPlaceholder="Search or add a year"
-                  onChange={onChangeEndYear}
-                  onSearch={handleAdditionalYear}
-                />
-              </div>
-            </div>
-          </div>
-        </div>
-      </Transition>
-    </div>
+  const yearSelectCurrentOption = useMemo(
+    () => ({ label: endYear?.toString(), value: endYear }),
+    [endYear],
+  );
+
+  const yearSelectOptions = useMemo(
+    () => allYears?.map((year) => ({ label: year.toString(), value: year })),
+    [allYears],
+  );
+
+  return visualizationMode === 'map' ? (
+    <Select
+      loading={isLoading}
+      current={yearSelectCurrentOption}
+      options={yearSelectOptions}
+      placeholder="Year"
+      showSearch
+      onChange={({ value }) => setFilter({ id: 'endYear', value: value })}
+    />
+  ) : (
+    <YearsRangeFilter
+      loading={isLoading}
+      startYear={startYear}
+      endYear={endYear}
+      years={allYears}
+      yearsGap={yearsGap}
+      onChange={setYearsRange}
+    />
   );
 };
 

--- a/client/src/containers/analysis-visualization/analysis-filters/years/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-filters/years/component.tsx
@@ -42,7 +42,7 @@ const YearsFilter: React.FC = () => {
       data?.map((year) => ({
         label: year.toString(),
         value: year,
-        disabled: visualizationMode !== 'map' && endYear <= year + 4, // results should  show a minimun of 5 years window
+        disabled: visualizationMode !== 'map' && endYear <= year + 4, // results should  show a minimum of 5 years window
       })),
     [data, endYear, visualizationMode],
   );
@@ -53,7 +53,7 @@ const YearsFilter: React.FC = () => {
     return result.map((year) => ({
       label: year.toString(),
       value: year,
-      disabled: visualizationMode !== 'map' && year - 4 <= startYear, // results should  show a minimun of 5 years window
+      disabled: visualizationMode !== 'map' && year - 4 <= startYear, // results should  show a minimum of 5 years window
     }));
   }, [data, additionalYear, startYear, visualizationMode]);
 

--- a/client/src/containers/analysis-visualization/analysis-filters/years/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-filters/years/component.tsx
@@ -13,10 +13,10 @@ const YearsFilter: React.FC = () => {
 
   const { visualizationMode, filters, layer } = useAppSelector(analysis);
   const { materials, indicator } = filters;
-  const { data: allYears, isLoading } = useYears(layer, materials, indicator);
+  const { data: years, isLoading } = useYears(layer, materials, indicator);
 
   const { startYear, endYear, yearsGap, setYearsRange } = useYearsRange({
-    years: allYears,
+    years: years,
     yearsGap: 5,
     ...filters,
   });
@@ -32,8 +32,8 @@ const YearsFilter: React.FC = () => {
   );
 
   const yearSelectOptions = useMemo(
-    () => allYears?.map((year) => ({ label: year.toString(), value: year })),
-    [allYears],
+    () => years?.map((year) => ({ label: year.toString(), value: year })),
+    [years],
   );
 
   return visualizationMode === 'map' ? (
@@ -50,7 +50,7 @@ const YearsFilter: React.FC = () => {
       loading={isLoading}
       startYear={startYear}
       endYear={endYear}
-      years={allYears}
+      years={years}
       yearsGap={yearsGap}
       onChange={setYearsRange}
     />

--- a/client/src/containers/filters/years-range/component.tsx
+++ b/client/src/containers/filters/years-range/component.tsx
@@ -12,8 +12,13 @@ export const YearsRangeFilter: React.FC<YearsRangeFilterProps> = ({
   startYear,
   endYear,
   years,
-  fiveYearGap = false,
+  loading = false,
+  yearsGap = 0,
+  showStartYearSearch = false,
+  showEndYearSearch = true,
+  showSearch,
   onChange,
+  onSearch,
 }: YearsRangeFilterProps) => {
   const wrapperRef = useRef();
 
@@ -31,7 +36,7 @@ export const YearsRangeFilter: React.FC<YearsRangeFilterProps> = ({
       years?.map((year) => ({
         label: year.toString(),
         value: year,
-        disabled: fiveYearGap && endYear <= year + 4,
+        disabled: endYear <= year + (yearsGap - 1),
       })),
     );
 
@@ -39,12 +44,12 @@ export const YearsRangeFilter: React.FC<YearsRangeFilterProps> = ({
       years?.map((year) => ({
         label: year.toString(),
         value: year,
-        disabled: fiveYearGap && year - 4 <= startYear,
+        disabled: startYear >= year - (yearsGap - 1),
       })),
     );
 
     setIsLoaded(true);
-  }, [endYear, fiveYearGap, isLoaded, startYear, years]);
+  }, [endYear, isLoaded, startYear, years, yearsGap]);
 
   useEffect(() => {
     if (!startYearOptions || !endYearOptions) return;
@@ -54,17 +59,17 @@ export const YearsRangeFilter: React.FC<YearsRangeFilterProps> = ({
 
   useEffect(() => {
     if (!startYearOption || !endYearOption) return;
-    // Prevents `onChange` to be called when this component loads, possibly causing a loop.
     if (startYear === startYearOption.value && endYear === endYearOption.value) return;
-    onChange({ startYear: Number(startYearOption.value), endYear: Number(endYearOption.value) });
+    onChange &&
+      onChange({ startYear: Number(startYearOption.value), endYear: Number(endYearOption.value) });
   }, [
     startYear,
     endYear,
-    onChange,
     startYearOption,
-    endYearOption,
     startYearOptions,
+    endYearOption,
     endYearOptions,
+    onChange,
   ]);
 
   useOutsideClick(wrapperRef, () => {
@@ -112,19 +117,21 @@ export const YearsRangeFilter: React.FC<YearsRangeFilterProps> = ({
               <div className="grid grid-cols-1 gap-2">
                 <div>From</div>
                 <Select
-                  loading={false}
-                  showSearch={false}
+                  loading={loading}
+                  showSearch={showSearch ?? showStartYearSearch}
                   options={startYearOptions}
                   current={startYearOption}
                   onChange={setStartYearOption}
+                  onSearch={onSearch}
                 />
                 <div>To</div>
                 <Select
-                  loading={false}
-                  showSearch={true}
+                  loading={loading}
+                  showSearch={showSearch ?? showEndYearSearch}
                   options={endYearOptions}
                   current={endYearOption}
                   onChange={setEndYearOption}
+                  onSearch={onSearch}
                 />
               </div>
             </div>

--- a/client/src/containers/filters/years-range/component.tsx
+++ b/client/src/containers/filters/years-range/component.tsx
@@ -1,0 +1,138 @@
+import React, { useRef, useEffect, useState, Fragment } from 'react';
+import { useOutsideClick } from 'rooks';
+import { Transition } from '@headlessui/react';
+import { ChevronDownIcon, ChevronUpIcon } from '@heroicons/react/solid';
+
+import Select from 'components/select';
+import type { SelectOption } from 'components/select/types';
+
+import { YearsRangeFilterProps } from './types';
+
+export const YearsRangeFilter: React.FC<YearsRangeFilterProps> = ({
+  startYear,
+  endYear,
+  years,
+  fiveYearGap = false,
+  onChange,
+}: YearsRangeFilterProps) => {
+  const wrapperRef = useRef();
+
+  const [isOpen, setIsOpen] = useState<boolean>(false);
+  const [isLoaded, setIsLoaded] = useState<boolean>(false);
+  const [startYearOptions, setStartYearOptions] = useState<SelectOption[]>();
+  const [startYearOption, setStartYearOption] = useState<SelectOption>();
+  const [endYearOptions, setEndYearOptions] = useState<SelectOption[]>();
+  const [endYearOption, setEndYearOption] = useState<SelectOption>();
+
+  useEffect(() => {
+    if (!years.length) return;
+
+    setStartYearOptions(
+      years?.map((year) => ({
+        label: year.toString(),
+        value: year,
+        disabled: fiveYearGap && endYear <= year + 4,
+      })),
+    );
+
+    setEndYearOptions(
+      years?.map((year) => ({
+        label: year.toString(),
+        value: year,
+        disabled: fiveYearGap && year - 4 <= startYear,
+      })),
+    );
+
+    setIsLoaded(true);
+  }, [endYear, fiveYearGap, isLoaded, startYear, years]);
+
+  useEffect(() => {
+    if (!startYearOptions || !endYearOptions) return;
+    setStartYearOption(startYearOptions.find((option) => option.value === startYear));
+    setEndYearOption(endYearOptions.find((option) => option.value === endYear));
+  }, [startYearOptions, endYearOptions, startYear, endYear]);
+
+  useEffect(() => {
+    if (!startYearOption || !endYearOption) return;
+    // Prevents `onChange` to be called when this component loads, possibly causing a loop.
+    if (startYear === startYearOption.value && endYear === endYearOption.value) return;
+    onChange({ startYear: Number(startYearOption.value), endYear: Number(endYearOption.value) });
+  }, [
+    startYear,
+    endYear,
+    onChange,
+    startYearOption,
+    endYearOption,
+    startYearOptions,
+    endYearOptions,
+  ]);
+
+  useOutsideClick(wrapperRef, () => {
+    setIsOpen(false);
+  });
+
+  // Prevent display when not loaded
+  if (!isLoaded) return null;
+
+  return (
+    <div ref={wrapperRef} className="relative">
+      <button
+        className="relative w-full py-2 pl-3 pr-10 text-left bg-white border border-gray-300 rounded-md shadow-sm cursor-pointer focus:outline-none focus:ring-1 focus:ring-green-700 focus:border-green-700 sm:text-sm"
+        onClick={() => {
+          setIsOpen(!isOpen);
+        }}
+      >
+        <span className="block h-5 truncate">
+          <span className="mr-1 text-gray-600">from</span>
+          <span>
+            {startYearOption?.label} - {endYearOption?.label}
+          </span>
+        </span>
+        <span className="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
+          {isOpen ? (
+            <ChevronUpIcon className="w-5 h-5 text-gray-900" aria-hidden="true" />
+          ) : (
+            <ChevronDownIcon className="w-5 h-5 text-gray-900" aria-hidden="true" />
+          )}
+        </span>
+      </button>
+      <Transition
+        show={isOpen}
+        as={Fragment}
+        enter="transition ease-out duration-200"
+        enterFrom="opacity-0 translate-y-1"
+        enterTo="opacity-100 translate-y-0"
+        leave="transition ease-in duration-150"
+        leaveFrom="opacity-100 translate-y-0"
+        leaveTo="opacity-0 translate-y-1"
+      >
+        <div className="absolute z-20 mt-1 w-60">
+          <div className="rounded-lg shadow-lg ring-1 ring-black ring-opacity-5">
+            <div className="relative p-4 bg-white rounded-lg">
+              <div className="grid grid-cols-1 gap-2">
+                <div>From</div>
+                <Select
+                  loading={false}
+                  showSearch={false}
+                  options={startYearOptions}
+                  current={startYearOption}
+                  onChange={setStartYearOption}
+                />
+                <div>To</div>
+                <Select
+                  loading={false}
+                  showSearch={true}
+                  options={endYearOptions}
+                  current={endYearOption}
+                  onChange={setEndYearOption}
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </Transition>
+    </div>
+  );
+};
+
+export default YearsRangeFilter;

--- a/client/src/containers/filters/years-range/component.tsx
+++ b/client/src/containers/filters/years-range/component.tsx
@@ -17,8 +17,9 @@ export const YearsRangeFilter: React.FC<YearsRangeFilterProps> = ({
   showStartYearSearch = false,
   showEndYearSearch = true,
   showSearch,
-  onChange,
-  onSearch,
+  onChange = () => null,
+  onStartYearSearch = () => null,
+  onEndYearSearch = () => null,
 }: YearsRangeFilterProps) => {
   const wrapperRef = useRef();
 
@@ -122,7 +123,7 @@ export const YearsRangeFilter: React.FC<YearsRangeFilterProps> = ({
                   options={startYearOptions}
                   current={startYearOption}
                   onChange={setStartYearOption}
-                  onSearch={onSearch}
+                  onSearch={onStartYearSearch}
                 />
                 <div>To</div>
                 <Select
@@ -131,7 +132,7 @@ export const YearsRangeFilter: React.FC<YearsRangeFilterProps> = ({
                   options={endYearOptions}
                   current={endYearOption}
                   onChange={setEndYearOption}
-                  onSearch={onSearch}
+                  onSearch={onEndYearSearch}
                 />
               </div>
             </div>

--- a/client/src/containers/filters/years-range/hooks.ts
+++ b/client/src/containers/filters/years-range/hooks.ts
@@ -1,0 +1,27 @@
+import { useState } from 'react';
+
+import { UseYearsRangeProps, YearsRangeParams } from './types';
+
+export function useYearsRange({
+  startYear: initialStartYear,
+  endYear: initialEndYear,
+}: UseYearsRangeProps): UseYearsRangeProps {
+  const [startYear, setStartYear] = useState<number>(initialStartYear);
+  const [endYear, setEndYear] = useState<number>(initialEndYear);
+
+  const setYearsRange = ({
+    startYear: startYearParam,
+    endYear: endYearParam,
+  }: YearsRangeParams) => {
+    setStartYear(startYearParam);
+    setEndYear(endYearParam);
+  };
+
+  return {
+    startYear,
+    endYear,
+    setStartYear,
+    setEndYear,
+    setYearsRange,
+  };
+}

--- a/client/src/containers/filters/years-range/hooks.ts
+++ b/client/src/containers/filters/years-range/hooks.ts
@@ -1,15 +1,17 @@
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect, useMemo } from 'react';
 
 import { UseYearsRangeProps, YearsRangeParams } from './types';
 
 export function useYearsRange({
-  years,
+  years: yearsProp,
   yearsGap = 0,
   startYear: initialStartYear,
   endYear: initialEndYear,
 }: UseYearsRangeProps): UseYearsRangeProps {
   const [startYear, setStartYear] = useState<number>(initialStartYear);
   const [endYear, setEndYear] = useState<number>(initialEndYear);
+
+  const years = useMemo(() => yearsProp.sort(), [yearsProp]);
 
   const setYearsRange = useCallback(
     ({ startYear: startYearParam, endYear: endYearParam }: YearsRangeParams) => {
@@ -53,8 +55,15 @@ export function useYearsRange({
     }
   }, [endYear, setYearsRange, startYear, years, yearsGap]);
 
+  const yearsInRange = useMemo(
+    () =>
+      years.filter((year) => (startYear && endYear ? year >= startYear && year <= endYear : true)),
+    [endYear, startYear, years],
+  );
+
   return {
     years,
+    yearsInRange,
     yearsGap,
     startYear,
     endYear,

--- a/client/src/containers/filters/years-range/hooks.ts
+++ b/client/src/containers/filters/years-range/hooks.ts
@@ -34,7 +34,7 @@ export function useYearsRange({
     const lastYear = years[years.length - 1];
 
     // We have a startYear and an endYear, but they fall out of the years array boundaries. Correct that.
-    if (startYear <= firstYear || endYear >= lastYear) {
+    if (startYear < firstYear || endYear > lastYear) {
       setStartYear(firstYear);
       setEndYear(lastYear);
       return;

--- a/client/src/containers/filters/years-range/hooks.ts
+++ b/client/src/containers/filters/years-range/hooks.ts
@@ -1,23 +1,61 @@
-import { useState } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 
 import { UseYearsRangeProps, YearsRangeParams } from './types';
 
 export function useYearsRange({
+  years,
+  yearsGap = 0,
   startYear: initialStartYear,
   endYear: initialEndYear,
 }: UseYearsRangeProps): UseYearsRangeProps {
   const [startYear, setStartYear] = useState<number>(initialStartYear);
   const [endYear, setEndYear] = useState<number>(initialEndYear);
 
-  const setYearsRange = ({
-    startYear: startYearParam,
-    endYear: endYearParam,
-  }: YearsRangeParams) => {
-    setStartYear(startYearParam);
-    setEndYear(endYearParam);
-  };
+  const setYearsRange = useCallback(
+    ({ startYear: startYearParam, endYear: endYearParam }: YearsRangeParams) => {
+      setStartYear(startYearParam);
+      setEndYear(endYearParam);
+    },
+    [],
+  );
+
+  useEffect(() => {
+    // If we don't have a years array there's nothing to set
+    if (!years) return;
+
+    // If we don't have a startYear nor an endYear, we need to set them with the default values in the array.
+    if (!startYear || !endYear) {
+      if (!startYear) setStartYear(years[0]);
+      if (!endYear) setEndYear(years[years.length - 1]);
+      return;
+    }
+
+    const firstYear = years[0];
+    const lastYear = years[years.length - 1];
+
+    // We have a startYear and an endYear, but they fall out of the years array boundaries. Correct that.
+    if (startYear <= firstYear || endYear >= lastYear) {
+      setStartYear(firstYear);
+      setEndYear(lastYear);
+      return;
+    }
+
+    // We have a startYear and endYear, they're within array boundaries, but the year gap is not respected
+    if (endYear - startYear < yearsGap) {
+      if (lastYear - firstYear < yearsGap) {
+        setStartYear(firstYear);
+        setEndYear(lastYear);
+        return;
+      } else {
+        // We have a years gap set, but not enough data to respect it.
+        console.error('Years gap cannot be respected; not enough years data');
+      }
+    }
+  }, [endYear, setYearsRange, startYear, years, yearsGap]);
 
   return {
+    years,
+    yearsGap,
     startYear,
     endYear,
     setStartYear,

--- a/client/src/containers/filters/years-range/hooks.ts
+++ b/client/src/containers/filters/years-range/hooks.ts
@@ -7,6 +7,7 @@ export function useYearsRange({
   yearsGap = 0,
   startYear: initialStartYear,
   endYear: initialEndYear,
+  validateRange = true,
 }: UseYearsRangeProps): UseYearsRangeProps {
   const [startYear, setStartYear] = useState<number>(initialStartYear);
   const [endYear, setEndYear] = useState<number>(initialEndYear);
@@ -36,7 +37,7 @@ export function useYearsRange({
     const lastYear = years[years.length - 1];
 
     // We have a startYear and an endYear, but they fall out of the years array boundaries. Correct that.
-    if (startYear < firstYear || endYear > lastYear) {
+    if (validateRange && (startYear < firstYear || endYear > lastYear)) {
       setStartYear(firstYear);
       setEndYear(lastYear);
       return;
@@ -53,7 +54,7 @@ export function useYearsRange({
         console.error('Years gap cannot be respected; not enough years data');
       }
     }
-  }, [endYear, setYearsRange, startYear, years, yearsGap]);
+  }, [endYear, setYearsRange, startYear, validateRange, years, yearsGap]);
 
   const yearsInRange = useMemo(
     () =>

--- a/client/src/containers/filters/years-range/index.ts
+++ b/client/src/containers/filters/years-range/index.ts
@@ -1,0 +1,2 @@
+export { default } from './component';
+export type { YearsRangeFilterProps } from './types';

--- a/client/src/containers/filters/years-range/index.ts
+++ b/client/src/containers/filters/years-range/index.ts
@@ -1,2 +1,3 @@
 export { default } from './component';
-export type { YearsRangeFilterProps } from './types';
+export { useYearsRange } from './hooks';
+export type { YearsRangeFilterProps, UseYearsRangeProps, YearsRangeParams } from './types';

--- a/client/src/containers/filters/years-range/types.d.ts
+++ b/client/src/containers/filters/years-range/types.d.ts
@@ -41,7 +41,9 @@ export type YearsRangeFilterProps = YearsRangeParams & {
 
 export type UseYearsRangeProps = Partial<YearsRangeParams> & {
   /** Array of all available years */
-  years: number[];
+  years?: number[];
+  /** Array of years in the range specified */
+  yearsInRange?: number[];
   /** Enforce N years gap between startYear and endYear */
   yearsGap?: number;
   /** Set the start year */

--- a/client/src/containers/filters/years-range/types.d.ts
+++ b/client/src/containers/filters/years-range/types.d.ts
@@ -31,8 +31,6 @@ export type YearsRangeFilterProps = YearsRangeParams & {
   showSearch?: boolean;
   /** Callback when the years range is changed */
   onChange?: ({ startYear, endYear }: YearsRangeParams) => void;
-  /** Callback when one of the years fields is searched */
-  onSearch?: SelectProps['onSearch'];
   /** Callback when the start year is searched */
   onStartYearSearch?: SelectProps['onSearch'];
   /** Callback when the end year is searched */
@@ -46,6 +44,11 @@ export type UseYearsRangeProps = Partial<YearsRangeParams> & {
   yearsInRange?: number[];
   /** Enforce N years gap between startYear and endYear */
   yearsGap?: number;
+  /**
+   * Whether to validate the set startYear/endYear fall within the years array range.
+   * Defaults to `true`
+   * */
+  validateRange?: boolean;
   /** Set the start year */
   setStartYear?: (startYear: number) => void;
   /** Set the end year */

--- a/client/src/containers/filters/years-range/types.d.ts
+++ b/client/src/containers/filters/years-range/types.d.ts
@@ -1,16 +1,24 @@
 export type YearsRangeParams = {
+  /** Start year option in the filter */
   startYear: number;
+  /** End year option in the filter */
   endYear: number;
 };
 
 export type YearsRangeFilterProps = YearsRangeParams & {
+  /** Array of available years to add to the filter */
   years: number[];
+  /** Whether the filter should enforce a 5 year gap between start and end years */
   fiveYearGap?: boolean;
+  /** Callback when the years range is changed */
   onChange?: ({ startYear, endYear }: YearsRangeParams) => void;
 };
 
 export type UseYearsRangeProps = Partial<YearsRangeParams> & {
+  /** Set the start year */
   setStartYear?: (startYear: number) => void;
+  /** Set the end year */
   setEndYear?: (endYear: number) => void;
+  /** Set the years range */
   setYearsRange?: ({ startYear, endYear }: YearsRangeParams) => void;
 };

--- a/client/src/containers/filters/years-range/types.d.ts
+++ b/client/src/containers/filters/years-range/types.d.ts
@@ -1,7 +1,16 @@
-export type YearsRangeFilterProps = {
+export type YearsRangeParams = {
   startYear: number;
   endYear: number;
+};
+
+export type YearsRangeFilterProps = YearsRangeParams & {
   years: number[];
   fiveYearGap?: boolean;
-  onChange?: ({ startYear, endYear }: { startYear: number; endYear: number }) => void;
+  onChange?: ({ startYear, endYear }: YearsRangeParams) => void;
+};
+
+export type UseYearsRangeProps = Partial<YearsRangeParams> & {
+  setStartYear?: (startYear: number) => void;
+  setEndYear?: (endYear: number) => void;
+  setYearsRange?: ({ startYear, endYear }: YearsRangeParams) => void;
 };

--- a/client/src/containers/filters/years-range/types.d.ts
+++ b/client/src/containers/filters/years-range/types.d.ts
@@ -1,3 +1,5 @@
+import { SelectProps } from 'components/select';
+
 export type YearsRangeParams = {
   /** Start year option in the filter */
   startYear: number;
@@ -6,15 +8,42 @@ export type YearsRangeParams = {
 };
 
 export type YearsRangeFilterProps = YearsRangeParams & {
+  /** Whether the data is still loading. Defaults to `false` */
+  loading?: boolean;
   /** Array of available years to add to the filter */
   years: number[];
-  /** Whether the filter should enforce a 5 year gap between start and end years */
-  fiveYearGap?: boolean;
+  /** Enforce N years gap between startYear and endYear */
+  yearsGap?: number;
+  /**
+   * Whether to show the search field for the start year select.
+   * Defaults to `false`
+   * */
+  showStartYearSearch?: boolean;
+  /**
+   * Whether to show the search field for the start year select.
+   * Defaults to `true`
+   * */
+  showEndYearSearch?: boolean;
+  /**
+   * Whether to show the search field for both start and end year select.
+   * Overrides `showStartYearSearch` and `showEndYearSearch`
+   * */
+  showSearch?: boolean;
   /** Callback when the years range is changed */
   onChange?: ({ startYear, endYear }: YearsRangeParams) => void;
+  /** Callback when one of the years fields is searched */
+  onSearch?: SelectProps['onSearch'];
+  /** Callback when the start year is searched */
+  onStartYearSearch?: SelectProps['onSearch'];
+  /** Callback when the end year is searched */
+  onEndYearSearch?: SelectProps['onSearch'];
 };
 
 export type UseYearsRangeProps = Partial<YearsRangeParams> & {
+  /** Array of all available years */
+  years: number[];
+  /** Enforce N years gap between startYear and endYear */
+  yearsGap?: number;
   /** Set the start year */
   setStartYear?: (startYear: number) => void;
   /** Set the end year */

--- a/client/src/containers/filters/years-range/types.d.ts
+++ b/client/src/containers/filters/years-range/types.d.ts
@@ -1,0 +1,7 @@
+export type YearsRangeFilterProps = {
+  startYear: number;
+  endYear: number;
+  years: number[];
+  fiveYearGap?: boolean;
+  onChange?: ({ startYear, endYear }: { startYear: number; endYear: number }) => void;
+};

--- a/client/src/containers/table/component.tsx
+++ b/client/src/containers/table/component.tsx
@@ -140,7 +140,7 @@ const Table: React.FC<TableProps> = ({
   return (
     <div
       className={cx('relative', className, {
-        'my-4': !className,
+        'my-4 shadow-sm': !className,
       })}
     >
       <KaTable {...tableProps} childComponents={childComponents} dispatch={dispatch} />

--- a/client/src/containers/table/component.tsx
+++ b/client/src/containers/table/component.tsx
@@ -23,18 +23,22 @@ const Table: React.FC<TableProps> = ({
   stickyFirstColumn: isFirstColumnSticky = true,
   ...props
 }: TableProps) => {
-  const [tableProps, changeTableProps] = useState({ ...defaultProps, ...props });
+  const [tableProps, setTableProps] = useState({ ...defaultProps, ...props });
 
   const firstColumnKey = props.columns[0]?.key;
   const stickyColumnKey = isFirstColumnSticky && firstColumnKey;
 
   const dispatch: DispatchFunc = (action) => {
-    changeTableProps((prevState) => kaReducer(prevState, action));
+    setTableProps((prevState) => kaReducer(prevState, action));
   };
 
   useEffect(() => {
     dispatch(updateData(props.data));
   }, [props.data]);
+
+  useEffect(() => {
+    setTableProps((tableProps) => ({ ...tableProps, columns: props.columns }));
+  }, [props.columns]);
 
   const childComponents = {
     tableWrapper: {

--- a/client/src/hooks/sourcing-locations/index.ts
+++ b/client/src/hooks/sourcing-locations/index.ts
@@ -14,6 +14,7 @@ type SourcingLocationsMaterialsDataResponse = UseQueryResult &
   SourcingLocationsMaterialsAPIResponse;
 
 export type SourcingLocationsParams = {
+  search?: string;
   'page[number]'?: number;
   'page[size]'?: number;
 };

--- a/client/src/pages/admin/data.tsx
+++ b/client/src/pages/admin/data.tsx
@@ -13,14 +13,12 @@ import UploadDataSourceModal from 'containers/admin/upload-data-source-modal';
 import Button from 'components/button';
 import Pagination, { PaginationProps } from 'components/pagination';
 import Search from 'components/search';
-import YearsRangeFilter from 'containers/filters/years-range';
+import YearsRangeFilter, { useYearsRange } from 'containers/filters/years-range';
 import Table, { TableProps } from 'containers/table';
 
 const AdminDataPage: React.FC = () => {
   const [searchText, setSearchText] = useDebounce('', 250);
   const [currentPage, setCurrentPage] = useState<number>(1);
-  const [startYear, setStartYear] = useState<number>();
-  const [endYear, setEndYear] = useState<number>();
 
   const {
     data: sourcingData,
@@ -31,6 +29,8 @@ const AdminDataPage: React.FC = () => {
     'page[size]': 10,
     'page[number]': currentPage,
   });
+
+  const { startYear, endYear, setYearsRange } = useYearsRange({});
 
   const {
     isOpen: isUploadDataSourceModalOpen,
@@ -66,16 +66,13 @@ const AdminDataPage: React.FC = () => {
     };
   }, [allYears, sourcingData, filteredYears]);
 
-  const handleYearsRangeChange = ({ startYear, endYear }) => {
-    setStartYear(startYear);
-    setEndYear(endYear);
-  };
-
   useEffect(() => {
     if (startYear && endYear) return;
-    setStartYear(allYears[0]);
-    setEndYear(allYears[allYears.length - 1]);
-  }, [allYears, endYear, startYear]);
+    setYearsRange({
+      startYear: allYears[0],
+      endYear: allYears[allYears.length - 1],
+    });
+  }, [allYears, endYear, setYearsRange, startYear]);
 
   /** Table Props */
 
@@ -144,7 +141,7 @@ const AdminDataPage: React.FC = () => {
               startYear={startYear}
               endYear={endYear}
               years={allYears}
-              onChange={handleYearsRangeChange}
+              onChange={setYearsRange}
             />
             {/*
             <Button theme="secondary" onClick={() => console.info('Filters: click')}>

--- a/client/src/pages/admin/data.tsx
+++ b/client/src/pages/admin/data.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect } from 'react';
+import { useState, useMemo } from 'react';
 import { DataType } from 'ka-table/enums';
 import { flatten, merge, uniq } from 'lodash';
 import { useDebounce } from '@react-hook/debounce';
@@ -30,8 +30,6 @@ const AdminDataPage: React.FC = () => {
     'page[number]': currentPage,
   });
 
-  const { startYear, endYear, setYearsRange } = useYearsRange({});
-
   const {
     isOpen: isUploadDataSourceModalOpen,
     open: openUploadDataSourceModal,
@@ -43,6 +41,8 @@ const AdminDataPage: React.FC = () => {
   const allYears = uniq(
     flatten(sourcingData.map(({ purchases }) => purchases.map(({ year }) => year))).sort(),
   );
+
+  const { startYear, endYear, setYearsRange } = useYearsRange({ years: allYears });
 
   const filteredYears = allYears.filter((year) =>
     startYear && endYear ? year >= startYear && year <= endYear : true,
@@ -65,14 +65,6 @@ const AdminDataPage: React.FC = () => {
       })),
     };
   }, [allYears, sourcingData, filteredYears]);
-
-  useEffect(() => {
-    if (startYear && endYear) return;
-    setYearsRange({
-      startYear: allYears[0],
-      endYear: allYears[allYears.length - 1],
-    });
-  }, [allYears, endYear, setYearsRange, startYear]);
 
   /** Table Props */
 

--- a/client/src/pages/admin/data.tsx
+++ b/client/src/pages/admin/data.tsx
@@ -42,11 +42,7 @@ const AdminDataPage: React.FC = () => {
     flatten(sourcingData.map(({ purchases }) => purchases.map(({ year }) => year))).sort(),
   );
 
-  const { startYear, endYear, setYearsRange } = useYearsRange({ years: allYears });
-
-  const filteredYears = allYears.filter((year) =>
-    startYear && endYear ? year >= startYear && year <= endYear : true,
-  );
+  const { startYear, endYear, yearsInRange, setYearsRange } = useYearsRange({ years: allYears });
 
   const yearsData = useMemo(() => {
     return {
@@ -55,7 +51,7 @@ const AdminDataPage: React.FC = () => {
         title: year.toString(),
         DataType: DataType.Number,
         width: 80,
-        visible: filteredYears.includes(year),
+        visible: yearsInRange.includes(year),
       })),
       data: sourcingData.map((dataRow) => ({
         ...dataRow,
@@ -64,7 +60,7 @@ const AdminDataPage: React.FC = () => {
           .reduce((a, b) => ({ ...a, ...b })),
       })),
     };
-  }, [allYears, sourcingData, filteredYears]);
+  }, [allYears, sourcingData, yearsInRange]);
 
   /** Table Props */
 

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -1042,6 +1042,13 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
+"@internationalized/date@3.0.0-alpha.1":
+  version "3.0.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@internationalized/date/-/date-3.0.0-alpha.1.tgz#987a86a98b837f275bce084ef502421bc5cdb5f7"
+  integrity sha512-fxciU4AQ/4XBYfse/mT9h1nsyNkmQkxwQtTmQVu6b4Tp2u95Y3m5BNgWgV2m3vLiiKZ82NtHJXAIGoqiK53w4g==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
+
 "@internationalized/message@^3.0.2":
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/@internationalized/message/-/message-3.0.2.tgz#c3db2b6b7f75af815819f77da11f8424381416e3"
@@ -1581,6 +1588,19 @@
     "@react-aria/utils" "^3.8.2"
     "@react-types/shared" "^3.8.0"
 
+"@react-aria/i18n@^3.3.3":
+  version "3.3.4"
+  resolved "https://registry.yarnpkg.com/@react-aria/i18n/-/i18n-3.3.4.tgz#172b8bcff0273410e67af31f7d84e49dd3ada463"
+  integrity sha512-1DV3I82UfL2dT8WBI/88TwtokO80B7ISSyuz6rO/6n7q76A/nC2AtVINbrGYrcKsCcxCEoEMxW5RVJ39fcLijA==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
+    "@internationalized/date" "3.0.0-alpha.1"
+    "@internationalized/message" "^3.0.2"
+    "@internationalized/number" "^3.0.2"
+    "@react-aria/ssr" "^3.0.3"
+    "@react-aria/utils" "^3.10.0"
+    "@react-types/shared" "^3.10.0"
+
 "@react-aria/interactions@^3.5.1", "@react-aria/interactions@^3.6.0":
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/@react-aria/interactions/-/interactions-3.6.0.tgz#63c16e6179e8ae38221e26256d9a7639d7f9b24e"
@@ -1589,6 +1609,25 @@
     "@babel/runtime" "^7.6.2"
     "@react-aria/utils" "^3.9.0"
     "@react-types/shared" "^3.9.0"
+
+"@react-aria/interactions@^3.7.0":
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/@react-aria/interactions/-/interactions-3.7.0.tgz#eb19c1068b557a6b6df1e1c4abef07de719e9f25"
+  integrity sha512-Xomchjb9bqvh3ocil+QCEYFSxsTy8PHEz43mNP6z2yuu3UqTpl2FsWfyKgF/Yy0WKVkyV2dO2uz758KJTCLZhw==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
+    "@react-aria/utils" "^3.10.0"
+    "@react-types/shared" "^3.10.0"
+
+"@react-aria/label@^3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@react-aria/label/-/label-3.2.1.tgz#e6562259e6b17e3856c4c3e0060903cf705d094b"
+  integrity sha512-QZ5/dpJKRjB1JtFZfOVd5GUiCpA2yMgmNA6ky6jT5XNAo7H14QqGRFUGDTLAQYGd+Bc3s+NayOT3NKUYur/3Xw==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
+    "@react-aria/utils" "^3.10.0"
+    "@react-types/label" "^3.5.0"
+    "@react-types/shared" "^3.10.0"
 
 "@react-aria/overlays@^3.6.3":
   version "3.7.2"
@@ -1605,12 +1644,50 @@
     "@react-types/overlays" "^3.5.1"
     dom-helpers "^3.3.1"
 
+"@react-aria/searchfield@^3.2.2":
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/@react-aria/searchfield/-/searchfield-3.2.2.tgz#8bbd408bf5ba6d96f0adafbb633f7bf1bb3b1386"
+  integrity sha512-efW0hGIDwpvb2eBR1XkKBk1CTYbCP1/afjQmjYya+BFHT3r/ukUZL1P4mOUe9kITQByY50qRb1/qjMGcs9Pkxg==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
+    "@react-aria/i18n" "^3.3.3"
+    "@react-aria/interactions" "^3.7.0"
+    "@react-aria/textfield" "^3.5.0"
+    "@react-aria/utils" "^3.11.0"
+    "@react-stately/searchfield" "^3.1.3"
+    "@react-types/button" "^3.4.1"
+    "@react-types/searchfield" "^3.1.2"
+    "@react-types/shared" "^3.10.1"
+
 "@react-aria/ssr@^3.0.3", "@react-aria/ssr@^3.1.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@react-aria/ssr/-/ssr-3.1.0.tgz#b7163e6224725c30121932a8d1422ef91d1fab22"
   integrity sha512-RxqQKmE8sO7TGdrcSlHTcVzMP450hqowtBSd2bBS9oPlcokVkaGq28c3Rwa8ty5ctw4EBCjXqjP7xdcKMGDzug==
   dependencies:
     "@babel/runtime" "^7.6.2"
+
+"@react-aria/textfield@^3.5.0":
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/@react-aria/textfield/-/textfield-3.5.0.tgz#d711378e351b1374e6f11eda2896e6e481f0b0ba"
+  integrity sha512-EUsr5YCavNbp/nUoBCfiLiir0I0/NiZ2i/RPtOzzsGHMHw2xOME9PiRHYPrj7vOQQEfNgN1btr1psvLML4dk5w==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
+    "@react-aria/focus" "^3.5.0"
+    "@react-aria/label" "^3.2.1"
+    "@react-aria/utils" "^3.10.0"
+    "@react-types/shared" "^3.10.0"
+    "@react-types/textfield" "^3.3.0"
+
+"@react-aria/utils@^3.10.0", "@react-aria/utils@^3.11.0":
+  version "3.11.0"
+  resolved "https://registry.yarnpkg.com/@react-aria/utils/-/utils-3.11.0.tgz#215ea23a5435672a822cd713bdb8217972c5c80b"
+  integrity sha512-4yFA8E9xqDCUlolYSsoyp/qxrkiQrnEqx1BQOrKDuicpW7MBJ39pJC23YFMpyK2a6xEptc6xJEeIEFJXp57jJw==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
+    "@react-aria/ssr" "^3.1.0"
+    "@react-stately/utils" "^3.3.0"
+    "@react-types/shared" "^3.10.1"
+    clsx "^1.1.1"
 
 "@react-aria/utils@^3.8.2", "@react-aria/utils@^3.9.0":
   version "3.9.0"
@@ -1740,6 +1817,16 @@
     "@react-stately/utils" "^3.2.2"
     "@react-types/overlays" "^3.5.1"
 
+"@react-stately/searchfield@^3.1.3":
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/@react-stately/searchfield/-/searchfield-3.1.3.tgz#c2fe18be4ca8478c3bb3fdebc7e9e4a14ebfae07"
+  integrity sha512-IIsgZ87RgdSTLcXB3U+EdgbtAXlpw50G9fDYhwpjIaiZQ60RsaEz0mo+s1+oapXGudCFWyQYNR+nqF7jzNKxwg==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
+    "@react-stately/utils" "^3.2.2"
+    "@react-types/searchfield" "^3.1.2"
+    "@react-types/shared" "^3.8.0"
+
 "@react-stately/toggle@^3.2.3":
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/@react-stately/toggle/-/toggle-3.2.3.tgz#a4de6edc16982990492c6c557e5194f46dacc809"
@@ -1754,6 +1841,13 @@
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/@react-stately/utils/-/utils-3.2.2.tgz#468eafa60740c6b0b847a368215dfaa55e87f505"
   integrity sha512-7NCpRMAexDdgVqbrB9uDrkDpM4Tdw5BU6Gu6IKUXmKsoDYziE6mAjaGkCZBitsrln1Cezc6euI5YPa1JqxgpJg==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
+
+"@react-stately/utils@^3.3.0":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/@react-stately/utils/-/utils-3.3.0.tgz#99866c5788539268a06035acd5925b25bb4cedde"
+  integrity sha512-f//Y8q0+FFcS04xvCNvbba7WWRLHzj2AegLgdgwTxsnk9Gb+AyuasdRrRY7bGQhdHuEJ7OIiQZ9EQWndDbrTcg==
   dependencies:
     "@babel/runtime" "^7.6.2"
 
@@ -1779,6 +1873,13 @@
     "@react-types/overlays" "^3.5.1"
     "@react-types/shared" "^3.8.0"
 
+"@react-types/label@^3.5.0":
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/@react-types/label/-/label-3.5.0.tgz#c7093871f42c62e1b5523f61a0856a2f58d4cf2a"
+  integrity sha512-a9lpQUyV4XwsZv0gV1jPjPWicSSa+DRliuXLTwORirxNLF0kMk89DLYf0a9CZhiEniJYqoqR3laJDvLAFW1x/Q==
+  dependencies:
+    "@react-types/shared" "^3.9.0"
+
 "@react-types/overlays@^3.5.1":
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/@react-types/overlays/-/overlays-3.5.1.tgz#35350dfca639d04a8fbd973de59b141450df1b46"
@@ -1786,10 +1887,29 @@
   dependencies:
     "@react-types/shared" "^3.8.0"
 
+"@react-types/searchfield@^3.1.2":
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/@react-types/searchfield/-/searchfield-3.1.2.tgz#184770b67f1fad57a6024ad00b7e42cf934ed54b"
+  integrity sha512-lIyXEzoS/XXmddAvgZk/a8/8qAkVt5XbUrX7CrpZOiwqIPsVDI2bDYiv7N9GdS0pMeSyu1X9mXCnJfvzu/Dkow==
+  dependencies:
+    "@react-types/textfield" "^3.2.3"
+
+"@react-types/shared@^3.10.0", "@react-types/shared@^3.10.1":
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/@react-types/shared/-/shared-3.10.1.tgz#16cd3038361dee63f351fa4d0fd25d90480a149b"
+  integrity sha512-U3dLJtstvOiZ8XLrWdNv9WXuruoDyfIfSXguTs9N0naDdO+M0MIbt/1Hg7Toe43ueAe56GM14IFL+S0/jhv8ow==
+
 "@react-types/shared@^3.8.0", "@react-types/shared@^3.9.0":
   version "3.9.0"
   resolved "https://registry.yarnpkg.com/@react-types/shared/-/shared-3.9.0.tgz#d834f3e6e2c992089192f3c83fb7963e3a6f5207"
   integrity sha512-YYksINfR6q92P10AhPEGo47Hd7oz1hrnZ6Vx8Gsrq62IbqDdv1XOTzPBaj17Z1ymNY2pitLUSEXsLmozt4wxxQ==
+
+"@react-types/textfield@^3.2.3", "@react-types/textfield@^3.3.0":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/@react-types/textfield/-/textfield-3.3.0.tgz#07a447fda327df4843e7d36cbd00f87f8a73e725"
+  integrity sha512-lOf0tx3c3dVaomH/uvKpOKFVTXQ232kLnMhOJTtj97JDX7fTr3SNhDUV0G8Zf4M0vr+l+xkTrJkywYE23rzliw==
+  dependencies:
+    "@react-types/shared" "^3.9.0"
 
 "@reduxjs/toolkit@^1.5.1":
   version "1.6.2"

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -6750,6 +6750,11 @@ lodash.clonedeep@4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
   integrity sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=
 
+lodash.debounce@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
+  integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
+
 lodash.flattendeep@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
@@ -8066,6 +8071,13 @@ quickselect@^2.0.0:
   resolved "https://registry.yarnpkg.com/quickselect/-/quickselect-2.0.0.tgz#f19680a486a5eefb581303e023e98faaf25dd018"
   integrity sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw==
 
+raf@^3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.1.tgz#0742e99a4a6552f445d73e3ee0328af0ff1ede39"
+  integrity sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==
+  dependencies:
+    performance-now "^2.1.0"
+
 ramda@~0.27.1:
   version "0.27.1"
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.27.1.tgz#66fc2df3ef873874ffc2da6aa8984658abacf5c9"
@@ -8633,6 +8645,14 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
   dependencies:
     hash-base "^3.0.0"
     inherits "^2.0.1"
+
+rooks@^5.10.0:
+  version "5.10.0"
+  resolved "https://registry.yarnpkg.com/rooks/-/rooks-5.10.0.tgz#af39b75709b9221da454bb9607b58b87dad9413e"
+  integrity sha512-zKO0dOn/GJYn2vdo/vgy9fbQq4xebvJYntaxtJnZRXODhco/nLcNOWnhtwSPwx9X1vFPzdnLypoVrt9MZ+Cmvg==
+  dependencies:
+    lodash.debounce "^4.0.8"
+    raf "^3.4.1"
 
 run-parallel@^1.1.9:
   version "1.2.0"


### PR DESCRIPTION
## Description

This PR adds searching and years filtering to the admin/data page. In addition, it simplifies using the range filter throughout the application, including in the Analysis view.  

**In this PR:**
- New `Search` (input) component  
  _Styled to match the app_  
- New `YearsRangeFilter` component  
    _To promote reusability of the filter button throughout the app._   
    - `useYearsRange` hook
      _Helper hook specific to the `YearsRangeFilter` component, to simplify the usage of the filter and centralise the code specific to years range filtering, as well as validating initialisations_   
- New `NoResults` component  
    _Primitive generic component currently in use in the admin views, to display when there are no results stemming from searching/filtering data_
- `Table` component changes:  
    - Small styling tweaks to better match the 
- `Select` component changes:  
    - Fixed an issue where the cursor would disappear while hovering a disabled list item
- `Admin/data` tab chances:  
    - Added search through the API endpoint  
    - Added frontend years filtering  
- `Analysis` tab changes  
    - `AnalysisFilters` `Years` filter now makes use of the `YearsRangeFilter` component  
        _Only for years ranges_  
    - Clicking outside the filter dropdown now closes it  
        _Matching other dropdowns we have in the app_

## JIRA  
[LANDGRIF-506 (Admin/Data table should be able to be searched by text)](https://vizzuality.atlassian.net/browse/LANDGRIF-506)  
[LANDGRIF-512 (Add years filters to Admin/Data)](https://vizzuality.atlassian.net/browse/LANDGRIF-512)

## Screenshots
<img width="1680" alt="Screenshot 2022-02-14 at 15 53 51" src="https://user-images.githubusercontent.com/6273795/153898841-a7638310-d0f3-42b1-b06e-ab63a4135f6a.png">
<img width="1680" alt="Screenshot 2022-02-14 at 15 54 18" src="https://user-images.githubusercontent.com/6273795/153898859-2b3800d7-d12d-46b0-885b-1f6283f0ad23.png">
