### PR TITLE
Analysis view bugfixes  

### DIFF
--- a/client/src/containers/analysis-visualization/analysis-filters/more-filters/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-filters/more-filters/component.tsx
@@ -1,4 +1,5 @@
-import React, { Fragment, useCallback, useEffect, useState, useMemo } from 'react';
+import React, { Fragment, useCallback, useEffect, useState, useMemo, useRef } from 'react';
+import { useOutsideClick } from 'rooks';
 import { Popover, Transition } from '@headlessui/react';
 import { FilterIcon } from '@heroicons/react/solid';
 
@@ -18,6 +19,8 @@ const INITIAL_FILTERS: Partial<AnalysisState['filters']> = {
 };
 
 const MoreFilters: React.FC = () => {
+  const filtersWrapperRef = useRef();
+
   const { filters } = useAppSelector(analysis);
   const dispatch = useAppDispatch();
 
@@ -63,8 +66,12 @@ const MoreFilters: React.FC = () => {
     setCounter(total);
   }, [selectedFilters]);
 
+  useOutsideClick(filtersWrapperRef, () => {
+    setOpen(false);
+  });
+
   return (
-    <Popover className="relative">
+    <Popover className="relative" >
       <Button theme="secondary" onClick={() => setOpen(!open)}>
         <span className="block h-5 truncate">
           <FilterIcon className="w-5 h-5 text-gray-900" aria-hidden="true" />
@@ -84,7 +91,10 @@ const MoreFilters: React.FC = () => {
         leaveTo="opacity-0"
       >
         <Popover.Panel static className="absolute right-0 z-10 mt-1 w-80 z-20">
-          <div className="rounded-lg shadow-lg ring-1 ring-black ring-opacity-5">
+          <div
+            ref={filtersWrapperRef}
+            className="rounded-lg shadow-lg ring-1 ring-black ring-opacity-5"
+          >
             <div className="relative p-4 bg-white rounded-lg">
               <div className="flex justify-between mb-4">
                 <div>Filter by</div>

--- a/client/src/containers/analysis-visualization/analysis-filters/more-filters/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-filters/more-filters/component.tsx
@@ -83,7 +83,7 @@ const MoreFilters: React.FC = () => {
         leaveFrom="opacity-100"
         leaveTo="opacity-0"
       >
-        <Popover.Panel static className="absolute right-0 z-10 mt-1 w-80">
+        <Popover.Panel static className="absolute right-0 z-10 mt-1 w-80 z-20">
           <div className="rounded-lg shadow-lg ring-1 ring-black ring-opacity-5">
             <div className="relative p-4 bg-white rounded-lg">
               <div className="flex justify-between mb-4">

--- a/client/src/containers/analysis-visualization/analysis-filters/more-filters/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-filters/more-filters/component.tsx
@@ -71,7 +71,7 @@ const MoreFilters: React.FC = () => {
   });
 
   return (
-    <Popover className="relative" >
+    <Popover className="relative">
       <Button theme="secondary" onClick={() => setOpen(!open)}>
         <span className="block h-5 truncate">
           <FilterIcon className="w-5 h-5 text-gray-900" aria-hidden="true" />
@@ -90,7 +90,7 @@ const MoreFilters: React.FC = () => {
         leaveFrom="opacity-100"
         leaveTo="opacity-0"
       >
-        <Popover.Panel static className="absolute right-0 z-10 mt-1 w-80 z-20">
+        <Popover.Panel static className="absolute right-0 mt-1 w-80 z-20">
           <div
             ref={filtersWrapperRef}
             className="rounded-lg shadow-lg ring-1 ring-black ring-opacity-5"

--- a/client/src/containers/analysis-visualization/component.tsx
+++ b/client/src/containers/analysis-visualization/component.tsx
@@ -16,6 +16,7 @@ const AnalysisVisualization: React.FC = () => {
     <section
       className={classNames('relative flex flex-col flex-1 md:h-full lg:order-last', {
         'overflow-hidden': visualizationMode === 'map',
+        'overflow-x-hidden': visualizationMode !== 'map',
         'backdrop-blur-3xl blur-sm pointer-events-none': !isSubContentCollapsed,
       })}
     >


### PR DESCRIPTION
**In this PR:**

Three bug fixes:  
  - Analysis tables overflowing horizontally (video 1)  
  - Analysis filters popover showing under a table's sticky column (screenshot 1)  
  - Analysis filter popover not closing when the user clicks outside (same as the one for screenshot 1) 

## JIRA  

[LANDGRIF-525](https://vizzuality.atlassian.net/browse/LANDGRIF-525)

## Screenshots  

**Screenshot 1**  
<img width="687" alt="Screenshot 2022-02-17 at 15 56 26" src="https://user-images.githubusercontent.com/6273795/154519691-a5474c8d-bab1-4011-a2be-e6321840bf8d.png">


## Videos  

**Video 1** 

https://user-images.githubusercontent.com/6273795/154519429-9ab9deb4-a35d-4381-8424-ab1259c1cea3.mp4


