### PR TITLE
Add `withSourcingLocations` query param to Analysis/Impact filters

### DIFF
--- a/client/src/components/tree-select/component.tsx
+++ b/client/src/components/tree-select/component.tsx
@@ -62,7 +62,7 @@ const TreeSelect: React.FC<TreeSelectProps> = ({
   );
 
   const customSwitcherIcon = useCallback(({ isLeaf, expanded }) => {
-    if (isLeaf) return null;
+    if (isLeaf) return <span className="block w-4" />;
     if (expanded) return <ChevronDownIcon className="h-4 w-4" />;
     return <ChevronRightIcon className="h-4 w-4" />;
   }, []);

--- a/client/src/components/tree-select/component.tsx
+++ b/client/src/components/tree-select/component.tsx
@@ -47,30 +47,17 @@ const TreeSelect: React.FC<TreeSelectProps> = ({
   const renderTreeNodes = useMemo(
     () =>
       (data, counter = 0) =>
-        data.map((item) => {
-          if (item.children) {
-            return (
-              <TreeNode
-                key={item.value}
-                title={item.label}
-                className={classNames(TREE_NODE_CLASSNAMES, `pl-${4 * counter}`, {
-                  'bg-green-50 text-green-700 font-semibold': selectedKeys.includes(item.value),
-                })}
-              >
-                {renderTreeNodes(item.children, counter + 1)}
-              </TreeNode>
-            );
-          }
-          return (
-            <TreeNode
-              key={item.value}
-              title={item.label}
-              className={classNames(TREE_NODE_CLASSNAMES, `pl-${4 * counter}`, {
-                'bg-green-50 text-green-700 font-semibold': selectedKeys.includes(item.value),
-              })}
-            />
-          );
-        }),
+        data.map((item) => (
+          <TreeNode
+            key={item.value}
+            title={item.label}
+            className={classNames(TREE_NODE_CLASSNAMES, `pl-${4 * counter}`, {
+              'bg-green-50 text-green-700 font-semibold': selectedKeys.includes(item.value),
+            })}
+          >
+            {item.children && renderTreeNodes(item.children, counter + 1)}
+          </TreeNode>
+        )),
     [selectedKeys],
   );
 

--- a/client/src/containers/analysis-visualization/analysis-filters/materials/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-filters/materials/component.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react';
 import { sortBy } from 'lodash';
 
-import { useMaterialsTrees } from 'hooks/materials';
+import { useMaterialsTrees, MaterialsTreesParams } from 'hooks/materials';
 
 import TreeSelect from 'components/tree-select';
 
@@ -10,11 +10,21 @@ import type { TreeSelectProps } from 'components/tree-select/types';
 type MaterialsFilterProps = {
   current: TreeSelectProps['current'];
   multiple?: TreeSelectProps['multiple'];
+  /** Tree depth. Defaults to `1` */
+  depth?: MaterialsTreesParams['depth'];
+  /** Only materials with sourcing locations. */
+  withSourcingLocations?: MaterialsTreesParams['withSourcingLocations'];
   onChange?: TreeSelectProps['onChange'];
 };
 
-const MaterialsFilter: React.FC<MaterialsFilterProps> = ({ multiple, current, onChange }) => {
-  const { data, isFetching } = useMaterialsTrees({ depth: 1 });
+const MaterialsFilter: React.FC<MaterialsFilterProps> = ({
+  multiple,
+  current,
+  depth = 1,
+  withSourcingLocations, // Do not a default; backend will override depth if this is set at all
+  onChange,
+}) => {
+  const { data, isFetching } = useMaterialsTrees({ depth, withSourcingLocations });
 
   const treeOptions: TreeSelectProps['options'] = useMemo(
     () =>

--- a/client/src/containers/analysis-visualization/analysis-filters/more-filters/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-filters/more-filters/component.tsx
@@ -106,6 +106,7 @@ const MoreFilters: React.FC = () => {
                   <div className="mb-1">Origins</div>
                   <OriginRegions
                     multiple
+                    withSourcingLocations
                     current={filters.origins}
                     onChange={(values) => handleChangeFilter('origins', values)}
                   />

--- a/client/src/containers/analysis-visualization/analysis-filters/more-filters/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-filters/more-filters/component.tsx
@@ -114,6 +114,7 @@ const MoreFilters: React.FC = () => {
                   <div className="mb-1">Suppliers</div>
                   <Suppliers
                     multiple
+                    withSourcingLocations
                     current={filters.suppliers}
                     onChange={(values) => handleChangeFilter('suppliers', values)}
                   />

--- a/client/src/containers/analysis-visualization/analysis-filters/more-filters/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-filters/more-filters/component.tsx
@@ -97,6 +97,7 @@ const MoreFilters: React.FC = () => {
                   <div className="mb-1">Material</div>
                   <Materials
                     multiple
+                    withSourcingLocations
                     current={filters.materials}
                     onChange={(values) => handleChangeFilter('materials', values)}
                   />

--- a/client/src/containers/analysis-visualization/analysis-filters/origin-regions/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-filters/origin-regions/component.tsx
@@ -2,21 +2,27 @@ import { useMemo } from 'react';
 import TreeSelect from 'components/tree-select';
 import { sortBy } from 'lodash';
 
-import { useAdminRegionsTrees } from 'hooks/admin-regions';
+import { useAdminRegionsTrees, AdminRegionsTreesParams } from 'hooks/admin-regions';
 import type { TreeSelectProps } from 'components/tree-select/types';
 
 type OriginRegionsFilterProps = {
   current: TreeSelectProps['current'];
   multiple?: TreeSelectProps['multiple'];
+  /** Tree depth. Defaults to `1` */
+  depth?: AdminRegionsTreesParams['depth'];
+  /** Only regions with sourcing locations. */
+  withSourcingLocations?: AdminRegionsTreesParams['withSourcingLocations'];
   onChange?: TreeSelectProps['onChange'];
 };
 
 const OriginRegionsFilter: React.FC<OriginRegionsFilterProps> = ({
   multiple,
   current,
+  depth = 1,
+  withSourcingLocations, // Do not a default; backend will override depth if this is set at all
   onChange,
 }) => {
-  const { data, isFetching } = useAdminRegionsTrees({ depth: 1 });
+  const { data, isFetching } = useAdminRegionsTrees({ depth, withSourcingLocations });
 
   const treeOptions: TreeSelectProps['options'] = useMemo(
     () =>

--- a/client/src/containers/analysis-visualization/analysis-filters/suppliers/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-filters/suppliers/component.tsx
@@ -2,18 +2,28 @@ import { useMemo } from 'react';
 import TreeSelect from 'components/tree-select';
 import { sortBy } from 'lodash';
 
-import { useSuppliersTrees } from 'hooks/suppliers';
+import { useSuppliersTrees, SuppliersTreesParams } from 'hooks/suppliers';
 
 import type { TreeSelectProps } from 'components/tree-select/types';
 
 type SuppliersFilterProps = {
   current: TreeSelectProps['current'];
   multiple?: TreeSelectProps['multiple'];
+  /** Tree depth. Defaults to `1` */
+  depth?: SuppliersTreesParams['depth'];
+  /** Only suppliers with sourcing locations. */
+  withSourcingLocations?: SuppliersTreesParams['withSourcingLocations'];
   onChange?: TreeSelectProps['onChange'];
 };
 
-const SuppliersFilter: React.FC<SuppliersFilterProps> = ({ multiple, current, onChange }) => {
-  const { data, isFetching } = useSuppliersTrees({ depth: 1 });
+const SuppliersFilter: React.FC<SuppliersFilterProps> = ({
+  multiple,
+  current,
+  depth = 1,
+  withSourcingLocations, // Do not a default; backend will override depth if this is set at all
+  onChange,
+}) => {
+  const { data, isFetching } = useSuppliersTrees({ depth, withSourcingLocations });
 
   const treeOptions: TreeSelectProps['options'] = useMemo(
     () =>

--- a/client/src/hooks/admin-regions/index.ts
+++ b/client/src/hooks/admin-regions/index.ts
@@ -11,8 +11,10 @@ const DEFAULT_QUERY_OPTIONS: UseQueryOptions = {
 };
 
 type ResponseData = UseQueryResult<OriginRegion[]>;
-type TreeParams = {
+
+export type AdminRegionsTreesParams = {
   depth?: number;
+  withSourcingLocations?: boolean;
 };
 
 export function useAdminRegions(): ResponseData {
@@ -47,7 +49,7 @@ export function useAdminRegions(): ResponseData {
   );
 }
 
-export function useAdminRegionsTrees(params: TreeParams): ResponseData {
+export function useAdminRegionsTrees(params: AdminRegionsTreesParams): ResponseData {
   // const [session] = useSession();
 
   const query = useQuery(

--- a/client/src/hooks/materials/index.ts
+++ b/client/src/hooks/materials/index.ts
@@ -11,8 +11,10 @@ const DEFAULT_QUERY_OPTIONS: UseQueryOptions = {
 };
 
 type ResponseData = UseQueryResult<Material[]>;
-type TreeParams = {
+
+export type MaterialsTreesParams = {
   depth?: number;
+  withSourcingLocations?: boolean;
 };
 
 export function useMaterials(): ResponseData {
@@ -47,11 +49,11 @@ export function useMaterials(): ResponseData {
   );
 }
 
-export function useMaterialsTrees(params: TreeParams): ResponseData {
+export function useMaterialsTrees(params: MaterialsTreesParams): ResponseData {
   // const [session] = useSession();
 
   const query = useQuery(
-    ['materials-trees'],
+    ['materials-trees', params],
     async () =>
       apiService
         .request({

--- a/client/src/hooks/suppliers/index.ts
+++ b/client/src/hooks/suppliers/index.ts
@@ -11,8 +11,10 @@ const DEFAULT_QUERY_OPTIONS: UseQueryOptions = {
 };
 
 type ResponseData = UseQueryResult<Supplier[]>;
-type TreeParams = {
+
+export type SuppliersTreesParams = {
   depth?: number;
+  withSourcingLocations?: boolean;
 };
 
 export function useSuppliers(): ResponseData {
@@ -47,7 +49,7 @@ export function useSuppliers(): ResponseData {
   );
 }
 
-export function useSuppliersTrees(params: TreeParams): ResponseData {
+export function useSuppliersTrees(params: SuppliersTreesParams): ResponseData {
   // const [session] = useSession();
 
   const query = useQuery(


### PR DESCRIPTION
## Description  

**In this PR:**
Added `withSourcingLocations` query param to Analysis/Impact filters, namely `Material`, `Origins` and  `Suppliers` filters in the `AdditionalFilters` component.  

**Notes:**  
1. The reason I opted for adding `depth` and `withSourcingLocations` as `props`, is because even though these filters are specific to the Analysis view, they are not specific to _Impact_. For instance, the `Materials` filter is also used when the user is on _Material production_ and not _Impact_.

    I feel like adding these `props` to one filter and not the others could become confusing in the future, so I added the same ones to all three. 

2. I made some alignment tweaks to the items in the `TreeSelect` component. Reason being, since with these filters some top level items may not have children, the expanding arrow would not appear, and it was confusing to see which items/children were under which top level item. In order to fix that issue I added the equivalent space of the arrow to preserve the original spacing of the component.

## JIRA  
[LANDGRIF-520 (Add withSourcingLocations query param for Impact filters)](https://vizzuality.atlassian.net/browse/LANDGRIF-520)

## Screenshots

**Materials**
<img width="637" alt="Screenshot 2022-02-18 at 15 30 02" src="https://user-images.githubusercontent.com/6273795/154712463-ca871346-362b-4ac2-81fc-0c60cdfbd4c4.png">

**Origins** 
<img width="738" alt="Screenshot 2022-02-18 at 15 30 10" src="https://user-images.githubusercontent.com/6273795/154712501-a182ca97-342d-47c8-b911-25d604b4c676.png">

**Suppliers** 
<img width="652" alt="Screenshot 2022-02-18 at 15 30 14" src="https://user-images.githubusercontent.com/6273795/154712535-f8288f54-d5cb-44ce-8221-1650ddd3e568.png">

