### PR TITLE
Revising loading spinners when fetching new data for tables

### DIFF
--- a/client/src/components/pagination/component.tsx
+++ b/client/src/components/pagination/component.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import classNames from 'classnames';
 import {
   ChevronDoubleLeftIcon,
@@ -12,6 +12,7 @@ import { PaginationProps } from './types';
 
 const Table: React.FC<PaginationProps> = ({
   className,
+  isLoading = false,
   numItems,
   currentPage,
   totalPages,
@@ -21,19 +22,32 @@ const Table: React.FC<PaginationProps> = ({
     // noOp
   },
 }: PaginationProps) => {
+  const [pagination, setPagination] = useState({
+    numItems: undefined,
+    currentPage: undefined,
+    totalPages: undefined,
+    totalItems: undefined,
+  });
+
+  useEffect(() => {
+    // Do not update pagination if data is loading.
+    if (isLoading) return;
+    setPagination({ numItems, currentPage, totalPages, totalItems });
+  }, [currentPage, isLoading, numItems, totalItems, totalPages]);
+
   const calcPagingRange = useCallback(() => {
     // https://codereview.stackexchange.com/a/183472
     const min = 1;
     let length = numNumberButtons;
 
-    if (length > totalPages) length = totalPages;
+    if (length > pagination.totalPages) length = pagination.totalPages;
 
-    let start = currentPage - Math.floor(length / 2);
+    let start = pagination.currentPage - Math.floor(length / 2);
     start = Math.max(start, min);
-    start = Math.min(start, min + totalPages - length);
+    start = Math.min(start, min + pagination.totalPages - length);
 
     return Array.from({ length: length }, (el, i) => start + i);
-  }, [currentPage, numNumberButtons, totalPages]);
+  }, [numNumberButtons, pagination]);
 
   const rangeButtons = calcPagingRange();
 
@@ -42,8 +56,8 @@ const Table: React.FC<PaginationProps> = ({
   };
 
   const handlePreviousClick = () => {
-    if (currentPage <= 1) return;
-    onPageClick(currentPage - 1);
+    if (pagination.currentPage <= 1) return;
+    onPageClick(pagination.currentPage - 1);
   };
 
   const handleRangeButtonClick = (pageNumber) => {
@@ -51,13 +65,16 @@ const Table: React.FC<PaginationProps> = ({
   };
 
   const handleNextClick = () => {
-    if (currentPage >= totalPages) return;
+    if (pagination.currentPage >= pagination.totalPages) return;
     onPageClick(currentPage + 1);
   };
 
   const handleLastClick = () => {
-    onPageClick(totalPages);
+    onPageClick(pagination.totalPages);
   };
+
+  // We don't have enough values to display the pagination; show nothing.
+  if (Object.values(pagination).some((val) => val === undefined)) return null;
 
   return (
     <div
@@ -71,16 +88,16 @@ const Table: React.FC<PaginationProps> = ({
       </div>
 
       <div className="flex items-center">
-        <Button disabled={currentPage <= 1} onClick={handleFirstClick}>
+        <Button disabled={pagination.currentPage <= 1} onClick={handleFirstClick}>
           <ChevronDoubleLeftIcon className="w-4 h-4" />
         </Button>
-        <Button disabled={currentPage <= 1} onClick={handlePreviousClick}>
+        <Button disabled={pagination.currentPage <= 1} onClick={handlePreviousClick}>
           <ChevronLeftIcon className="w-5 h-5" />
         </Button>
         {rangeButtons.map((buttonNumber) => (
           <Button
             key={buttonNumber}
-            active={buttonNumber === currentPage}
+            active={buttonNumber === pagination.currentPage}
             onClick={() => {
               handleRangeButtonClick(buttonNumber);
             }}
@@ -88,10 +105,16 @@ const Table: React.FC<PaginationProps> = ({
             {buttonNumber}
           </Button>
         ))}
-        <Button disabled={currentPage >= totalPages} onClick={handleNextClick}>
+        <Button
+          disabled={pagination.currentPage >= pagination.totalPages}
+          onClick={handleNextClick}
+        >
           <ChevronRightIcon className="w-5 h-5" />
         </Button>
-        <Button disabled={currentPage >= totalPages} onClick={handleLastClick}>
+        <Button
+          disabled={pagination.currentPage >= pagination.totalPages}
+          onClick={handleLastClick}
+        >
           <ChevronDoubleRightIcon className="w-4 h-4" />
         </Button>
       </div>

--- a/client/src/components/pagination/types.d.ts
+++ b/client/src/components/pagination/types.d.ts
@@ -1,6 +1,11 @@
 export type PaginationProps = {
   /** Classnames to be applied */
   className?: string;
+  /**
+   * Whether data is currently being loaded. Will cause pagination to freeze its current state.
+   * Defaults to `false`.
+   * */
+  isLoading?: boolean;
   /** Number of items being displayed */
   numItems: number;
   /** Current page number */

--- a/client/src/containers/table/component.tsx
+++ b/client/src/containers/table/component.tsx
@@ -177,6 +177,12 @@ const Table: React.FC<TableProps> = ({
       }),
       ...props.childComponents?.dataRow,
     },
+    noDataRow: {
+      elementAttributes: () => ({
+        className: DEFAULT_CLASSNAMES.noDataRow,
+      }),
+      ...props.childComponents?.noDataRow,
+    },
     cell: {
       elementAttributes: (props) => {
         const isFirstColumn = props.column.key === firstColumnKey;

--- a/client/src/containers/table/constants.ts
+++ b/client/src/containers/table/constants.ts
@@ -8,6 +8,7 @@ export const DEFAULT_CLASSNAMES = {
   headCell: 'h-auto py-3 w-48',
   headCellContent: 'font-bold uppercase whitespace-nowrap text-xs leading-4 text-gray-600',
   dataRow: 'border-0 group even:bg-gray-50 odd:bg-white',
+  noDataRow: 'h-44 md:h-96',
   cell: 'h-auto py-3 group-even:bg-gray-50 group-odd:bg-white w-90',
   cellText: 'text-gray-900 leading-5 break-words',
   groupCell: 'z-10 sticky left-0 flex',

--- a/client/src/containers/table/index.ts
+++ b/client/src/containers/table/index.ts
@@ -1,3 +1,9 @@
+import dynamic from 'next/dynamic';
+
 export { default } from './component';
 export type { TableProps, ApiSortingType } from './types';
 export { DataType, SortingMode, ApiSortingDirection } from './enums';
+
+export const TableNoSSR = dynamic(() => import('./component'), {
+  ssr: false,
+});

--- a/client/src/containers/table/types.d.ts
+++ b/client/src/containers/table/types.d.ts
@@ -3,21 +3,35 @@ import { ITableProps, ICellProps, ChildComponents } from 'ka-table';
 import { SortingMode } from './enums';
 
 export type ColumnProps = ICellProps & {
+  /** Custom cell types */
   type: 'line-chart';
+  /** Whether the column is sortable */
   isSortable: boolean;
 };
 
 export interface TableProps extends ITableProps {
+  /** classNames to apply to the table */
   className?: string;
+  /**
+   * Whether data is currently being loaded. Will cause pagination to freeze its current state.
+   * Defaults to `false`.
+   * */
   isLoading?: boolean;
+  /** Whether to make the first column sticky. Defaults to `true` */
   stickyFirstColumn?: boolean;
+  /** ka-table childComponents */
   childComponents?: ChildComponents;
+  /** ka-table sorting modes + a custom one: `Api` */
   sortingMode?: SortingMode;
+  /** Default sorting time */
   defaultSorting?: ApiSortingType;
+  /** Callback when sorting changes. Applicable to `Api` sorting only. */
   onSortingChange?: func;
 }
 
 export type ApiSortingType = {
+  /** Field to sort by */
   orderBy: string;
+  /** Sort by asc or desc */
   order: ApiSortDirection;
 };

--- a/client/src/containers/table/types.d.ts
+++ b/client/src/containers/table/types.d.ts
@@ -9,6 +9,7 @@ export type ColumnProps = ICellProps & {
 
 export interface TableProps extends ITableProps {
   className?: string;
+  isLoading?: boolean;
   stickyFirstColumn?: boolean;
   childComponents?: ChildComponents;
   sortingMode?: SortingMode;

--- a/client/src/pages/admin/data.tsx
+++ b/client/src/pages/admin/data.tsx
@@ -13,7 +13,13 @@ import Button from 'components/button';
 import Pagination, { PaginationProps } from 'components/pagination';
 import Search from 'components/search';
 import YearsRangeFilter, { useYearsRange } from 'containers/filters/years-range';
-import Table, { TableProps, DataType, SortingMode, ApiSortingType } from 'containers/table';
+import {
+  TableNoSSR as Table,
+  TableProps,
+  DataType,
+  SortingMode,
+  ApiSortingType,
+} from 'containers/table';
 
 const AdminDataPage: React.FC = () => {
   const [searchText, setSearchText] = useDebounce('', 250);
@@ -72,6 +78,7 @@ const AdminDataPage: React.FC = () => {
 
   const tableProps: TableProps = useMemo(() => {
     return {
+      isLoading: isFetchingSourcingData,
       rowKeyField: 'id',
       columns: [
         { key: 'materialName', title: 'Material', dataType: DataType.String, width: 240 },
@@ -90,19 +97,20 @@ const AdminDataPage: React.FC = () => {
         setSorting(params);
       },
     };
-  }, [sorting, sourcingData, yearsData.columns, yearsData.data]);
+  }, [isFetchingSourcingData, sorting, sourcingData, yearsData.columns, yearsData.data]);
 
   /** Pagination Props */
 
   const paginationProps: PaginationProps = useMemo(
     () => ({
+      isLoading: isFetchingSourcingData,
       numItems: sourcingData.length,
       currentPage: currentPage,
       totalPages: sourcingMetadata.totalPages,
       totalItems: sourcingMetadata.totalItems,
       onPageClick: setCurrentPage,
     }),
-    [currentPage, sourcingData, sourcingMetadata],
+    [currentPage, isFetchingSourcingData, sourcingData, sourcingMetadata],
   );
 
   /** Helpers for use in the JSX */
@@ -114,7 +122,6 @@ const AdminDataPage: React.FC = () => {
   return (
     <AdminLayout
       currentTab={ADMIN_TABS.DATA}
-      loading={isFetchingSourcingData}
       headerButtons={
         <>
           <Button theme="secondary" onClick={() => console.info('Download: click')}>
@@ -163,7 +170,7 @@ const AdminDataPage: React.FC = () => {
 
       {!hasData && isSearching && <NoResults />}
 
-      {hasData && (
+      {(hasData || isFetchingData) && (
         <>
           <Table {...tableProps} />
           <Pagination className="my-4 ml-4 mr-2" {...paginationProps} />


### PR DESCRIPTION
## Description  

**In this PR:**
- `Pagination` component changes:  
    - Ability to "freeze" the current state while data is being loaded by the parent component    
    - Added a check to verify all the values needed to correctly display pagination are available  
      _Preventing `NaN` from appearing in the view, if one of the required values is undefined_  
- `Table` component changes:  
    - Ability to "freeze" the current state (`columns`, `data`, `tableProps` in general) while data is being loaded by the parent component 
    - Added a "Loading" spinner to display in the table itself, while data is being loaded by the parent component  
    - Slightly tweaked the styling of the `ka-table` `noDataRow` child component  
      _So that the loading spinner_ that is shown while data is being loaded fits, when there is no data (first load)
    - Made it easier to import the `Table` with no server side rendering  
    - Added descriptions/comments to the types declarations in `types.d.ts`  
- Admin / Data view  
    - Added the necessary changes so that fetching new data no longer displays a full page loading spinner  
      _Instead it'll show a spinner in the table itself_

**Notes:**  

Consulted with Andreia with the video below. 

## JIRA  

[LANDGRIF-528 (Revise loading spinners when fetching new data for tables)](https://vizzuality.atlassian.net/browse/LANDGRIF-528)

## Screenshot
<img width="1676" alt="Screenshot 2022-02-21 at 15 25 36" src="https://user-images.githubusercontent.com/6273795/154984391-fd082f59-c126-4a3e-8c04-19d359fc602a.png">

## Video  
https://user-images.githubusercontent.com/6273795/154984414-86b4f673-904a-42a0-a10c-6f4dada92a3c.mp4


