### PR TITLE
Frontend bugfixes

### DIFF
--- a/client/src/containers/analysis-visualization/analysis-filters/years/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-filters/years/component.tsx
@@ -20,7 +20,9 @@ const YearsFilter: React.FC = () => {
   const { startYear, endYear, yearsGap, setYearsRange } = useYearsRange({
     years: years,
     yearsGap: 5,
-    validateRange: false,
+    // Map mode only makes use of the endYear and will display the Select,
+    // not the YearsRangeFilter.
+    validateRange: visualizationMode !== 'map',
     ...filters,
   });
 

--- a/client/src/layouts/application/component.tsx
+++ b/client/src/layouts/application/component.tsx
@@ -9,7 +9,7 @@ const ApplicationLayout: React.FC<ApplicationLayoutProps> = (props: ApplicationL
   const { children } = props;
 
   return (
-    <div className="h-screen flex bg-gray-100">
+    <div className="flex bg-gray-100">
       {/* Navigation */}
       <Sidebar />
 

--- a/client/src/pages/analysis/index.tsx
+++ b/client/src/pages/analysis/index.tsx
@@ -54,7 +54,7 @@ const AnalysisPage: React.FC = () => {
         <title>Analysis - Landgriffon</title>
       </Head>
       <main className="flex-1">
-        <div className="lg:h-screen flex">
+        <div className="h-screen flex">
           {/* Analysis content */}
           <div className="relative h-full z-30">
             <section className="relative h-full top-0 hidden lg:block lg:flex-shrink-0 lg:order-first">


### PR DESCRIPTION
## Description  

**In this PR:**
1. Fixing Analysis views not displaying on mobile  
2. Fixing Admin view background colour not always covering the whole background  
3. Years range for the `YearsRangeFilter` in the Analysis / Table view not displaying correctly.
    How to reproduce:  
        - Go to the Analysis view, choose `Impact`  
        - Ensure the year is set to `2010`
        - Click on the "Table" button/icon  
           The YearsRange filter and view are broken  

## JIRA  

N/A

## Screenshots
<img width="502" alt="Screenshot 2022-02-21 at 16 44 29" src="https://user-images.gith
<img width="1679" alt="Screenshot 2022-02-21 at 16 44 49" src="https://user-images.githubusercontent.com/6273795/154998470-a2bd5a06-5727-4943-ba5f-e1ce40abfb42.png">
ubusercontent.com/6273795/154998446-4c67a168-bd32-43bb-bcf3-7b9d88d1d1b2.png">
<img width="1677" alt="Screenshot 2022-02-21 at 16 46 02" src="https://user-images.githubusercontent.com/6273795/154998490-491764da-0719-4147-b447-0ddebad967a8.png">

