### PR TITLE
Api/suppliers max name length

### DIFF
--- a/api/src/modules/suppliers/dto/create.supplier.dto.ts
+++ b/api/src/modules/suppliers/dto/create.supplier.dto.ts
@@ -14,7 +14,7 @@ export class CreateSupplierDto {
   @IsString()
   @IsNotEmpty()
   @MinLength(2)
-  @MaxLength(40)
+  @MaxLength(300)
   @ApiProperty()
   name!: string;
 

--- a/api/src/modules/suppliers/dto/update.supplier.dto.ts
+++ b/api/src/modules/suppliers/dto/update.supplier.dto.ts
@@ -6,7 +6,7 @@ export class UpdateSupplierDto extends PartialType(CreateSupplierDto) {
   @IsString()
   @IsOptional()
   @MinLength(2)
-  @MaxLength(40)
+  @MaxLength(300)
   @ApiProperty()
   name?: string;
 }

--- a/api/test/e2e/suppliers/suppliers-create.spec.ts
+++ b/api/test/e2e/suppliers/suppliers-create.spec.ts
@@ -79,13 +79,19 @@ describe('Suppliers - Create', () => {
   });
 
   test('Create a supplier with name bigger than 300 characters should return bad request error', async () => {
-    await request(app.getHttpServer())
+    const response = await request(app.getHttpServer())
       .post('/api/v1/suppliers')
       .set('Authorization', `Bearer ${jwtToken}`)
       .send({
         name: 'i'.repeat(301),
       })
       .expect(HttpStatus.BAD_REQUEST);
+
+    expect(response).toHaveErrorMessage(
+      HttpStatus.BAD_REQUEST,
+      'Bad Request Exception',
+      ['name must be shorter than or equal to 300 characters'],
+    );
   });
 
   test('Create a supplier without the required fields should fail with a 400 error', async () => {

--- a/api/test/e2e/suppliers/suppliers-create.spec.ts
+++ b/api/test/e2e/suppliers/suppliers-create.spec.ts
@@ -57,6 +57,37 @@ describe('Suppliers - Create', () => {
     expect(response).toHaveJSONAPIAttributes(expectedJSONAPIAttributes);
   });
 
+  test('Create a supplier with name smaller or equal to 300 characters should be successful', async () => {
+    const response = await request(app.getHttpServer())
+      .post('/api/v1/suppliers')
+      .set('Authorization', `Bearer ${jwtToken}`)
+      .send({
+        name: 'i'.repeat(300),
+      })
+      .expect(HttpStatus.CREATED);
+
+    const createdSupplier = await supplierRepository.findOne(
+      response.body.data.id,
+    );
+
+    if (!createdSupplier) {
+      throw new Error('Error loading created Supplier');
+    }
+
+    expect(createdSupplier.name).toEqual('i'.repeat(300));
+    expect(response).toHaveJSONAPIAttributes(expectedJSONAPIAttributes);
+  });
+
+  test('Create a supplier with name bigger than 300 characters should return bad request error', async () => {
+    await request(app.getHttpServer())
+      .post('/api/v1/suppliers')
+      .set('Authorization', `Bearer ${jwtToken}`)
+      .send({
+        name: 'i'.repeat(301),
+      })
+      .expect(HttpStatus.BAD_REQUEST);
+  });
+
   test('Create a supplier without the required fields should fail with a 400 error', async () => {
     const response = await request(app.getHttpServer())
       .post('/api/v1/suppliers')

--- a/api/test/e2e/suppliers/suppliers-create.spec.ts
+++ b/api/test/e2e/suppliers/suppliers-create.spec.ts
@@ -69,7 +69,7 @@ describe('Suppliers - Create', () => {
       'Bad Request Exception',
       [
         'name should not be empty',
-        'name must be shorter than or equal to 40 characters',
+        'name must be shorter than or equal to 300 characters',
         'name must be longer than or equal to 2 characters',
         'name must be a string',
       ],

--- a/api/test/e2e/suppliers/suppliers-update.spec.ts
+++ b/api/test/e2e/suppliers/suppliers-update.spec.ts
@@ -53,13 +53,19 @@ describe('Suppliers - Update', () => {
 
   test('Update a supplier name with length more than 300 should return bad request error', async () => {
     const supplier: Supplier = await createSupplier();
-    await request(app.getHttpServer())
+    const response = await request(app.getHttpServer())
       .patch(`/api/v1/suppliers/${supplier.id}`)
       .set('Authorization', `Bearer ${jwtToken}`)
       .send({
         name: 'i'.repeat(301),
       })
       .expect(HttpStatus.BAD_REQUEST);
+
+    expect(response).toHaveErrorMessage(
+      HttpStatus.BAD_REQUEST,
+      'Bad Request Exception',
+      ['name must be shorter than or equal to 300 characters'],
+    );
   });
 
   test('Update a supplier name with length less or equal to 300 should be successful', async () => {

--- a/api/test/e2e/suppliers/suppliers-update.spec.ts
+++ b/api/test/e2e/suppliers/suppliers-update.spec.ts
@@ -70,7 +70,7 @@ describe('Suppliers - Update', () => {
       .send({
         name: 'i'.repeat(300),
       })
-      .expect(HttpStatus.BAD_REQUEST);
+      .expect(HttpStatus.OK);
   });
 
   test("Update a supplier's parentId should be successful", async () => {

--- a/api/test/e2e/suppliers/suppliers-update.spec.ts
+++ b/api/test/e2e/suppliers/suppliers-update.spec.ts
@@ -51,6 +51,28 @@ describe('Suppliers - Update', () => {
     expect(response).toHaveJSONAPIAttributes(expectedJSONAPIAttributes);
   });
 
+  test('Update a supplier name with length more than 300 should return bad request error', async () => {
+    const supplier: Supplier = await createSupplier();
+    await request(app.getHttpServer())
+      .patch(`/api/v1/suppliers/${supplier.id}`)
+      .set('Authorization', `Bearer ${jwtToken}`)
+      .send({
+        name: 'i'.repeat(301),
+      })
+      .expect(HttpStatus.BAD_REQUEST);
+  });
+
+  test('Update a supplier name with length less or equal to 300 should be successful', async () => {
+    const supplier: Supplier = await createSupplier();
+    await request(app.getHttpServer())
+      .patch(`/api/v1/suppliers/${supplier.id}`)
+      .set('Authorization', `Bearer ${jwtToken}`)
+      .send({
+        name: 'i'.repeat(300),
+      })
+      .expect(HttpStatus.BAD_REQUEST);
+  });
+
   test("Update a supplier's parentId should be successful", async () => {
     const supplierOne: Supplier = await createSupplier();
     const supplierTwo: Supplier = await createSupplier();


### PR DESCRIPTION
change max length for supplier name (v3 sourcing data contains bigger names and data ingestion fails)