### PR TITLE
Removing placeholder warning/error from admin/data view

### DIFF
--- a/client/src/pages/admin/data.tsx
+++ b/client/src/pages/admin/data.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo } from 'react';
 import { flatten, merge, uniq } from 'lodash';
 import { useDebounce } from '@react-hook/debounce';
-import { ExclamationIcon /*, FilterIcon*/ } from '@heroicons/react/solid';
+// import { FilterIcon } from '@heroicons/react/solid';
 
 import useModal from 'hooks/modals';
 import { useSourcingLocationsMaterials } from 'hooks/sourcing-locations';
@@ -160,10 +160,6 @@ const AdminDataPage: React.FC = () => {
               </span>
             </Button>
             */}
-          </div>
-          <div className="flex items-center text-sm text-yellow-800">
-            <ExclamationIcon className="w-5 h-5 mr-3 text-yellow-400" aria-hidden="true" />1 entry
-            needs to be updated
           </div>
         </div>
       )}


### PR DESCRIPTION
Designs changed and these won't be displayed anymore, so I'm removing them to prevent confusion. 

<img width="495" alt="admin-data-error" src="https://user-images.githubusercontent.com/6273795/155130427-62843e0f-a839-49d4-ac5a-7f1c3681a87e.png">
