### PR TITLE
new routes for scenarios edit and create

### DIFF
--- a/client/docs/analysis.stories.mdx
+++ b/client/docs/analysis.stories.mdx
@@ -30,10 +30,10 @@ The user should be able to...
 
 * `/analysis`: list scenarios
 * `/analysis?scenario=:id`: there is a scenario selected for visualization
-* `/analysis?edit_scenario=:id`: edit a scenario given an id
-* `/analysis?new_scenario`: creates a new scenario and redirect to `/analysis?edit_scenario=:id`
-* `/analysis?edit_scenario=:id?new_intervention`: edit a scenario and open the form for intervention creation
-* `/analysis?edit_scenario=:id&edit_intervention=:id`: edit a scenario and/or an intervention given an id
+* `/analysis?scenario=edit=:id`: edit a scenario given an id
+* `/analysis?scenario=new`: creates a new scenario and redirect to `/analysis?edit_scenario=:id`
+* `/analysis?scenario=edit=:id?new_intervention`: edit a scenario and open the form for intervention creation
+* `/analysis?scenario=edit=:id&edit_intervention=:id`: edit a scenario and/or an intervention given an id
 
 ## Visualizations modes
 

--- a/client/src/containers/interventions/new/component.tsx
+++ b/client/src/containers/interventions/new/component.tsx
@@ -88,8 +88,8 @@ const InterventionForm: FC = () => {
             </button>
             {!!currentStep && !isFirstStep && (
               <Button
-                type="button"
-                //type="submit"
+                // type="button"
+                type="submit"
                 className="ml-3 inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-green-700 hover:bg-green-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
                 onClick={handleIntervention}
               >

--- a/client/src/containers/scenarios/component.tsx
+++ b/client/src/containers/scenarios/component.tsx
@@ -10,13 +10,13 @@ import type { Page } from 'components/breadcrumb/types';
 const ScenariosComponent: React.FC = () => {
   const { query } = useRouter();
   const { data, isLoading, error } = useScenarios({ sort: query.sortBy as string });
-  const { edit_scenario } = query;
+  const { scenario } = query;
 
   // Breadcrumbs
   let pages: Page[] = [{ name: 'Analysis', href: '/analysis' }]; // Default
 
-  if (edit_scenario) {
-    pages = [...pages, { name: 'Edit scenario', href: '/analysis?edit_scenario' }];
+  if (scenario === 'edit') {
+    pages = [...pages, { name: 'Edit scenario', href: '/analysis?scenario=edit' }];
   }
 
   return (
@@ -51,7 +51,7 @@ const ScenariosComponent: React.FC = () => {
         </div>
       )}
       <div className="bg-white z-20 sticky bottom-0 left-0 w-full py-6">
-        <Link href="/analysis?new_scenario=true" shallow passHref>
+        <Link href={{ pathname: '/analysis', query: { scenario: 'new' } }} shallow passHref>
           <AnchorLink size="xl" className="block w-full">
             <PlusIcon className="-ml-5 mr-3 h-5 w-5" aria-hidden="true" />
             Create a new scenario

--- a/client/src/containers/scenarios/new/index.tsx
+++ b/client/src/containers/scenarios/new/index.tsx
@@ -11,9 +11,9 @@ const ScenariosNewContainer: React.FC = () => {
 
   if (response.isSuccess) {
     // router.replace({
-    //   pathname: '/analysis',
+    //   pathname: '/analysis/scenario',
     //   query: {
-    //     new_scenario: response.data.id,
+    //     new: response.data.id,
     //   },
     // });
   }

--- a/client/src/pages/analysis/index.tsx
+++ b/client/src/pages/analysis/index.tsx
@@ -24,30 +24,31 @@ const AnalysisPage: React.FC = () => {
   const { isSidebarCollapsed, isSubContentCollapsed } = useAppSelector(analysis);
 
   const analysisContent = () => {
-    if (new_scenario) return <ScenarioNew />;
-    if (edit_scenario) return <ScenarioEdit />;
+    if (scenario === 'new') return <ScenarioNew />;
+    if (scenario === 'edit') return <ScenarioEdit />;
     return <Scenarios />;
   };
 
   const dispatch = useAppDispatch();
-  const { query } = useRouter();
-  const { new_scenario, edit_scenario } = query;
+  const {
+    query: { scenario },
+  } = useRouter();
 
   // Breadcrumbs
   let pages: Page[] = [{ name: 'Analysis', href: '/analysis' }]; // Default
-  if (edit_scenario) {
-    pages = [...pages, { name: 'Edit scenario', href: '/analysis?edit_scenario' }];
+  if (scenario === 'edit') {
+    pages = [...pages, { name: 'Edit scenario', href: '/analysis?scenario=edit' }];
   }
 
-  if (new_scenario) {
-    pages = [...pages, { name: 'New scenario', href: '/analysis?new_scenario' }];
+  if (scenario === 'new') {
+    pages = [...pages, { name: 'New scenario', href: '/analysis?scenario=new' }];
   }
 
   useEffect(() => {
     // Close and cancel interventions creation
     // when user goes to scenarios list
-    if (!new_scenario && !edit_scenario) dispatch(setSubContentCollapsed(true));
-  }, [new_scenario, edit_scenario, dispatch]);
+    if (!scenario) dispatch(setSubContentCollapsed(true));
+  }, [scenario, dispatch]);
 
   return (
     <ApplicationLayout>


### PR DESCRIPTION
**DESCRIPTION**

This PR changes the routes for "Create a new scenario" and "Edit scenario".

Moved from:
   "analysis/scenario?new_scenario" to "analysis/scenario=new"
   "analysis/scenario?edit_scenario" to "analysis/scenario=edit" 