### PR TITLE
Fixing `TreeSelect` display issues in the `MoreFilters` component

### DIFF
--- a/client/src/components/tree-select/component.tsx
+++ b/client/src/components/tree-select/component.tsx
@@ -30,7 +30,7 @@ const THEMES_LABEL = {
 
 const THEMES_WRAPPER = {
   default:
-    'flex-wrap bg-white relative border border-gray-300 rounded-md shadow-sm py-2 pr-10 pl-3 cursor-pointer',
+    'flex-wrap w-full bg-white relative border border-gray-300 rounded-md shadow-sm py-2 pr-10 pl-3 cursor-pointer',
   primary: 'border-b-2 border-green-700 max-w-[190px] overflow-x-hidden truncate text-ellipsis',
 };
 

--- a/client/src/containers/analysis-visualization/analysis-filters/more-filters/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-filters/more-filters/component.tsx
@@ -131,8 +131,8 @@ const MoreFilters: React.FC = () => {
                   />
                 </div>
               </div>
-              <div className="flex gap-2 mt-4">
-                <Button theme="secondary" className="px-8" onClick={() => setOpen(false)}>
+              <div className="flex gap-2 mt-6">
+                <Button theme="secondary" className="px-9" onClick={() => setOpen(false)}>
                   Cancel
                 </Button>
                 <Button theme="primary" className="flex-grow" onClick={handleApply}>


### PR DESCRIPTION
## Description  

**In this PR:**

Quick fix to the issue causing the `TreeSelect` component to not display correctly. It looks like even though its own wrapper has the same size, the sub elements would not be taking the wrapper's width. 

## JIRA  
[LANDGRIF-533 (Selects in the MoreFilters component have styling issues)](https://vizzuality.atlassian.net/browse/LANDGRIF-533)

## Screenshots
**Before**  
<img width="542" alt="Screenshot 2022-02-24 at 09 58 55" src="https://user-images.githubusercontent.com/6273795/155503650-85899a33-4868-4099-9c13-8e248528693e.png">

**After**
<img width="533" alt="Screenshot 2022-02-24 at 09 59 09" src="https://user-images.githubusercontent.com/6273795/155503668-1b710bf0-68ac-40f3-8cb6-8bb2d32d708b.png">

