### PR TITLE
Adding info/tooltip buttons to Analysis / Scenarios forms

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -38,6 +38,7 @@
     "@reduxjs/toolkit": "^1.5.1",
     "@tailwindcss/forms": "^0.4.0",
     "@tailwindcss/typography": "^0.5.0",
+    "@tippyjs/react": "^4.2.6",
     "@visx/annotation": "^2.1.0",
     "@visx/axis": "^2.1.0",
     "@visx/event": "^2.1.0",

--- a/client/src/components/tooltip/component.tsx
+++ b/client/src/components/tooltip/component.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import classNames from 'classnames';
+import Tooltip from '@tippyjs/react';
+
+import 'tippy.js/dist/tippy.css';
+
+import { TooltipProps } from './types';
+
+export const ToolTip: React.FC<TooltipProps> = ({
+  className,
+  children,
+  ...props
+}: TooltipProps) => {
+  const mergeProps = {
+    interactive: true,
+    trigger: 'mouseenter focus',
+    disabled: !props.content,
+    ...props,
+  };
+
+  return (
+    <Tooltip {...mergeProps}>
+      <button
+        className={classNames(
+          'rounded-md focus:outline-none focus:ring-1 focus:ring-green-700',
+          {
+            'cursor-pointer': !!props.content,
+          },
+          className,
+        )}
+        disabled={!props.content}
+      >
+        {children}
+      </button>
+    </Tooltip>
+  );
+};
+
+export default ToolTip;

--- a/client/src/components/tooltip/index.ts
+++ b/client/src/components/tooltip/index.ts
@@ -1,0 +1,2 @@
+export { default } from './component';
+export type { TooltipProps } from './types';

--- a/client/src/components/tooltip/types.d.ts
+++ b/client/src/components/tooltip/types.d.ts
@@ -1,0 +1,8 @@
+import { TippyProps } from '@tippyjs/react';
+
+/** TippyProps: https://atomiks.github.io/tippyjs/v6/all-props */
+export type TooltipProps = PropsWithChildren &
+  TippyProps & {
+    /** Classnames to apply to the Tooltip wrapper */
+    className: string;
+  };

--- a/client/src/containers/info-tooltip/component.tsx
+++ b/client/src/containers/info-tooltip/component.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { InformationCircleIcon } from '@heroicons/react/solid';
+
+import Tooltip from 'components/tooltip';
+
+import { InfoTooltipProps } from './types';
+
+export const InfoToolTip: React.FC<InfoTooltipProps> = ({ ...props }: InfoTooltipProps) => {
+  const mergeProps = {
+    placement: 'right',
+    ...props,
+  };
+
+  return (
+    <Tooltip {...mergeProps}>
+      <InformationCircleIcon className="block h-5 w-5" />
+    </Tooltip>
+  );
+};
+
+export default InfoToolTip;

--- a/client/src/containers/info-tooltip/index.ts
+++ b/client/src/containers/info-tooltip/index.ts
@@ -1,0 +1,2 @@
+export { default } from './component';
+export type { InfoTooltipProps } from './types';

--- a/client/src/containers/info-tooltip/types.d.ts
+++ b/client/src/containers/info-tooltip/types.d.ts
@@ -1,0 +1,4 @@
+import { TippyProps } from '@tippyjs/react';
+
+/** TippyProps: https://atomiks.github.io/tippyjs/v6/all-props */
+export type InfoTooltipProps = TippyProps;

--- a/client/src/containers/interventions/new/step2/material/component.tsx
+++ b/client/src/containers/interventions/new/step2/material/component.tsx
@@ -1,6 +1,10 @@
 import { useMemo, useCallback, useState } from 'react';
 
+// components
 import Select from 'components/select';
+
+// containers
+import InfoTooltip from 'containers/info-tooltip';
 
 // types
 import { SelectOptions, SelectOption } from 'components/select/types';
@@ -68,7 +72,10 @@ const Material = () => {
   return (
     <>
       <fieldset className="sm:col-span-3 text-sm">
-        <legend className="font-medium leading-5">New supplier</legend>
+        <legend className="flex font-medium leading-5">
+          New supplier
+          <InfoTooltip className="ml-2" />
+        </legend>
 
         <div className="mt-6 grid grid-cols-2 gap-y-6 gap-x-6 sm:grid-cols-2">
           <div className="block font-medium text-gray-700">

--- a/client/src/containers/interventions/new/step2/supplier-impact/component.tsx
+++ b/client/src/containers/interventions/new/step2/supplier-impact/component.tsx
@@ -3,6 +3,9 @@ import { useMemo, useCallback, useState, FC } from 'react';
 // types
 import { setFilter } from 'store/features/analysis';
 
+// containers
+import InfoTooltip from 'containers/info-tooltip';
+
 // utils
 import { NUMBER_FORMAT } from 'containers/analysis-visualization/constants';
 
@@ -77,7 +80,10 @@ const Step2: FC = () => {
   return (
     <>
       <fieldset className="sm:col-span-3 text-sm">
-        <legend className="font-medium leading-5">Supplier impacts per tone</legend>
+        <legend className="flex font-medium leading-5">
+          Supplier impacts per tone
+          <InfoTooltip className="ml-2" />
+        </legend>
         <div className="flex items-center justify-between mt-6">
           <div className="flex items-center">
             <input

--- a/client/src/containers/interventions/new/step2/supplier/component.tsx
+++ b/client/src/containers/interventions/new/step2/supplier/component.tsx
@@ -1,6 +1,10 @@
 import { useMemo, useCallback, useState } from 'react';
 
+// components
 import Select from 'components/select';
+
+// containers
+import InfoTooltip from 'containers/info-tooltip';
 
 // types
 import { SelectOptions, SelectOption } from 'components/select/types';
@@ -55,7 +59,10 @@ const Supplier = () => {
   return (
     <>
       <fieldset className="sm:col-span-3 text-sm">
-        <legend className="font-medium leading-5">Supplier location</legend>
+        <legend className="flex font-medium leading-5">
+          Supplier location
+          <InfoTooltip className="ml-2" />
+        </legend>
 
         <div className="mt-6 grid grid-cols-2 gap-y-6 gap-x-6 sm:grid-cols-2">
           <div className="block font-medium text-gray-700">

--- a/client/src/containers/scenarios/new/form/component.tsx
+++ b/client/src/containers/scenarios/new/form/component.tsx
@@ -12,7 +12,7 @@ const ScenariosForm = () => {
   const growthContent = useMemo<boolean>(() => tab && tab.includes('growth'), [tab]);
 
   return (
-    <div className="p-12 bg-white z-50 h-full">
+    <div className="p-12 bg-white z-50">
       {!growthContent && <InterventionsForm />}
       {growthContent && <GrowthForm />}
       <div className="absolute top-5 right-0 transform translate-x-1/2 z-30">

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -1523,6 +1523,11 @@
   resolved "https://registry.yarnpkg.com/@panva/asn1.js/-/asn1.js-1.0.0.tgz#dd55ae7b8129e02049f009408b97c61ccf9032f6"
   integrity sha512-UdkG3mLEqXgnlKsWanWcgb6dOjUzJ+XC5f+aWw30qrtjxeNUSfKX1cd5FBzOaXQumoe9nIqeZUvrRJS03HCCtw==
 
+"@popperjs/core@^2.9.0":
+  version "2.11.2"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.2.tgz#830beaec4b4091a9e9398ac50f865ddea52186b9"
+  integrity sha512-92FRmppjjqz29VMJ2dn+xdyXZBrMlE42AV6Kq6BwjWV7CNUW1hs2FtxSNLQE+gJhaZ6AAmYuO9y8dshhcBl7vA==
+
 "@prisma/client@^2.16.1":
   version "2.30.3"
   resolved "https://registry.yarnpkg.com/@prisma/client/-/client-2.30.3.tgz#49c1015e2cec26a44b20c62eb2fd738cb0bb043b"
@@ -1964,6 +1969,13 @@
     lodash.isplainobject "^4.0.6"
     lodash.merge "^4.6.2"
     lodash.uniq "^4.5.0"
+
+"@tippyjs/react@^4.2.6":
+  version "4.2.6"
+  resolved "https://registry.yarnpkg.com/@tippyjs/react/-/react-4.2.6.tgz#971677a599bf663f20bb1c60a62b9555b749cc71"
+  integrity sha512-91RicDR+H7oDSyPycI13q3b7o4O60wa2oRbjlz2fyRLmHImc4vyDwuUP8NtZaN0VARJY5hybvDYrFzhY9+Lbyw==
+  dependencies:
+    tippy.js "^6.3.1"
 
 "@types/chroma-js@^2.1.3":
   version "2.1.3"
@@ -9473,6 +9485,13 @@ tinyqueue@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/tinyqueue/-/tinyqueue-2.0.3.tgz#64d8492ebf39e7801d7bd34062e29b45b2035f08"
   integrity sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA==
+
+tippy.js@^6.3.1:
+  version "6.3.7"
+  resolved "https://registry.yarnpkg.com/tippy.js/-/tippy.js-6.3.7.tgz#8ccfb651d642010ed9a32ff29b0e9e19c5b8c61c"
+  integrity sha512-E1d3oP2emgJ9dRQZdf3Kkn0qJgI6ZLpyS5z6ZkY1DF3kaQaBsGZsndEpHwx+eC+tYM41HaSNvNtLx8tU57FzTQ==
+  dependencies:
+    "@popperjs/core" "^2.9.0"
 
 tmp@^0.2.1, tmp@~0.2.1:
   version "0.2.1"


### PR DESCRIPTION
## Description  

**In this PR:**

- New `Tooltip` component: 
  _Simple component that makes use of `https://github.com/atomiks/tippyjs-react` to display tooltips_
  - Keyboard accessible  
  - Will not break if no content is provided (no empty tooltip, pointer cursor, etc)  
  - Both text and html/react can be used for the tooltip component  
- New `InfoTooltip` container/component:  
  _Standardised, easy to use component to add `InformationCircleIcon`s tooltips, as used throughout the app. Makes use of the generic `Tooltip` component_  
- Analysis > New Scenario forms  
  - Added the InfoTooltip icons
    _Ready to accept tooltips, although without content they'll just display as simple icons_

## JIRA  

[LANDGRIF-522 (analysis page / new intervention. missing button info in layout)](https://vizzuality.atlassian.net/browse/LANDGRIF-522)

## Screenshots
<img width="701" alt="Screenshot 2022-02-24 at 13 05 55" src="https://user-images.githubusercontent.com/6273795/155529533-60c538d4-bc58-4406-80b0-21f4c1138554.png">

