### PR TITLE
Styling inputs, labels to match the designs

### DIFF
--- a/client/src/components/forms/checkbox/component.tsx
+++ b/client/src/components/forms/checkbox/component.tsx
@@ -2,21 +2,24 @@ import React from 'react';
 import Hint from '../hint';
 import classnames from 'classnames';
 
+const THEMES = {
+  default:
+    'border rounded text-sm text-green-700 focus:outline-none focus:ring-2 focus:ring-green-700/50 focus:border-green-700 px-0',
+};
+
 type CheckboxProps = React.InputHTMLAttributes<HTMLInputElement> & {
+  theme?: 'default';
   error?: string;
 };
 
 const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
-  ({ error, children, ...props }, ref) => (
-    <div>
+  ({ className, theme = 'default', error, children, ...props }, ref) => (
+    <div className={classnames('mt-1', className)}>
       <div className="flex items-center">
         <input
-          className={classnames(
-            'h-4 w-4 text-green-700 focus:ring-green-700 border-gray-700 rounded',
-            {
-              'border-red-600': !!error,
-            },
-          )}
+          className={classnames([THEMES[theme]], {
+            'border-red-600': !!error,
+          })}
           {...props}
           ref={ref}
           type="checkbox"

--- a/client/src/components/forms/input/component.tsx
+++ b/client/src/components/forms/input/component.tsx
@@ -8,10 +8,15 @@ const THEMES = {
     icon: 'absolute w-5 h-5 text-gray-400 transform -translate-y-1/2 top-1/2 left-3',
     unit: 'absolute right-3 text-sm text-gray-500',
   },
+  'inline-primary': {
+    base: 'appearance-none w-full text-sm text-center text-green-700 font-bold border-0 border-b-2 border-green-700 px-0 py-0 focus:outline-none focus:border-green-700 focus:ring-0',
+    icon: 'absolute w-4 h-4 text-green-700 transform -translate-y-1/2 top-1/2 left-0',
+    unit: 'absolute right-0 text-sm font-bold text-green-700',
+  },
 };
 
 type InputProps = React.InputHTMLAttributes<HTMLInputElement> & {
-  theme?: 'default';
+  theme?: 'default' | 'inline-primary';
   type?: string;
   // https://github.com/tailwindlabs/heroicons/issues/64#issuecomment-859168741
   icon?: (props: React.ComponentProps<'svg'>) => JSX.Element;
@@ -31,7 +36,8 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
             className={classnames([THEMES[theme].base], {
               // The Checkbox component should be used instead, but just in case.
               'px-0': type === 'checkbox',
-              'pl-10': !!icon,
+              'pl-10': !!icon && theme !== 'inline-primary',
+              'pl-3': !!icon && theme === 'inline-primary',
               'border-red-600': !!error,
             })}
             type={type}
@@ -40,7 +46,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
             // approximate a padding based on the unit's character length to a good degree.
             // ~10px per character, + 14px for extra right padding.
             style={{
-              paddingRight: unit && unit?.length * 10 + 14,
+              paddingRight: unit && unit?.length * 10 + (theme === 'inline-primary' ? 2 : 14),
             }}
             {...props}
           />

--- a/client/src/components/forms/input/component.tsx
+++ b/client/src/components/forms/input/component.tsx
@@ -2,25 +2,35 @@ import React from 'react';
 import Hint from '../hint';
 import classnames from 'classnames';
 
+const THEMES = {
+  default:
+    'appearance-none block w-full px-3 py-2 border border-gray-200 rounded-md shadow-sm text-gray-900 placeholder-gray-500 focus:outline-none focus:ring-green-700 focus:border-green-700 sm:text-sm',
+};
+
 type InputProps = React.InputHTMLAttributes<HTMLInputElement> & {
+  theme?: 'none' | 'default';
+  type?: string;
   error?: string;
 };
 
-const Input = React.forwardRef<HTMLInputElement, InputProps>(({ error, ...props }, ref) => (
-  <>
-    <div className="mt-1">
-      <input
-        className={classnames(
-          'appearance-none block w-full px-3 py-2 border border-gray-200 rounded-md shadow-sm text-gray-900 placeholder-gray-500 focus:outline-none focus:ring-green-700 focus:border-green-700 sm:text-sm',
-          { 'border-red-600': !!error },
-        )}
-        ref={ref}
-        {...props}
-      />
-    </div>
-    {error && <Hint>{error}</Hint>}
-  </>
-));
+const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, type = 'text', theme = 'default', error, ...props }, ref) => (
+    <>
+      <div className={classnames('relative mt-1', className)}>
+        <input
+          className={classnames({
+            [THEMES[theme]]: !!theme,
+            'border-red-600': !!error,
+          })}
+          type={type}
+          ref={ref}
+          {...props}
+        />
+      </div>
+      {error && <Hint>{error}</Hint>}
+    </>
+  ),
+);
 
 Input.displayName = 'Input';
 

--- a/client/src/components/forms/input/component.tsx
+++ b/client/src/components/forms/input/component.tsx
@@ -3,33 +3,53 @@ import Hint from '../hint';
 import classnames from 'classnames';
 
 const THEMES = {
-  default:
-    'appearance-none block w-full px-3 py-2 border border-gray-200 rounded-md shadow-sm text-gray-900 placeholder-gray-500 focus:outline-none focus:ring-green-700 focus:border-green-700 sm:text-sm',
+  default: {
+    base: 'appearance-none block w-full px-3 py-2 border border-gray-200 rounded-md shadow-sm text-gray-900 placeholder-gray-500 focus:outline-none focus:ring-green-700 focus:border-green-700 text-sm',
+    icon: 'absolute w-5 h-5 text-gray-400 transform -translate-y-1/2 top-1/2 left-3',
+    unit: 'absolute right-3 text-sm text-gray-500',
+  },
 };
 
 type InputProps = React.InputHTMLAttributes<HTMLInputElement> & {
-  theme?: 'none' | 'default';
+  theme?: 'default';
   type?: string;
+  // https://github.com/tailwindlabs/heroicons/issues/64#issuecomment-859168741
+  icon?: (props: React.ComponentProps<'svg'>) => JSX.Element;
+  unit?: string;
   error?: string;
 };
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
-  ({ className, type = 'text', theme = 'default', error, ...props }, ref) => (
-    <>
+  ({ className, type = 'text', theme = 'default', icon, unit, error, ...props }, ref) => {
+    const Icon = icon;
+
+    return (
       <div className={classnames('relative mt-1', className)}>
-        <input
-          className={classnames({
-            [THEMES[theme]]: !!theme,
-            'border-red-600': !!error,
-          })}
-          type={type}
-          ref={ref}
-          {...props}
-        />
+        <div className="flex items-center">
+          {icon && <Icon className={THEMES[theme].icon} />}
+          <input
+            className={classnames([THEMES[theme].base], {
+              // The Checkbox component should be used instead, but just in case.
+              'px-0': type === 'checkbox',
+              'pl-10': !!icon,
+              'border-red-600': !!error,
+            })}
+            type={type}
+            ref={ref}
+            // We need to make space for units. This is far from ideal, should be able to
+            // approximate a padding based on the unit's character length to a good degree.
+            // ~10px per character, + 14px for extra right padding.
+            style={{
+              paddingRight: unit && unit?.length * 10 + 14,
+            }}
+            {...props}
+          />
+          {unit && <span className={THEMES[theme].unit}>{unit}</span>}
+        </div>
+        {error && <Hint>{error}</Hint>}
       </div>
-      {error && <Hint>{error}</Hint>}
-    </>
-  ),
+    );
+  },
 );
 
 Input.displayName = 'Input';

--- a/client/src/components/forms/label/component.tsx
+++ b/client/src/components/forms/label/component.tsx
@@ -1,5 +1,16 @@
-const Label: React.FC<React.LabelHTMLAttributes<HTMLLabelElement>> = ({ children, ...props }) => (
-  <label className="block text-sm font-medium text-gray-900" {...props}>
+import classnames from 'classnames';
+
+const THEMES = {
+  default: 'block text-sm font-medium text-gray-900',
+};
+
+type LabelProps = React.LabelHTMLAttributes<HTMLLabelElement> & {
+  theme?: 'default';
+  error?: string;
+};
+
+const Label: React.FC<LabelProps> = ({ className, theme = 'default', children, ...props }) => (
+  <label className={classnames(className, [THEMES[theme]])} {...props}>
     {children}
   </label>
 );

--- a/client/src/components/forms/radio/component.tsx
+++ b/client/src/components/forms/radio/component.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import Hint from '../hint';
+import classnames from 'classnames';
+
+const THEMES = {
+  default:
+    'border rounded-full text-sm text-green-700 focus:outline-none focus:ring-2 focus:ring-green-700/50 focus:border-green-700 px-0',
+};
+
+type RadioProps = React.InputHTMLAttributes<HTMLInputElement> & {
+  theme?: 'default';
+  error?: string;
+};
+
+const Radio = React.forwardRef<HTMLInputElement, RadioProps>(
+  ({ className, theme = 'default', error, children, ...props }, ref) => (
+    <div className={classnames('mt-1', className)}>
+      <div className="flex items-center">
+        <input
+          className={classnames([THEMES[theme]], {
+            'border-red-600': !!error,
+          })}
+          {...props}
+          ref={ref}
+          type="checkbox"
+        />
+        <label htmlFor={props.id} className="ml-2 block text-sm text-gray-900">
+          {children}
+        </label>
+      </div>
+      {error && <Hint>{error}</Hint>}
+    </div>
+  ),
+);
+
+Radio.displayName = 'Radio';
+
+export default Radio;

--- a/client/src/components/forms/radio/index.ts
+++ b/client/src/components/forms/radio/index.ts
@@ -1,0 +1,1 @@
+export { default } from './component';

--- a/client/src/components/forms/textarea/component.tsx
+++ b/client/src/components/forms/textarea/component.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import Hint from '../hint';
+import classnames from 'classnames';
+
+const THEMES = {
+  default:
+    'border w-full rounded-md text-sm focus:outline-none focus:ring-1 focus:ring-green-700 focus:border-green-700 px-3',
+};
+
+type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement> & {
+  theme?: 'default';
+  error?: string;
+};
+
+const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
+  ({ className, theme = 'default', error, ...props }, ref) => (
+    <>
+      <div className={classnames('mt-1', className)}>
+        <textarea
+          className={classnames([THEMES[theme]], {
+            'border-red-600': !!error,
+          })}
+          ref={ref}
+          {...props}
+        />
+      </div>
+      {error && <Hint>{error}</Hint>}
+    </>
+  ),
+);
+
+Textarea.displayName = 'Textarea';
+
+export default Textarea;

--- a/client/src/components/forms/textarea/index.ts
+++ b/client/src/components/forms/textarea/index.ts
@@ -1,0 +1,1 @@
+export { default } from './component';

--- a/client/src/components/search/component.tsx
+++ b/client/src/components/search/component.tsx
@@ -4,6 +4,8 @@ import { useButton } from '@react-aria/button';
 import { useSearchField } from '@react-aria/searchfield';
 import { useSearchFieldState } from '@react-stately/searchfield';
 
+import Input from 'components/forms/input';
+
 import type { SearchProps } from './types';
 
 export const Search: FC<SearchProps> = ({ ...props }: SearchProps) => {
@@ -16,14 +18,13 @@ export const Search: FC<SearchProps> = ({ ...props }: SearchProps) => {
 
   return (
     <div className="relative flex items-center w-full">
-      <SearchIcon className="absolute w-5 h-5 text-gray-400 transform -translate-y-1/2 top-1/2 left-3" />
-
-      <input
+      <Input
         {...inputProps}
+        icon={SearchIcon}
         ref={ref}
         placeholder={placeholder}
         type="search"
-        className="h-full py-2 pl-10 pr-8 text-sm font-medium leading-4 text-left bg-white border border-gray-300 rounded-md shadow-sm md:w-auto focus:outline-none focus:ring-1 focus:ring-green-700 focus:border-green-700"
+        className="h-full pr-8"
       />
 
       {state.value !== '' && (

--- a/client/src/components/select/component.tsx
+++ b/client/src/components/select/component.tsx
@@ -20,7 +20,7 @@ const THEMES = {
     arrow: 'absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none',
   },
   'default-bordernone': {
-    base: 'focus:outline-none pl-3 pr-10',
+    base: 'flex focus:outline-none pl-3 pr-10',
     arrow: 'absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none',
   },
   'inline-primary': {

--- a/client/src/components/select/component.tsx
+++ b/client/src/components/select/component.tsx
@@ -15,7 +15,7 @@ const SEARCH_OPTIONS = {
   threshold: 0.4,
 };
 
-const ScenariosComparison: React.FC<SelectProps> = (props: SelectProps) => {
+const Select: React.FC<SelectProps> = (props: SelectProps) => {
   const {
     showSearch = false,
     disabled = false,
@@ -193,4 +193,4 @@ const ScenariosComparison: React.FC<SelectProps> = (props: SelectProps) => {
   );
 };
 
-export default ScenariosComparison;
+export default Select;

--- a/client/src/components/select/component.tsx
+++ b/client/src/components/select/component.tsx
@@ -3,7 +3,6 @@ import { Listbox, Transition } from '@headlessui/react';
 import { ChevronDownIcon, ChevronUpIcon, XIcon, SearchIcon } from '@heroicons/react/solid';
 import classNames from 'classnames';
 import Fuse from 'fuse.js';
-import cx from 'classnames';
 
 import Loading from 'components/loading';
 
@@ -13,6 +12,21 @@ const SEARCH_OPTIONS = {
   includeScore: false,
   keys: ['label'],
   threshold: 0.4,
+};
+
+const THEMES = {
+  default: {
+    base: 'bg-white relative w-full flex align-center py-2 text-left text-sm cursor-pointer font-medium border border-gray-300 rounded-md focus:outline-none focus:ring-1 focus:ring-green-700 focus:border-green-700 pl-3 pr-10',
+    arrow: 'absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none',
+  },
+  'default-bordernone': {
+    base: 'focus:outline-none pl-3 pr-10',
+    arrow: 'absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none',
+  },
+  'inline-primary': {
+    base: 'relative py-0.5 flex text-sm font-bold border-b-2 border-green-700 max-w-[190px] truncate text-ellipsis',
+    arrow: 'absolute -bottom-3 transform left-1/2 -translate-x-1/2 text-green-700',
+  },
 };
 
 const Select: React.FC<SelectProps> = (props: SelectProps) => {
@@ -27,7 +41,7 @@ const Select: React.FC<SelectProps> = (props: SelectProps) => {
     searchPlaceholder = 'Search',
     onChange,
     onSearch,
-    theme = 'primary',
+    theme = 'default',
   } = props;
   const [selected, setSelected] = useState<SelectProps['current']>(current);
   const [searchTerm, setSearchTerm] = useState<string>('');
@@ -53,7 +67,9 @@ const Select: React.FC<SelectProps> = (props: SelectProps) => {
     },
     [onSearch],
   );
+
   const resetSearch = useCallback(() => setSearchTerm(''), []);
+
   const optionsResult: SelectProps['options'] = useMemo(() => {
     if (searchTerm && searchTerm !== '') {
       return fuse.search(searchTerm).map(({ item }) => item);
@@ -61,26 +77,12 @@ const Select: React.FC<SelectProps> = (props: SelectProps) => {
     return options;
   }, [fuse, options, searchTerm]);
 
-  const THEME = {
-    primary:
-      'border border-gray-300 rounded-md focus:outline-none focus:ring-1 focus:ring-green-700 focus:border-green-700 pl-3 pr-10',
-    primary_bordernone: 'focus:outline-none pl-3 pr-10',
-    secondary: 'underline text-green-700 pr-2 font-bold',
-  };
-
   return (
     <Listbox value={selected} onChange={setSelected} disabled={disabled}>
       {({ open }) => (
         <>
           <div className="relative">
-            <Listbox.Button
-              className={cx(
-                'bg-white relative w-full flex align-center py-2 text-left text-sm cursor-pointer font-medium',
-                {
-                  [THEME[theme]]: !!theme,
-                },
-              )}
-            >
+            <Listbox.Button className={THEMES[theme].base}>
               {loading ? (
                 <div className="p-4">
                   <Loading className="mr-3 -ml-1 text-green-700" />
@@ -94,27 +96,17 @@ const Select: React.FC<SelectProps> = (props: SelectProps) => {
                     <span className="text-gray-300 truncate">{placeholder}</span>
                   )}
                   {selected && <span className="inline-block truncate">{selected?.label}</span>}
-                  {theme === 'secondary' && (
-                    <span className="absolute -bottom-1 left-1/2 transform -translate-x-1/2 flex items-center pointer-events-none">
-                      {open ? (
-                        <ChevronUpIcon className="h-4 w-4 text-green-700" aria-hidden="true" />
-                      ) : (
-                        <ChevronDownIcon className="h-4 w-4 text-green-700" aria-hidden="true" />
-                      )}
-                    </span>
-                  )}
-                  {theme !== 'secondary' && (
-                    <span className="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
-                      {open ? (
-                        <ChevronUpIcon className="h-4 w-4 text-gray-900" aria-hidden="true" />
-                      ) : (
-                        <ChevronDownIcon className="h-4 w-4 text-gray-900" aria-hidden="true" />
-                      )}
-                    </span>
-                  )}
                 </>
               )}
             </Listbox.Button>
+
+            <span className={classNames('absolute flex pointer-events-none', THEMES[theme].arrow)}>
+              {open ? (
+                <ChevronUpIcon className="h-4 w-4" aria-hidden="true" />
+              ) : (
+                <ChevronDownIcon className="h-4 w-4" aria-hidden="true" />
+              )}
+            </span>
 
             <Transition
               show={open}

--- a/client/src/components/select/types.d.ts
+++ b/client/src/components/select/types.d.ts
@@ -21,5 +21,5 @@ export type SelectProps = {
   searchPlaceholder?: string;
   onChange?: (selected: SelectOption) => unknown;
   onSearch?: (query: string) => unknown;
-  theme?: 'primary' | 'primary_bordernone' | 'secondary';
+  theme?: 'default' | 'default-bordernone' | 'inline-primary';
 };

--- a/client/src/components/tree-select/component.tsx
+++ b/client/src/components/tree-select/component.tsx
@@ -1,4 +1,5 @@
-import { Fragment, useCallback, useState, useMemo, useEffect } from 'react';
+import { Fragment, useCallback, useState, useMemo, useEffect, useRef } from 'react';
+import { useOutsideClick } from 'rooks';
 import classNames from 'classnames';
 import { Transition } from '@headlessui/react';
 import {
@@ -65,6 +66,8 @@ const TreeSelect: React.FC<TreeSelectProps> = ({
   const [selectedKeys, setSelectedKeys] = useState<TreeProps['selectedKeys']>([]);
   const [expandedKeys, setExpandedKeys] = useState<TreeProps['expandedKeys']>([]);
   const [checkedKeys, setCheckedKeys] = useState<TreeProps['checkedKeys']>([]);
+
+  const wrapperRef = useRef();
 
   const renderTreeNodes = useMemo(
     () =>
@@ -230,8 +233,12 @@ const TreeSelect: React.FC<TreeSelectProps> = ({
     }
   }, [current]);
 
+  useOutsideClick(wrapperRef, () => {
+    setIsOpen(false);
+  });
+
   return (
-    <div className="relative">
+    <div ref={wrapperRef} className="relative">
       {multiple ? (
         <div className="flex align-center relative" onClick={handleToggleOpen}>
           <div className={classNames('flex', THEMES_WRAPPER[theme])}>

--- a/client/src/components/tree-select/component.tsx
+++ b/client/src/components/tree-select/component.tsx
@@ -17,27 +17,22 @@ import Loading from 'components/loading';
 
 import type { TreeSelectProps, TreeSelectOption } from './types';
 
-const THEMES_TREE_NODES = {
-  default:
-    'flex items-center space-x-2 px-1 py-2 whitespace-nowrap text-sm cursor-pointer hover:bg-green-50 hover:text-green-700',
-  primary:
-    'flex items-center space-x-2 px-1 py-2 whitespace-nowrap text-sm cursor-pointer hover:bg-green-50 hover:text-green-700',
-};
-
-const THEMES_LABEL = {
-  default: 'text-gray-300',
-  primary: 'truncate text-ellipsis font-bold cursor-pointer',
-};
-
-const THEMES_WRAPPER = {
-  default:
-    'flex-wrap w-full bg-white relative border border-gray-300 rounded-md shadow-sm py-2 pr-10 pl-3 cursor-pointer',
-  primary: 'border-b-2 border-green-700 max-w-[190px] overflow-x-hidden truncate text-ellipsis',
-};
-
-const THEMES_ICON = {
-  default: 'inset-y-0 right-0 items-center pr-2  text-gray-900',
-  primary: '-bottom-3  transform left-1/2 -translate-x-1/2 text-green-700',
+const THEMES = {
+  default: {
+    label: 'text-gray-300',
+    wrapper:
+      'flex-wrap w-full bg-white relative border border-gray-300 rounded-md shadow-sm py-2 pr-10 pl-3 cursor-pointer',
+    arrow: 'inset-y-0 right-0 items-center pr-2  text-gray-900',
+    treeNodes:
+      'flex items-center space-x-2 px-1 py-2 whitespace-nowrap text-sm cursor-pointer hover:bg-green-50 hover:text-green-700',
+  },
+  'inline-primary': {
+    label: 'truncate text-ellipsis font-bold cursor-pointer px-0 py-0',
+    wrapper: 'border-b-2 border-green-700 max-w-[190px] overflow-x-hidden truncate text-ellipsis',
+    arrow: '-bottom-3  transform left-1/2 -translate-x-1/2 text-green-700',
+    treeNodes:
+      'flex items-center space-x-2 px-1 py-2 whitespace-nowrap text-sm cursor-pointer hover:bg-green-50 hover:text-green-700',
+  },
 };
 
 const SEARCH_OPTIONS = {
@@ -76,7 +71,7 @@ const TreeSelect: React.FC<TreeSelectProps> = ({
           <TreeNode
             key={item.value}
             title={item.label}
-            className={classNames(THEMES_TREE_NODES[theme], `pl-${4 * counter}`, {
+            className={classNames(THEMES[theme].treeNodes, `pl-${4 * counter}`, {
               'bg-green-50 text-green-700 font-semibold': selectedKeys.includes(item.value),
             })}
           >
@@ -213,8 +208,8 @@ const TreeSelect: React.FC<TreeSelectProps> = ({
     [checkedKeys, onChange, options],
   );
 
-  const Icon = () => (
-    <span className={classNames('absolute flex pointer-events-none', THEMES_ICON[theme])}>
+  const Arrow = () => (
+    <span className={classNames('absolute flex pointer-events-none', THEMES[theme].arrow)}>
       {isOpen ? (
         <ChevronUpIcon className="h-4 w-4" aria-hidden="true" />
       ) : (
@@ -241,17 +236,17 @@ const TreeSelect: React.FC<TreeSelectProps> = ({
     <div ref={wrapperRef} className="relative">
       {multiple ? (
         <div className="flex align-center relative" onClick={handleToggleOpen}>
-          <div className={classNames('flex', THEMES_WRAPPER[theme])}>
+          <div className={classNames('flex', THEMES[theme].wrapper)}>
             {currentOptions &&
               !!currentOptions.length &&
               !ellipsis &&
               currentOptions.slice(0, maxBadges).map((option) => (
                 <Badge
                   key={option.value}
-                  className={classNames('text-sm m-0.5', THEMES_LABEL[theme])}
+                  className={classNames('text-sm m-0.5', THEMES[theme].label)}
                   data={option}
                   onClick={handleRemoveBadget}
-                  removable={theme === 'primary' ? false : true}
+                  removable={theme === 'inline-primary' ? false : true}
                 >
                   {option.label}
                 </Badge>
@@ -259,28 +254,28 @@ const TreeSelect: React.FC<TreeSelectProps> = ({
             {currentOptions && !!currentOptions.length && ellipsis && (
               <Badge
                 key={currentOptions[0].value}
-                className={classNames('text-sm m-0.5', THEMES_LABEL[theme])}
+                className={classNames('text-sm m-0.5', THEMES[theme].label)}
                 data={currentOptions[0]}
                 onClick={handleRemoveBadget}
-                removable={theme === 'primary' ? false : true}
+                removable={theme === 'inline-primary' ? false : true}
               >
                 {currentOptions[0].label}
               </Badge>
             )}
             {currentOptions && currentOptions.length > maxBadges && (
-              <Badge className={classNames('text-sm m-0.5', THEMES_LABEL[theme])}>
+              <Badge className={classNames('text-sm m-0.5', THEMES[theme].label)}>
                 {currentOptions.length - maxBadges} more selected
               </Badge>
             )}
             {(!currentOptions || currentOptions.length === 0) && (
               <span className="inline-block truncate">
                 {placeholder && (
-                  <span className={classNames('text-sm', THEMES_LABEL[theme])}>{placeholder}</span>
+                  <span className={classNames('text-sm', THEMES[theme].label)}>{placeholder}</span>
                 )}
               </span>
             )}
           </div>
-          <Icon />
+          <Arrow />
         </div>
       ) : (
         <button
@@ -296,7 +291,7 @@ const TreeSelect: React.FC<TreeSelectProps> = ({
               <span className="text-gray-300">{placeholder}</span>
             )}
           </span>
-          <Icon />
+          <Arrow />
         </button>
       )}
       <Transition

--- a/client/src/components/tree-select/component.tsx
+++ b/client/src/components/tree-select/component.tsx
@@ -26,7 +26,7 @@ const THEMES_TREE_NODES = {
 
 const THEMES_LABEL = {
   default: 'text-gray-300',
-  primary: 'truncate text-ellipsis font-bold',
+  primary: 'truncate text-ellipsis font-bold cursor-pointer',
 };
 
 const THEMES_WRAPPER = {

--- a/client/src/components/tree-select/types.d.ts
+++ b/client/src/components/tree-select/types.d.ts
@@ -17,6 +17,6 @@ export type TreeSelectProps = {
   current: TreeSelectOptions;
   onChange?: (selected: SelectOption) => unknown;
   onSearch?: (query: string) => unknown;
-  theme?: 'primary' | 'secondary';
+  theme?: 'default' | 'inline-primary';
   ellipsis?: boolean;
 };

--- a/client/src/containers/analysis-visualization/analysis-filters/materials/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-filters/materials/component.tsx
@@ -15,7 +15,7 @@ type MaterialsFilterProps = {
   /** Only materials with sourcing locations. */
   withSourcingLocations?: MaterialsTreesParams['withSourcingLocations'];
   onChange?: TreeSelectProps['onChange'];
-  theme?: 'primary' | 'secondary';
+  theme?: 'default' | 'inline-primary';
   currentOptions?: TreeSelectProps['current'];
   ellipsis?: TreeSelectProps['ellipsis'];
 };

--- a/client/src/containers/analysis-visualization/analysis-filters/origin-regions/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-filters/origin-regions/component.tsx
@@ -13,7 +13,7 @@ type OriginRegionsFilterProps = {
   /** Only regions with sourcing locations. */
   withSourcingLocations?: AdminRegionsTreesParams['withSourcingLocations'];
   onChange?: TreeSelectProps['onChange'];
-  theme?: 'primary' | 'secondary';
+  theme?: 'default' | 'inline-primary';
   ellipsis?: TreeSelectProps['ellipsis'];
 };
 

--- a/client/src/containers/analysis-visualization/analysis-filters/suppliers/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-filters/suppliers/component.tsx
@@ -14,7 +14,7 @@ type SuppliersFilterProps = {
   /** Only suppliers with sourcing locations. */
   withSourcingLocations?: SuppliersTreesParams['withSourcingLocations'];
   onChange?: TreeSelectProps['onChange'];
-  theme?: 'primary' | 'secondary';
+  theme?: 'default' | 'inline-primary';
   ellipsis?: TreeSelectProps['ellipsis'];
 };
 

--- a/client/src/containers/growth/content/index.tsx
+++ b/client/src/containers/growth/content/index.tsx
@@ -74,33 +74,27 @@ const GowthForm = () => {
           <Label htmlFor="business">
             Growth description <span className="text-gray-600">(optional)</span>
           </Label>
-          <div className="mt-1">
-            <Textarea id="business" name="business" rows={3} className="w-full" defaultValue="" />
-          </div>
+          <Textarea id="business" name="business" rows={3} className="w-full" defaultValue="" />
         </div>
       </fieldset>
 
       <fieldset className="mt-6 grid grid-cols-2 gap-y-6 gap-x-6 sm:grid-cols-2 text-sm font-medium text-gray-700">
-        <div className="mt-1">
-          <span>Business unity</span>
-          <Select
-            loading={isLoadingBusinessUnity}
-            current={currentBusinessUnity}
-            options={optionsBusiness}
-            placeholder="Select"
-            onChange={() => onChange('business_unity', currentBusinessUnity.value)}
-          />
-        </div>
-        <div className="mt-1">
-          <span>Growth rate (Linear)</span>
-          <Select
-            loading={isLoadingGrowth}
-            current={currentGrowth}
-            options={optionsGrowth}
-            placeholder="Select"
-            onChange={() => onChange('growth', currentGrowth.value)}
-          />
-        </div>
+        <Label>Business unity</Label>
+        <Select
+          loading={isLoadingBusinessUnity}
+          current={currentBusinessUnity}
+          options={optionsBusiness}
+          placeholder="Select"
+          onChange={() => onChange('business_unity', currentBusinessUnity.value)}
+        />
+        <Label>Growth rate (Linear)</Label>
+        <Select
+          loading={isLoadingGrowth}
+          current={currentGrowth}
+          options={optionsGrowth}
+          placeholder="Select"
+          onChange={() => onChange('growth', currentGrowth.value)}
+        />
       </fieldset>
     </>
   );

--- a/client/src/containers/growth/content/index.tsx
+++ b/client/src/containers/growth/content/index.tsx
@@ -7,6 +7,7 @@ import { useAppDispatch, useAppSelector } from 'store/hooks';
 
 // components
 import Select from 'components/select';
+import Textarea from 'components/forms/textarea';
 
 // types
 import { SelectOptions, SelectOption } from 'components/select/types';
@@ -73,13 +74,7 @@ const GowthForm = () => {
             Growth description <span className="text-gray-600">(optional)</span>
           </label>
           <div className="mt-1">
-            <textarea
-              id="business"
-              name="business"
-              rows={3}
-              className="shadow-sm focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm border border-gray-300 rounded-md"
-              defaultValue=""
-            />
+            <Textarea id="business" name="business" rows={3} className="w-full" defaultValue="" />
           </div>
         </div>
       </fieldset>

--- a/client/src/containers/growth/content/index.tsx
+++ b/client/src/containers/growth/content/index.tsx
@@ -7,6 +7,7 @@ import { useAppDispatch, useAppSelector } from 'store/hooks';
 
 // components
 import Select from 'components/select';
+import Label from 'components/forms/label';
 import Textarea from 'components/forms/textarea';
 
 // types
@@ -70,9 +71,9 @@ const GowthForm = () => {
       </p>
       <fieldset className="sm:col-span-3 text-sm">
         <div className="mt-6">
-          <label htmlFor="business" className="block text-sm font-medium text-gray-700">
+          <Label htmlFor="business">
             Growth description <span className="text-gray-600">(optional)</span>
-          </label>
+          </Label>
           <div className="mt-1">
             <Textarea id="business" name="business" rows={3} className="w-full" defaultValue="" />
           </div>

--- a/client/src/containers/interventions/form/component.tsx
+++ b/client/src/containers/interventions/form/component.tsx
@@ -1,8 +1,10 @@
 import { useCallback } from 'react';
+
 import { useAppDispatch } from 'store/hooks';
-import Steps from 'components/steps';
 import { setSubContentCollapsed } from 'store/features/analysis';
 
+import Textarea from 'components/forms/textarea';
+import Steps from 'components/steps';
 import type { Step } from 'components/steps/types';
 
 const steps: Step[] = [
@@ -64,13 +66,7 @@ const InterventionForm = () => {
                   About
                 </label>
                 <div className="mt-1">
-                  <textarea
-                    id="about"
-                    name="about"
-                    rows={3}
-                    className="shadow-sm focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm border border-gray-300 rounded-md"
-                    defaultValue=""
-                  />
+                  <Textarea id="about" name="about" rows={3} className="w-full" defaultValue="" />
                 </div>
                 <p className="mt-2 text-sm text-gray-500">Write a few sentences about yourself.</p>
               </div>

--- a/client/src/containers/interventions/form/component.tsx
+++ b/client/src/containers/interventions/form/component.tsx
@@ -4,6 +4,7 @@ import { useAppDispatch } from 'store/hooks';
 import { setSubContentCollapsed } from 'store/features/analysis';
 
 import Checkbox from 'components/forms/checkbox';
+import Label from 'components/forms/label';
 import Radio from 'components/forms/radio';
 import Textarea from 'components/forms/textarea';
 import Steps from 'components/steps';
@@ -46,9 +47,7 @@ const InterventionForm = () => {
 
             <div className="mt-6 grid grid-cols-1 gap-y-6 gap-x-4 sm:grid-cols-6">
               <div className="sm:col-span-4">
-                <label htmlFor="username" className="block text-sm font-medium text-gray-700">
-                  Username
-                </label>
+                <Label htmlFor="username">Username</Label>
                 <div className="mt-1 flex rounded-md shadow-sm">
                   <span className="inline-flex items-center px-3 rounded-l-md border border-r-0 border-gray-300 bg-gray-50 text-gray-500 sm:text-sm">
                     workcation.com/
@@ -64,9 +63,7 @@ const InterventionForm = () => {
               </div>
 
               <div className="sm:col-span-6">
-                <label htmlFor="about" className="block text-sm font-medium text-gray-700">
-                  About
-                </label>
+                <Label htmlFor="about">About</Label>
                 <div className="mt-1">
                   <Textarea id="about" name="about" rows={3} className="w-full" defaultValue="" />
                 </div>
@@ -74,9 +71,7 @@ const InterventionForm = () => {
               </div>
 
               <div className="sm:col-span-6">
-                <label htmlFor="photo" className="block text-sm font-medium text-gray-700">
-                  Photo
-                </label>
+                <Label htmlFor="photo">Photo</Label>
                 <div className="mt-1 flex items-center">
                   <span className="h-12 w-12 rounded-full overflow-hidden bg-gray-100">
                     <svg
@@ -97,9 +92,7 @@ const InterventionForm = () => {
               </div>
 
               <div className="sm:col-span-6">
-                <label htmlFor="cover_photo" className="block text-sm font-medium text-gray-700">
-                  Cover photo
-                </label>
+                <Label htmlFor="cover_photo">Cover photo</Label>
                 <div className="mt-1 flex justify-center px-6 pt-5 pb-6 border-2 border-gray-300 border-dashed rounded-md">
                   <div className="space-y-1 text-center">
                     <svg
@@ -117,9 +110,9 @@ const InterventionForm = () => {
                       />
                     </svg>
                     <div className="flex text-sm text-gray-600">
-                      <label
+                      <Label
                         htmlFor="file-upload"
-                        className="relative cursor-pointer bg-white rounded-md font-medium text-indigo-600 hover:text-indigo-500 focus-within:outline-none focus-within:ring-2 focus-within:ring-offset-2 focus-within:ring-indigo-500"
+                        className="relative cursor-pointer bg-white rounded-md text-indigo-600 hover:text-indigo-500 focus-within:outline-none focus-within:ring-2 focus-within:ring-offset-2 focus-within:ring-indigo-500"
                       >
                         <span>Upload a file</span>
                         <input
@@ -128,7 +121,7 @@ const InterventionForm = () => {
                           type="file"
                           className="sr-only"
                         />
-                      </label>
+                      </Label>
                       <p className="pl-1">or drag and drop</p>
                     </div>
                     <p className="text-xs text-gray-500">PNG, JPG, GIF up to 10MB</p>
@@ -147,9 +140,7 @@ const InterventionForm = () => {
             </div>
             <div className="mt-6 grid grid-cols-1 gap-y-6 gap-x-4 sm:grid-cols-6">
               <div className="sm:col-span-3">
-                <label htmlFor="first_name" className="block text-sm font-medium text-gray-700">
-                  First name
-                </label>
+                <Label htmlFor="first_name">First name</Label>
                 <div className="mt-1">
                   <input
                     type="text"
@@ -162,9 +153,7 @@ const InterventionForm = () => {
               </div>
 
               <div className="sm:col-span-3">
-                <label htmlFor="last_name" className="block text-sm font-medium text-gray-700">
-                  Last name
-                </label>
+                <Label htmlFor="last_name">Last name</Label>
                 <div className="mt-1">
                   <input
                     type="text"
@@ -177,9 +166,7 @@ const InterventionForm = () => {
               </div>
 
               <div className="sm:col-span-4">
-                <label htmlFor="email" className="block text-sm font-medium text-gray-700">
-                  Email address
-                </label>
+                <Label htmlFor="email">Email address</Label>
                 <div className="mt-1">
                   <input
                     id="email"
@@ -192,9 +179,7 @@ const InterventionForm = () => {
               </div>
 
               <div className="sm:col-span-3">
-                <label htmlFor="country" className="block text-sm font-medium text-gray-700">
-                  Country / Region
-                </label>
+                <Label htmlFor="country">Country / Region</Label>
                 <div className="mt-1">
                   <select
                     id="country"
@@ -210,9 +195,7 @@ const InterventionForm = () => {
               </div>
 
               <div className="sm:col-span-6">
-                <label htmlFor="street_address" className="block text-sm font-medium text-gray-700">
-                  Street address
-                </label>
+                <Label htmlFor="street_address">Street address</Label>
                 <div className="mt-1">
                   <input
                     type="text"
@@ -225,9 +208,7 @@ const InterventionForm = () => {
               </div>
 
               <div className="sm:col-span-2">
-                <label htmlFor="city" className="block text-sm font-medium text-gray-700">
-                  City
-                </label>
+                <Label htmlFor="city">City</Label>
                 <div className="mt-1">
                   <input
                     type="text"
@@ -239,9 +220,7 @@ const InterventionForm = () => {
               </div>
 
               <div className="sm:col-span-2">
-                <label htmlFor="state" className="block text-sm font-medium text-gray-700">
-                  State / Province
-                </label>
+                <Label htmlFor="state">State / Province</Label>
                 <div className="mt-1">
                   <input
                     type="text"
@@ -253,9 +232,7 @@ const InterventionForm = () => {
               </div>
 
               <div className="sm:col-span-2">
-                <label htmlFor="zip" className="block text-sm font-medium text-gray-700">
-                  ZIP / Postal
-                </label>
+                <Label htmlFor="zip">ZIP / Postal</Label>
                 <div className="mt-1">
                   <input
                     type="text"
@@ -286,9 +263,7 @@ const InterventionForm = () => {
                       <Checkbox id="comments" name="comments" />
                     </div>
                     <div className="ml-3 text-sm">
-                      <label htmlFor="comments" className="font-medium text-gray-700">
-                        Comments
-                      </label>
+                      <Label htmlFor="comments">Comments</Label>
                       <p className="text-gray-500">
                         Get notified when someones posts a comment on a posting.
                       </p>
@@ -299,9 +274,7 @@ const InterventionForm = () => {
                       <Checkbox id="candidates" name="candidates" />
                     </div>
                     <div className="ml-3 text-sm">
-                      <label htmlFor="candidates" className="font-medium text-gray-700">
-                        Candidates
-                      </label>
+                      <Label htmlFor="candidates">Candidates</Label>
                       <p className="text-gray-500">
                         Get notified when a candidate applies for a job.
                       </p>
@@ -312,9 +285,7 @@ const InterventionForm = () => {
                       <Checkbox id="offers" name="offers" />
                     </div>
                     <div className="ml-3 text-sm">
-                      <label htmlFor="offers" className="font-medium text-gray-700">
-                        Offers
-                      </label>
+                      <Label htmlFor="offers">Offers</Label>
                       <p className="text-gray-500">
                         Get notified when a candidate accepts or rejects an offer.
                       </p>
@@ -334,30 +305,15 @@ const InterventionForm = () => {
                 <div className="mt-4 space-y-4">
                   <div className="flex items-center">
                     <Radio id="push_everything" name="push_notifications" />
-                    <label
-                      htmlFor="push_everything"
-                      className="ml-3 block text-sm font-medium text-gray-700"
-                    >
-                      Everything
-                    </label>
+                    <Label htmlFor="push_everything">Everything</Label>
                   </div>
                   <div className="flex items-center">
                     <Radio id="push_email" name="push_notifications" />
-                    <label
-                      htmlFor="push_email"
-                      className="ml-3 block text-sm font-medium text-gray-700"
-                    >
-                      Same as email
-                    </label>
+                    <Label htmlFor="push_email">Same as email</Label>
                   </div>
                   <div className="flex items-center">
                     <Radio id="push_nothing" name="push_notifications" />
-                    <label
-                      htmlFor="push_nothing"
-                      className="ml-3 block text-sm font-medium text-gray-700"
-                    >
-                      No push notifications
-                    </label>
+                    <Label htmlFor="push_nothing">No push notifications</Label>
                   </div>
                 </div>
               </fieldset>

--- a/client/src/containers/interventions/form/component.tsx
+++ b/client/src/containers/interventions/form/component.tsx
@@ -3,6 +3,7 @@ import { useCallback } from 'react';
 import { useAppDispatch } from 'store/hooks';
 import { setSubContentCollapsed } from 'store/features/analysis';
 
+import Checkbox from 'components/forms/checkbox';
 import Textarea from 'components/forms/textarea';
 import Steps from 'components/steps';
 import type { Step } from 'components/steps/types';
@@ -281,12 +282,7 @@ const InterventionForm = () => {
                 <div className="mt-4 space-y-4">
                   <div className="relative flex items-start">
                     <div className="flex items-center h-5">
-                      <input
-                        id="comments"
-                        name="comments"
-                        type="checkbox"
-                        className="focus:ring-indigo-500 h-4 w-4 text-indigo-600 border-gray-300 rounded"
-                      />
+                      <Checkbox id="comments" name="comments" />
                     </div>
                     <div className="ml-3 text-sm">
                       <label htmlFor="comments" className="font-medium text-gray-700">
@@ -299,12 +295,7 @@ const InterventionForm = () => {
                   </div>
                   <div className="relative flex items-start">
                     <div className="flex items-center h-5">
-                      <input
-                        id="candidates"
-                        name="candidates"
-                        type="checkbox"
-                        className="focus:ring-indigo-500 h-4 w-4 text-indigo-600 border-gray-300 rounded"
-                      />
+                      <Checkbox id="candidates" name="candidates" />
                     </div>
                     <div className="ml-3 text-sm">
                       <label htmlFor="candidates" className="font-medium text-gray-700">
@@ -317,12 +308,7 @@ const InterventionForm = () => {
                   </div>
                   <div className="relative flex items-start">
                     <div className="flex items-center h-5">
-                      <input
-                        id="offers"
-                        name="offers"
-                        type="checkbox"
-                        className="focus:ring-indigo-500 h-4 w-4 text-indigo-600 border-gray-300 rounded"
-                      />
+                      <Checkbox id="offers" name="offers" />
                     </div>
                     <div className="ml-3 text-sm">
                       <label htmlFor="offers" className="font-medium text-gray-700">

--- a/client/src/containers/interventions/form/component.tsx
+++ b/client/src/containers/interventions/form/component.tsx
@@ -4,6 +4,7 @@ import { useAppDispatch } from 'store/hooks';
 import { setSubContentCollapsed } from 'store/features/analysis';
 
 import Checkbox from 'components/forms/checkbox';
+import Radio from 'components/forms/radio';
 import Textarea from 'components/forms/textarea';
 import Steps from 'components/steps';
 import type { Step } from 'components/steps/types';
@@ -332,12 +333,7 @@ const InterventionForm = () => {
                 </div>
                 <div className="mt-4 space-y-4">
                   <div className="flex items-center">
-                    <input
-                      id="push_everything"
-                      name="push_notifications"
-                      type="radio"
-                      className="focus:ring-indigo-500 h-4 w-4 text-indigo-600 border-gray-300"
-                    />
+                    <Radio id="push_everything" name="push_notifications" />
                     <label
                       htmlFor="push_everything"
                       className="ml-3 block text-sm font-medium text-gray-700"
@@ -346,12 +342,7 @@ const InterventionForm = () => {
                     </label>
                   </div>
                   <div className="flex items-center">
-                    <input
-                      id="push_email"
-                      name="push_notifications"
-                      type="radio"
-                      className="focus:ring-indigo-500 h-4 w-4 text-indigo-600 border-gray-300"
-                    />
+                    <Radio id="push_email" name="push_notifications" />
                     <label
                       htmlFor="push_email"
                       className="ml-3 block text-sm font-medium text-gray-700"
@@ -360,12 +351,7 @@ const InterventionForm = () => {
                     </label>
                   </div>
                   <div className="flex items-center">
-                    <input
-                      id="push_nothing"
-                      name="push_notifications"
-                      type="radio"
-                      className="focus:ring-indigo-500 h-4 w-4 text-indigo-600 border-gray-300"
-                    />
+                    <Radio id="push_nothing" name="push_notifications" />
                     <label
                       htmlFor="push_nothing"
                       className="ml-3 block text-sm font-medium text-gray-700"

--- a/client/src/containers/interventions/new/component.tsx
+++ b/client/src/containers/interventions/new/component.tsx
@@ -79,16 +79,14 @@ const InterventionForm: FC = () => {
         {!!currentStep && !isFirstStep && <Step2 />}
         <div className="pt-5">
           <div className="flex justify-end">
-            <button
-              type="button"
+            <Button
               className="bg-white py-2 px-4 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
               onClick={handleCancel}
             >
               Cancel
-            </button>
+            </Button>
             {!!currentStep && !isFirstStep && (
               <Button
-                // type="button"
                 type="submit"
                 className="ml-3 inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-green-700 hover:bg-green-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
                 onClick={handleIntervention}

--- a/client/src/containers/interventions/new/step1/component.tsx
+++ b/client/src/containers/interventions/new/step1/component.tsx
@@ -175,7 +175,7 @@ const Step1: FC = () => {
             options={optionsBusinesses}
             placeholder="all businesses"
             // onChange={() => onChange('businesses', currentBusiness.value)}
-            theme="primary"
+            theme="inline-primary"
           />
           <span className="text-gray-700 font-medium">from</span>
           <Suppliers

--- a/client/src/containers/interventions/new/step1/component.tsx
+++ b/client/src/containers/interventions/new/step1/component.tsx
@@ -7,6 +7,7 @@ import { analysis, setFilter } from 'store/features/analysis';
 
 // components
 import Input from 'components/forms/input';
+import Label from 'components/forms/label';
 import Textarea from 'components/forms/textarea';
 import Select from 'components/select';
 
@@ -124,12 +125,9 @@ const Step1: FC = () => {
     <>
       <fieldset className="sm:col-span-3 text-sm">
         <div className="mt-6">
-          <label
-            htmlFor="intervention_description"
-            className="block text-sm font-medium text-gray-700"
-          >
+          <Label htmlFor="intervention_description">
             Intervention description <span className="text-gray-600">(optional)</span>
-          </label>
+          </Label>
           <div className="mt-1">
             <Textarea
               id="intervention_description"

--- a/client/src/containers/interventions/new/step1/component.tsx
+++ b/client/src/containers/interventions/new/step1/component.tsx
@@ -164,7 +164,7 @@ const Step1: FC = () => {
               current={filters.materials}
               // onChange={(values) => handleChangeFilter('materials', values)}
               onChange={handleChange}
-              theme="primary"
+              theme="inline-primary"
               ellipsis
             />
           </div>
@@ -183,7 +183,7 @@ const Step1: FC = () => {
             withSourcingLocations
             current={filters.suppliers}
             // onChange={(values) => handleChangeFilter('suppliers', values)}
-            theme="primary"
+            theme="inline-primary"
           />
           <span className="text-gray-700 font-medium">in</span>
           <OriginRegions
@@ -191,7 +191,7 @@ const Step1: FC = () => {
             withSourcingLocations
             current={filters.suppliers}
             // onChange={(values) => handleChangeFilter('suppliers', values)}
-            theme="primary"
+            theme="inline-primary"
           />
           <span className="text-gray-700 font-medium">.</span>
         </div>

--- a/client/src/containers/interventions/new/step1/component.tsx
+++ b/client/src/containers/interventions/new/step1/component.tsx
@@ -7,6 +7,7 @@ import { analysis, setFilter } from 'store/features/analysis';
 
 // components
 import Input from 'components/forms/input';
+import Textarea from 'components/forms/textarea';
 import Select from 'components/select';
 
 import Materials from 'containers/analysis-visualization/analysis-filters/materials/component';
@@ -130,11 +131,11 @@ const Step1: FC = () => {
             Intervention description <span className="text-gray-600">(optional)</span>
           </label>
           <div className="mt-1">
-            <textarea
+            <Textarea
               id="ntervention_description"
               name="ntervention_description"
               rows={3}
-              className="shadow-sm focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm border border-gray-300 rounded-md"
+              className="w-full"
               defaultValue=""
             />
           </div>

--- a/client/src/containers/interventions/new/step1/component.tsx
+++ b/client/src/containers/interventions/new/step1/component.tsx
@@ -151,9 +151,10 @@ const Step1: FC = () => {
             max={100}
             aria-label="percentage"
             placeholder="100"
-            className="border-none mr-1 will-change-contents text-green-700"
+            defaultValue={100}
+            theme="inline-primary"
+            unit="%"
           />
-          <span className="text-green-700 font-bold">%</span>
 
           <span className="text-gray-700 font-medium">of</span>
           <div className="font-bold">

--- a/client/src/containers/interventions/new/step1/component.tsx
+++ b/client/src/containers/interventions/new/step1/component.tsx
@@ -6,6 +6,7 @@ import { useAppDispatch, useAppSelector } from 'store/hooks';
 import { analysis, setFilter } from 'store/features/analysis';
 
 // components
+import Input from 'components/forms/input';
 import Select from 'components/select';
 
 import Materials from 'containers/analysis-visualization/analysis-filters/materials/component';
@@ -143,7 +144,7 @@ const Step1: FC = () => {
       <fieldset className="mt-1 flex flex-col">
         <p className="font-medium leading-5 text-sm">Apply intervention to:</p>
         <div className="flex items-center text-green-700 space-x-2">
-          <input
+          <Input
             type="number"
             name="percentage"
             id="percentage"

--- a/client/src/containers/interventions/new/step1/component.tsx
+++ b/client/src/containers/interventions/new/step1/component.tsx
@@ -30,7 +30,7 @@ const Step1: FC = () => {
 
   // const { data: materials, isLoading: isLoadingMaterials } = useMaterials();
   // const { data: businesses, isLoading: isLoadingBusinesses } = useBusinesses();
-  // const { data: supliers, isLoading: isLoadingSupliers } = useSupliers();
+  // const { data: suppliers, isLoading: isLoadingSuppliers } = useSuppliers();
   // const { data: sourcingRegions, isLoading: isLoadingSourcingRegions } = useSourcingRegions();
 
   const business = 'business2';
@@ -132,8 +132,8 @@ const Step1: FC = () => {
           </label>
           <div className="mt-1">
             <Textarea
-              id="ntervention_description"
-              name="ntervention_description"
+              id="intervention_description"
+              name="intervention_description"
               rows={3}
               className="w-full"
               defaultValue=""
@@ -220,7 +220,7 @@ const Step1: FC = () => {
               options={optionsInterventionType}
               placeholder="Select"
               onChange={handleInterventionType}
-              // onChange={({ value }) => dispatch(setFilter({ id: 'interventioType', value: value }))}
+              // onChange={({ value }) => dispatch(setFilter({ id: 'interventionType', value: value }))}
             />
           </div>
         </div>

--- a/client/src/containers/interventions/new/step2/material/component.tsx
+++ b/client/src/containers/interventions/new/step2/material/component.tsx
@@ -131,7 +131,7 @@ const Material = () => {
                 loading={isLoadingCountries}
                 current={currentCountry}
                 options={optionsCountries}
-                placeholder="all Countrys"
+                placeholder="All Countries"
                 onChange={() => onChange('all_countries', currentCountry.value)}
               />
             </div>

--- a/client/src/containers/interventions/new/step2/material/component.tsx
+++ b/client/src/containers/interventions/new/step2/material/component.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useCallback, useState } from 'react';
 
 // components
+import Input from 'components/forms/input';
 import Select from 'components/select';
 
 // containers
@@ -140,12 +141,12 @@ const Material = () => {
         <label htmlFor="address" className="mt-4 block font-medium text-gray-700">
           City / Address / Coordinates
           <div className="mt-1">
-            <input
+            <Input
+              className="w-full"
               type="text"
               name="address"
               id="address"
               autoComplete="given-address"
-              className="shadow-sm focus:ring-indigo-500 focus:border-indigo-500 block w-full border-gray-300 rounded-md"
             />
           </div>
         </label>

--- a/client/src/containers/interventions/new/step2/material/component.tsx
+++ b/client/src/containers/interventions/new/step2/material/component.tsx
@@ -141,16 +141,16 @@ const Material = () => {
 
         <Label htmlFor="address" className="mt-4">
           City / Address / Coordinates
-          <div className="mt-1">
-            <Input
-              className="w-full"
-              type="text"
-              name="address"
-              id="address"
-              autoComplete="given-address"
-            />
-          </div>
         </Label>
+        <div className="mt-1">
+          <Input
+            className="w-full"
+            type="text"
+            name="address"
+            id="address"
+            autoComplete="given-address"
+          />
+        </div>
       </fieldset>
     </>
   );

--- a/client/src/containers/interventions/new/step2/material/component.tsx
+++ b/client/src/containers/interventions/new/step2/material/component.tsx
@@ -2,6 +2,7 @@ import { useMemo, useCallback, useState } from 'react';
 
 // components
 import Input from 'components/forms/input';
+import Label from 'components/forms/label';
 import Select from 'components/select';
 
 // containers
@@ -138,7 +139,7 @@ const Material = () => {
           </div>
         </div>
 
-        <label htmlFor="address" className="mt-4 block font-medium text-gray-700">
+        <Label htmlFor="address" className="mt-4">
           City / Address / Coordinates
           <div className="mt-1">
             <Input
@@ -149,7 +150,7 @@ const Material = () => {
               autoComplete="given-address"
             />
           </div>
-        </label>
+        </Label>
       </fieldset>
     </>
   );

--- a/client/src/containers/interventions/new/step2/material/component.tsx
+++ b/client/src/containers/interventions/new/step2/material/component.tsx
@@ -81,29 +81,29 @@ const Material = () => {
 
         <div className="mt-6 grid grid-cols-2 gap-y-6 gap-x-6 sm:grid-cols-2">
           <div className="block font-medium text-gray-700">
-            Tier 1 supplier <span className="text-gray-500">(optional)</span>
-            <div className="mt-1">
-              <Select
-                loading={isLoadingProducers}
-                current={currentProducer}
-                options={optionsProducers}
-                placeholder="Select"
-                onChange={() => onChange('producer', currentProducer.value)}
-              />
-            </div>
+            <Label className="mb-1">
+              Tier 1 supplier <span className="text-gray-500">(optional)</span>
+            </Label>
+            <Select
+              loading={isLoadingProducers}
+              current={currentProducer}
+              options={optionsProducers}
+              placeholder="Select"
+              onChange={() => onChange('producer', currentProducer.value)}
+            />
           </div>
 
           <div className="block font-medium text-gray-700">
-            Producer <span className="text-gray-500">(optional)</span>
-            <div className="mt-1">
-              <Select
-                loading={isLoadingProducers}
-                current={currentProducer}
-                options={optionsProducers}
-                placeholder="Select"
-                onChange={() => onChange('producer', currentProducer.value)}
-              />
-            </div>
+            <Label className="mb-1">
+              Producer <span className="text-gray-500">(optional)</span>
+            </Label>
+            <Select
+              loading={isLoadingProducers}
+              current={currentProducer}
+              options={optionsProducers}
+              placeholder="Select"
+              onChange={() => onChange('producer', currentProducer.value)}
+            />
           </div>
         </div>
       </fieldset>
@@ -113,44 +113,38 @@ const Material = () => {
 
         <div className="mt-6 grid grid-cols-2 gap-y-6 gap-x-6 sm:grid-cols-2">
           <div className="block font-medium text-gray-700">
-            <span>Location type</span>
-            <div className="mt-1">
-              <Select
-                loading={isLoadingLocationType}
-                current={currentLocationType}
-                options={optionsLocationTypes}
-                placeholder="all LocationTypes"
-                onChange={() => onChange('all', currentLocationType.value)}
-              />
-            </div>
+            <Label className="mb-1">Location type</Label>
+            <Select
+              loading={isLoadingLocationType}
+              current={currentLocationType}
+              options={optionsLocationTypes}
+              placeholder="all LocationTypes"
+              onChange={() => onChange('all', currentLocationType.value)}
+            />
           </div>
 
           <div className="block font-medium text-gray-700">
-            <span>Country</span>
-            <div className="mt-1">
-              <Select
-                loading={isLoadingCountries}
-                current={currentCountry}
-                options={optionsCountries}
-                placeholder="All Countries"
-                onChange={() => onChange('all_countries', currentCountry.value)}
-              />
-            </div>
+            <Label className="mb-1">Country</Label>
+            <Select
+              loading={isLoadingCountries}
+              current={currentCountry}
+              options={optionsCountries}
+              placeholder="All Countries"
+              onChange={() => onChange('all_countries', currentCountry.value)}
+            />
           </div>
         </div>
 
         <Label htmlFor="address" className="mt-4">
           City / Address / Coordinates
         </Label>
-        <div className="mt-1">
-          <Input
-            className="w-full"
-            type="text"
-            name="address"
-            id="address"
-            autoComplete="given-address"
-          />
-        </div>
+        <Input
+          className="w-full"
+          type="text"
+          name="address"
+          id="address"
+          autoComplete="given-address"
+        />
       </fieldset>
     </>
   );

--- a/client/src/containers/interventions/new/step2/supplier-impact/component.tsx
+++ b/client/src/containers/interventions/new/step2/supplier-impact/component.tsx
@@ -103,22 +103,21 @@ const Step2: FC = () => {
         </div>
         <div className="mt-6 grid grid-cols-2 gap-y-6 gap-x-6 sm:grid-cols-2">
           {data.map((indicator) => (
-            <Label htmlFor={indicator.name} key={indicator.id}>
-              {indicator.name}
-              <div className="mt-1 relative">
-                <Input
-                  className="w-full"
-                  type="number"
-                  name={indicator.name}
-                  id={indicator.name}
-                  unit={indicator.unit}
-                  defaultValue={landgriffonEstimates ? indicator.value : ''}
-                  value={landgriffonEstimates ? indicator.value : indicatorsValues[indicator.name]}
-                  disabled={landgriffonEstimates}
-                  onChange={(e) => handleChange(indicator.name, Number(e?.target?.value))}
-                />
-              </div>
-            </Label>
+            <div key={indicator.name}>
+              <Label htmlFor={indicator.name} key={indicator.id}>
+                {indicator.name}
+              </Label>
+              <Input
+                type="number"
+                name={indicator.name}
+                id={indicator.name}
+                unit={indicator.unit}
+                defaultValue={landgriffonEstimates ? indicator.value : ''}
+                value={landgriffonEstimates ? indicator.value : indicatorsValues[indicator.name]}
+                disabled={landgriffonEstimates}
+                onChange={(e) => handleChange(indicator.name, Number(e?.target?.value))}
+              />
+            </div>
           ))}
         </div>
       </fieldset>

--- a/client/src/containers/interventions/new/step2/supplier-impact/component.tsx
+++ b/client/src/containers/interventions/new/step2/supplier-impact/component.tsx
@@ -3,6 +3,7 @@ import { useMemo, useCallback, useState, FC } from 'react';
 // components
 import Checkbox from 'components/forms/checkbox';
 import Input from 'components/forms/input';
+import Label from 'components/forms/label';
 
 // types
 import { setFilter } from 'store/features/analysis';
@@ -95,18 +96,14 @@ const Step2: FC = () => {
               name="landgriffon_estimates"
               onChange={() => setLandgriffonEstimates(!landgriffonEstimates)}
             />
-            <label htmlFor="landgriffon_estimates" className="ml-2 block text-sm text-gray-900">
+            <Label htmlFor="landgriffon_estimates" className="ml-2">
               Use LandGriffon location-based estimates.
-            </label>
+            </Label>
           </div>
         </div>
         <div className="mt-6 grid grid-cols-2 gap-y-6 gap-x-6 sm:grid-cols-2">
           {data.map((indicator) => (
-            <label
-              htmlFor={indicator.name}
-              key={indicator.id}
-              className="block font-medium text-gray-700"
-            >
+            <Label htmlFor={indicator.name} key={indicator.id}>
               {indicator.name}
               <div className="mt-1 relative">
                 <Input
@@ -121,7 +118,7 @@ const Step2: FC = () => {
                   onChange={(e) => handleChange(indicator.name, Number(e?.target?.value))}
                 />
               </div>
-            </label>
+            </Label>
           ))}
         </div>
       </fieldset>

--- a/client/src/containers/interventions/new/step2/supplier-impact/component.tsx
+++ b/client/src/containers/interventions/new/step2/supplier-impact/component.tsx
@@ -1,5 +1,8 @@
 import { useMemo, useCallback, useState, FC } from 'react';
 
+// components
+import Input from 'components/forms/input';
+
 // types
 import { setFilter } from 'store/features/analysis';
 
@@ -86,7 +89,7 @@ const Step2: FC = () => {
         </legend>
         <div className="flex items-center justify-between mt-6">
           <div className="flex items-center">
-            <input
+            <Input
               id="landgriffon_estimates"
               name="landgriffon_estimates"
               type="checkbox"
@@ -106,18 +109,18 @@ const Step2: FC = () => {
               className="block font-medium text-gray-700"
             >
               {indicator.name}
-              <div className="mt-1 relative flex items-center">
-                <input
+              <div className="mt-1 relative">
+                <Input
+                  className="w-full"
                   type="number"
                   name={indicator.name}
                   id={indicator.name}
+                  unit={indicator.unit}
                   defaultValue={landgriffonEstimates ? indicator.value : ''}
                   value={landgriffonEstimates ? indicator.value : indicatorsValues[indicator.name]}
-                  className="shadow-sm focus:ring-indigo-500 focus:border-indigo-500 block w-full border-gray-300 rounded-md text-gray-500"
                   disabled={landgriffonEstimates}
                   onChange={(e) => handleChange(indicator.name, Number(e?.target?.value))}
                 />
-                <span className="absolute right-2 text-gray-500">{indicator.unit}</span>
               </div>
             </label>
           ))}

--- a/client/src/containers/interventions/new/step2/supplier-impact/component.tsx
+++ b/client/src/containers/interventions/new/step2/supplier-impact/component.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useCallback, useState, FC } from 'react';
 
 // components
+import Checkbox from 'components/forms/checkbox';
 import Input from 'components/forms/input';
 
 // types
@@ -89,11 +90,9 @@ const Step2: FC = () => {
         </legend>
         <div className="flex items-center justify-between mt-6">
           <div className="flex items-center">
-            <Input
+            <Checkbox
               id="landgriffon_estimates"
               name="landgriffon_estimates"
-              type="checkbox"
-              className="h-4 w-4 text-green-600 focus:ring-green-500 border-gray-300 rounded"
               onChange={() => setLandgriffonEstimates(!landgriffonEstimates)}
             />
             <label htmlFor="landgriffon_estimates" className="ml-2 block text-sm text-gray-900">

--- a/client/src/containers/interventions/new/step2/supplier-impact/component.tsx
+++ b/client/src/containers/interventions/new/step2/supplier-impact/component.tsx
@@ -30,7 +30,7 @@ const Step2: FC = () => {
     () => [
       {
         description:
-          'The different terrestrial ecosystems play an important role storing carbon on the below-ground plant organic matter and soil. Particularly forest, through growth of trees and the increase of soil carbon, contain a large part of the carbon stored on land.\n\nActivities such us land use change or deforestation may affect carbon storage producing a disturbance of the carbon pools that may be released into the atmosphere.\n\nCarbon emissions due to land use change would therefore be the realease of carbon into the atmosphere driven by the change from forest into a specific aggriculture commodity.',
+          'The different terrestrial ecosystems play an important role storing carbon on the below-ground plant organic matter and soil. Particularly forest, through growth of trees and the increase of soil carbon, contain a large part of the carbon stored on land.\n\nActivities such us land use change or deforestation may affect carbon storage producing a disturbance of the carbon pools that may be released into the atmosphere.\n\nCarbon emissions due to land use change would therefore be the release of carbon into the atmosphere driven by the change from forest into a specific agriculture commodity.',
         id: 'c71eb531-2c8e-40d2-ae49-1049543be4d1',
         metadata: {},
         name: 'Carbon emissions',

--- a/client/src/containers/interventions/new/step2/supplier/component.tsx
+++ b/client/src/containers/interventions/new/step2/supplier/component.tsx
@@ -2,6 +2,7 @@ import { useMemo, useCallback, useState } from 'react';
 
 // components
 import Input from 'components/forms/input';
+import Label from 'components/forms/label';
 import Select from 'components/select';
 
 // containers
@@ -93,7 +94,7 @@ const Supplier = () => {
           </div>
         </div>
 
-        <label htmlFor="address" className="mt-4 block font-medium text-gray-700">
+        <Label htmlFor="address" className="mt-4">
           City / Address / Coordinates
           <div className="mt-1">
             <Input
@@ -104,7 +105,7 @@ const Supplier = () => {
               autoComplete="given-address"
             />
           </div>
-        </label>
+        </Label>
       </fieldset>
     </>
   );

--- a/client/src/containers/interventions/new/step2/supplier/component.tsx
+++ b/client/src/containers/interventions/new/step2/supplier/component.tsx
@@ -86,7 +86,7 @@ const Supplier = () => {
                 loading={isLoadingCountries}
                 current={currentCountry}
                 options={optionsCountries}
-                placeholder="all Countrys"
+                placeholder="All Countries"
                 onChange={() => onChange('all_countries', currentCountry.value)}
               />
             </div>

--- a/client/src/containers/interventions/new/step2/supplier/component.tsx
+++ b/client/src/containers/interventions/new/step2/supplier/component.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useCallback, useState } from 'react';
 
 // components
+import Input from 'components/forms/input';
 import Select from 'components/select';
 
 // containers
@@ -95,12 +96,12 @@ const Supplier = () => {
         <label htmlFor="address" className="mt-4 block font-medium text-gray-700">
           City / Address / Coordinates
           <div className="mt-1">
-            <input
+            <Input
+              className="w-full"
               type="text"
               name="address"
               id="address"
               autoComplete="given-address"
-              className="shadow-sm focus:ring-indigo-500 focus:border-indigo-500 block w-full border-gray-300 rounded-md"
             />
           </div>
         </label>

--- a/client/src/containers/interventions/new/step2/supplier/component.tsx
+++ b/client/src/containers/interventions/new/step2/supplier/component.tsx
@@ -96,16 +96,16 @@ const Supplier = () => {
 
         <Label htmlFor="address" className="mt-4">
           City / Address / Coordinates
-          <div className="mt-1">
-            <Input
-              className="w-full"
-              type="text"
-              name="address"
-              id="address"
-              autoComplete="given-address"
-            />
-          </div>
         </Label>
+        <div className="mt-1">
+          <Input
+            className="w-full"
+            type="text"
+            name="address"
+            id="address"
+            autoComplete="given-address"
+          />
+        </div>
       </fieldset>
     </>
   );

--- a/client/src/containers/interventions/new/step2/supplier/component.tsx
+++ b/client/src/containers/interventions/new/step2/supplier/component.tsx
@@ -97,15 +97,13 @@ const Supplier = () => {
         <Label htmlFor="address" className="mt-4">
           City / Address / Coordinates
         </Label>
-        <div className="mt-1">
-          <Input
-            className="w-full"
-            type="text"
-            name="address"
-            id="address"
-            autoComplete="given-address"
-          />
-        </div>
+        <Input
+          className="w-full"
+          type="text"
+          name="address"
+          id="address"
+          autoComplete="given-address"
+        />
       </fieldset>
     </>
   );

--- a/client/src/containers/scenarios/filters/component.tsx
+++ b/client/src/containers/scenarios/filters/component.tsx
@@ -102,7 +102,7 @@ const ScenariosFilters = () => {
       </ul>
 
       <Select
-        theme="primary_bordernone"
+        theme="default-bordernone"
         current={SORT_OPTIONS[0]}
         options={SORT_OPTIONS}
         onChange={handleSort}

--- a/client/src/containers/scenarios/new/index.tsx
+++ b/client/src/containers/scenarios/new/index.tsx
@@ -31,7 +31,7 @@ const ScenariosNewContainer: React.FC = () => {
           name="title"
           id="title"
           placeholder="Untitled"
-          aria-label="sceanrio title"
+          aria-label="Scenario title"
           autoFocus
           className="flex-1 block w-full md:text-2xl sm:text-sm border-none text-gray-400 p-0 font-semibold mb-6"
         />

--- a/client/src/containers/scenarios/new/index.tsx
+++ b/client/src/containers/scenarios/new/index.tsx
@@ -3,6 +3,7 @@ import { useQuery } from 'react-query';
 import { createScenario } from 'services/scenarios';
 
 import InterventionsAttributes from 'containers/scenarios/attributes';
+import Textarea from 'components/forms/textarea';
 import { useAppDispatch } from 'store/hooks';
 import { setSubContentCollapsed } from 'store/features/analysis';
 
@@ -40,11 +41,11 @@ const ScenariosNewContainer: React.FC = () => {
             Scenario description <span className="text-gray-500">(optional)</span>
           </label>
           <div className="mt-1">
-            <textarea
+            <Textarea
               id="description"
               name="description"
               rows={3}
-              className="shadow-sm focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm border border-gray-300 rounded-md"
+              className="w-full"
               defaultValue=""
             />
           </div>

--- a/client/src/containers/scenarios/new/index.tsx
+++ b/client/src/containers/scenarios/new/index.tsx
@@ -41,15 +41,13 @@ const ScenariosNewContainer: React.FC = () => {
           <Label htmlFor="description">
             Scenario description <span className="text-gray-500">(optional)</span>
           </Label>
-          <div className="mt-1">
-            <Textarea
-              id="description"
-              name="description"
-              rows={3}
-              className="w-full"
-              defaultValue=""
-            />
-          </div>
+          <Textarea
+            id="description"
+            name="description"
+            rows={3}
+            className="w-full"
+            defaultValue=""
+          />
         </div>
       </form>
       <div className="h-full flex flex-col w-auto bg-white py-6 overflow-auto relative">

--- a/client/src/containers/scenarios/new/index.tsx
+++ b/client/src/containers/scenarios/new/index.tsx
@@ -3,6 +3,7 @@ import { useQuery } from 'react-query';
 import { createScenario } from 'services/scenarios';
 
 import InterventionsAttributes from 'containers/scenarios/attributes';
+import Label from 'components/forms/label';
 import Textarea from 'components/forms/textarea';
 import { useAppDispatch } from 'store/hooks';
 import { setSubContentCollapsed } from 'store/features/analysis';
@@ -37,9 +38,9 @@ const ScenariosNewContainer: React.FC = () => {
         />
 
         <div className="sm:col-span-6">
-          <label htmlFor="description" className="block text-sm text-gray-900">
+          <Label htmlFor="description">
             Scenario description <span className="text-gray-500">(optional)</span>
-          </label>
+          </Label>
           <div className="mt-1">
             <Textarea
               id="description"

--- a/client/src/pages/admin/users.tsx
+++ b/client/src/pages/admin/users.tsx
@@ -1,18 +1,21 @@
 import { useMemo } from 'react';
+import { useDebounce } from '@react-hook/debounce';
 import { ITableProps } from 'ka-table';
 import { DataType } from 'ka-table/enums';
-import { debounce } from 'lodash';
 import dynamic from 'next/dynamic';
 import { PlusIcon } from '@heroicons/react/solid';
 
 import AdminLayout, { ADMIN_TABS } from 'layouts/admin';
 import Button from 'components/button';
+import Search from 'components/search';
 
 type ITableData = ITableProps;
 
 const TableNoSSR = dynamic(() => import('containers/table'), { ssr: false });
 
 const AdminUsersPage: React.FC = () => {
+  const [searchText, setSearchText] = useDebounce('', 250);
+
   const tableData = Array(100)
     .fill(undefined)
     .map((_, index) => ({
@@ -21,10 +24,6 @@ const AdminUsersPage: React.FC = () => {
       title: `Title: ${index}`,
       role: `Role: ${index}`,
     }));
-
-  const handleSearch = debounce(({ target }: { target: HTMLInputElement }): void => {
-    console.info('Search: ', target.value);
-  }, 200);
 
   const tableProps: ITableData = useMemo(
     () => ({
@@ -44,13 +43,7 @@ const AdminUsersPage: React.FC = () => {
     <AdminLayout currentTab={ADMIN_TABS.USERS}>
       <div className="flex flex-col-reverse md:flex-row justify-between items-center">
         <div className="flex w-full md:w-auto gap-2">
-          <input
-            className="w-full md:w-auto bg-white border border-gray-300 rounded-md shadow-sm text-left focus:outline-none focus:ring-1 focus:ring-green-700 focus:border-green-700 text-sm font-medium"
-            type="search"
-            placeholder="Search table"
-            defaultValue=""
-            onChange={handleSearch}
-          />
+          <Search placeholder="Search table" onChange={setSearchText} />
         </div>
         <div className="flex items-center">
           <Button theme="primary" onClick={() => console.info('Add user: click')}>


### PR DESCRIPTION
## Description  

### In this PR

**Components changes:** 
- New `Textarea` component:  
  - With `theme`, `errors` support
- New `Radio` component:  
  - With `theme`, `errors` support
- `Input` component changes:
  - Added `theme` support  
  - Added new `inline-primary` theme  
  - Added `Icon` support  _We can now pass it an icon and it'll display it inside the input, with correct paddings (see the admin/data search input)_
  - Added `unit` support _We can now pass it a unit, and it'll display it inside the input, with correct paddings (see analysis/intervention/step 2)_
- `Checkbox` component changes:  
    - Added `theme` support  
- `Label` component changes:
    - Added `theme` support  
- `Select` component changes: 
    - Added an `inline-primary` theme  
    - Fixed a label/arrow misalignment when using the `default-bordernone` theme
- `TreeSelect` component changes:
    - Added an `inline-primary` theme (matching the one for `Select`)  
    - Minor refactor to keep theme names consistent between elements

**Others:**  
- Fixed several typos in the Scenarios forms   
- Removed several `div` wrappers which would only add a `mt-1` to components
  _The margin top that had been used throughout the app got embedded in the form components_  
- Replaced the HTML elements with our custom styled components in several forms
- Standardised how `label`s were being used throughout the app (wrapping inputs vs not)

**Notes:**
A lot could still be improved, but it'd turn into a monster PR. Already is, in some ways. 

## JIRA  

[LANDGRIF-534](https://vizzuality.atlassian.net/browse/LANDGRIF-534)
