### PR TITLE
fixed session object for users

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -77,7 +77,7 @@
     "react-dropzone": "^11.5.1",
     "react-hook-form": "7.27.1",
     "react-map-gl": "^6.1.15",
-    "react-query": "^3.16.0",
+    "react-query": "3.34.16",
     "react-redux": "^7.2.4",
     "react-spring": "^9.4.2",
     "rooks": "^5.10.0",

--- a/client/src/pages/api/auth/[...nextauth].ts
+++ b/client/src/pages/api/auth/[...nextauth].ts
@@ -50,7 +50,17 @@ const options: NextAuthOptions = {
 
         const { data, status } = signInRequest;
 
-        if (status === 201) return data;
+        // Parsing session data
+        if (data && status === 201) {
+          return {
+            ...data.user,
+            name:
+              data.displayName ||
+              (data.user.fname && data.user.lname ? `${data.user.fname} ${data.user.lname}` : null),
+            picture: data.user.avatarDataUrl,
+            accessToken: data.accessToken,
+          };
+        }
 
         return null;
       },
@@ -59,7 +69,7 @@ const options: NextAuthOptions = {
 
   callbacks: {
     // Assigning encoded token from API to token created in the session
-    jwt({ token, account: user }) {
+    jwt({ token, user }) {
       const newToken = { ...token };
 
       if (user) {

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -7755,10 +7755,10 @@ react-map-gl@^6.1.15:
     resize-observer-polyfill "^1.5.1"
     viewport-mercator-project "^7.0.4"
 
-react-query@^3.16.0:
-  version "3.32.1"
-  resolved "https://registry.yarnpkg.com/react-query/-/react-query-3.32.1.tgz#829a87d039ece85660d8911ac59b1c92d1879064"
-  integrity sha512-7UN8BYBaZb911iJUyJ/T+CjlBGBf5W8rcm3jRQ5wW4f+mt/onvRxJlB0U2r2fsT204poJt6VO0jPlm5dwu3PrQ==
+react-query@3.34.16:
+  version "3.34.16"
+  resolved "https://registry.yarnpkg.com/react-query/-/react-query-3.34.16.tgz#279ea180bcaeaec49c7864b29d1711ee9f152594"
+  integrity sha512-7FvBvjgEM4YQ8nPfmAr+lJfbW95uyW/TVjFoi2GwCkF33/S8ajx45tuPHPFGWs4qYwPy1mzwxD4IQfpUDrefNQ==
   dependencies:
     "@babel/runtime" "^7.5.5"
     broadcast-channel "^3.4.1"


### PR DESCRIPTION
This PR allows you to use `useSession` to get the `name`, `email`, and `accessToken`.

Changelog:
* Upgrade to react-query v3.34.16