### PR TITLE
Feature LANDGRIF-548 calculate impact for new interventions

### DIFF
--- a/api/src/migrations/1645259040554-ImpactStoredFunctions.ts
+++ b/api/src/migrations/1645259040554-ImpactStoredFunctions.ts
@@ -278,6 +278,8 @@ export class ImpactStoredFunctions1645259040554 implements MigrationInterface {
 
     DROP FUNCTION IF EXISTS sum_weighted_carbon_over_georegion();
 
+    DROP FUNCTION IF EXISTS sum_material_over_georegion()
+
     `);
   }
 }

--- a/api/src/modules/geo-coding/errors/geo-coding.error.ts
+++ b/api/src/modules/geo-coding/errors/geo-coding.error.ts
@@ -1,0 +1,1 @@
+export class GeoCodingError extends Error {}

--- a/api/src/modules/geo-coding/geocoders/google-maps.geocoder.ts
+++ b/api/src/modules/geo-coding/geocoders/google-maps.geocoder.ts
@@ -11,6 +11,7 @@ import {
   GeocodeArgs,
   GeocoderInterface,
 } from 'modules/geo-coding/geocoders/geocoder.interface';
+import { GeoCodingError } from 'modules/geo-coding/errors/geo-coding.error';
 
 export class GoogleMapsGeocoder implements GeocoderInterface {
   private logger: Logger = new Logger(GoogleMapsGeocoder.name);
@@ -44,9 +45,9 @@ export class GoogleMapsGeocoder implements GeocoderInterface {
         `Google geocoding API request failed. Please make sure that a correct API key is provided`,
       );
     }
-    if (!response?.data) {
-      throw new UnprocessableEntityException(
-        `Google geocoding API request failed. Please make sure that a correct API key is provided`,
+    if (!response.data.results.length) {
+      throw new GeoCodingError(
+        `Could not GeoLocate new Location by address: ${args}. Please make sure your Address info is correct`,
       );
     }
     return response.data;
@@ -62,6 +63,12 @@ export class GoogleMapsGeocoder implements GeocoderInterface {
     const geocodeResponseData: GeocodeResponseData = await this.geocode(
       geocodeRequest,
     );
+
+    if (!geocodeResponseData.results.length) {
+      throw new GeoCodingError(
+        `Could not GeoLocate new Location by Coordinates Latitude ${coordinates.lat} and Longitude: ${coordinates.lng}. Please make sure your Location info is correct`,
+      );
+    }
     return geocodeResponseData;
   }
 }

--- a/api/src/modules/geo-coding/geocoders/google-maps.geocoder.ts
+++ b/api/src/modules/geo-coding/geocoders/google-maps.geocoder.ts
@@ -45,9 +45,11 @@ export class GoogleMapsGeocoder implements GeocoderInterface {
         `Google geocoding API request failed. Please make sure that a correct API key is provided`,
       );
     }
+
+    console.log('ARGS', args, response);
     if (!response.data.results.length) {
       throw new GeoCodingError(
-        `Could not GeoLocate new Location by address: ${args}. Please make sure your Address info is correct`,
+        `Could not GeoLocate new Location by address: ${args.address}. Please make sure your Address info is correct`,
       );
     }
     return response.data;

--- a/api/src/modules/geo-coding/geocoders/google-maps.geocoder.ts
+++ b/api/src/modules/geo-coding/geocoders/google-maps.geocoder.ts
@@ -46,7 +46,6 @@ export class GoogleMapsGeocoder implements GeocoderInterface {
       );
     }
 
-    console.log('ARGS', args, response);
     if (!response.data.results.length) {
       throw new GeoCodingError(
         `Could not GeoLocate new Location by address: ${args.address}. Please make sure your Address info is correct`,

--- a/api/src/modules/import-data/sourcing-data/sourcing-data-import.service.ts
+++ b/api/src/modules/import-data/sourcing-data/sourcing-data-import.service.ts
@@ -109,7 +109,7 @@ export class SourcingDataImportService {
           dtoMatchedData.sourcingData,
         );
 
-      // TODO: TBD What to do when there is some location where we cannot determine it's admin-region: i.e coordinates
+      // TODO: TBD What to do when there is some location where we cannot determine its admin-region: i.e coordinates
       //       in the middle of the sea
       const geoCodedSourcingData: SourcingData[] =
         await this.geoCodingService.geoCodeLocations(
@@ -122,7 +122,7 @@ export class SourcingDataImportService {
 
       // TODO: Current approach calculates Impact for all Sourcing Records present in the DB
       //       Getting H3 data for calculations is done within DB so we need to improve the error handling
-      //       TBD: What to when is no H3 for a Material
+      //       TBD: What to do when there is no H3 for a Material
       try {
         await this.indicatorRecordsService.createIndicatorRecordsForAllSourcingRecords();
         this.logger.log('Indicator Records generated');

--- a/api/src/modules/indicator-coefficients/dto/indicator-coefficients.dto.ts
+++ b/api/src/modules/indicator-coefficients/dto/indicator-coefficients.dto.ts
@@ -1,24 +1,32 @@
 import { INDICATOR_TYPES } from 'modules/indicators/indicator.entity';
-import { IsNotEmpty, IsNumber } from 'class-validator';
+import { IsNotEmpty, IsNumber, Max, Min } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 
 export class IndicatorCoefficientsDto {
   @ApiProperty()
+  @Max(100)
+  @Min(0)
   @IsNotEmpty()
   @IsNumber()
   [INDICATOR_TYPES.DEFORESTATION]: number;
 
   @ApiProperty()
+  @Max(100)
+  @Min(0)
   @IsNotEmpty()
   @IsNumber()
   [INDICATOR_TYPES.UNSUSTAINABLE_WATER_USE]: number;
 
   @ApiProperty()
+  @Max(100)
+  @Min(0)
   @IsNotEmpty()
   @IsNumber()
   [INDICATOR_TYPES.BIODIVERSITY_LOSS]: number;
 
   @ApiProperty()
+  @Max(100)
+  @Min(0)
   @IsNotEmpty()
   @IsNumber()
   [INDICATOR_TYPES.CARBON_EMISSIONS]: number;

--- a/api/src/modules/indicator-coefficients/dto/indicator-coefficients.dto.ts
+++ b/api/src/modules/indicator-coefficients/dto/indicator-coefficients.dto.ts
@@ -1,0 +1,25 @@
+import { INDICATOR_TYPES } from 'modules/indicators/indicator.entity';
+import { IsNotEmpty, IsNumber } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class IndicatorCoefficientsDto {
+  @ApiProperty()
+  @IsNotEmpty()
+  @IsNumber()
+  [INDICATOR_TYPES.DEFORESTATION]: number;
+
+  @ApiProperty()
+  @IsNotEmpty()
+  @IsNumber()
+  [INDICATOR_TYPES.UNSUSTAINABLE_WATER_USE]: number;
+
+  @ApiProperty()
+  @IsNotEmpty()
+  @IsNumber()
+  [INDICATOR_TYPES.BIODIVERSITY_LOSS]: number;
+
+  @ApiProperty()
+  @IsNotEmpty()
+  @IsNumber()
+  [INDICATOR_TYPES.CARBON_EMISSIONS]: number;
+}

--- a/api/src/modules/indicator-coefficients/interfaces/indicator-coefficients.interface.ts
+++ b/api/src/modules/indicator-coefficients/interfaces/indicator-coefficients.interface.ts
@@ -1,8 +1,0 @@
-import { INDICATOR_TYPES } from 'modules/indicators/indicator.entity';
-
-export interface IndicatorCoefficientsInterface {
-  [INDICATOR_TYPES.DEFORESTATION]: number;
-  [INDICATOR_TYPES.UNSUSTAINABLE_WATER_USE]: number;
-  [INDICATOR_TYPES.BIODIVERSITY_LOSS]: number;
-  [INDICATOR_TYPES.CARBON_EMISSIONS]: number;
-}

--- a/api/src/modules/indicator-coefficients/interfaces/indicator-coefficients.interface.ts
+++ b/api/src/modules/indicator-coefficients/interfaces/indicator-coefficients.interface.ts
@@ -1,0 +1,8 @@
+import { INDICATOR_TYPES } from 'modules/indicators/indicator.entity';
+
+export interface IndicatorCoefficientsInterface {
+  [INDICATOR_TYPES.DEFORESTATION]: number;
+  [INDICATOR_TYPES.UNSUSTAINABLE_WATER_USE]: number;
+  [INDICATOR_TYPES.BIODIVERSITY_LOSS]: number;
+  [INDICATOR_TYPES.CARBON_EMISSIONS]: number;
+}

--- a/api/src/modules/indicator-records/indicator-record.repository.ts
+++ b/api/src/modules/indicator-records/indicator-record.repository.ts
@@ -9,10 +9,6 @@ export class IndicatorRecordRepository extends Repository<IndicatorRecord> {
 
   /**
    * @description Calculate Raw Indicator values given a GeoRegion Id and Material Id:
-   * @todo: This most likely will change to fit PR: https://github.com/Vizzuality/landgriffon/pull/231/
-   *        once it's merged
-   *
-   *@todo: Add proper typing when functionally validated with Science
    */
   async getIndicatorRawDataByGeoRegionAndMaterial(
     geoRegionId: string,
@@ -37,7 +33,7 @@ export class IndicatorRecordRepository extends Repository<IndicatorRecord> {
         `Could not calculate raw Indicator values for GeoRegion Id: ${geoRegionId} and Material Id: ${materialId} `,
       );
       throw new ServiceUnavailableException(
-        `Could not calculate Raw Indicator values for new Scenario`,
+        `Could not calculate Raw Indicator values for new Scenario: ${error.message}`,
       );
     }
   }

--- a/api/src/modules/indicator-records/indicator-records.service.ts
+++ b/api/src/modules/indicator-records/indicator-records.service.ts
@@ -364,7 +364,7 @@ export class IndicatorRecordsService extends AppBaseService<
       );
     } else {
       const materialH3Data: MaterialToH3 | undefined =
-        await this.materialsToH3sService.findOne(materialId);
+        await this.materialsToH3sService.findOne({ where: { materialId } });
       if (!materialH3Data) {
         throw new MissingH3DataError(
           `No H3 Data required for calculate Impact for Material with ID: ${materialId}`,

--- a/api/src/modules/indicator-records/indicator-records.service.ts
+++ b/api/src/modules/indicator-records/indicator-records.service.ts
@@ -21,7 +21,10 @@ import {
 import { H3DataService } from 'modules/h3-data/h3-data.service';
 import { H3Data } from 'modules/h3-data/h3-data.entity';
 import { MissingH3DataError } from 'modules/indicator-records/errors/missing-h3-data.error';
-import { MATERIAL_TO_H3_TYPE } from 'modules/materials/material-to-h3.entity';
+import {
+  MATERIAL_TO_H3_TYPE,
+  MaterialToH3,
+} from 'modules/materials/material-to-h3.entity';
 import { MaterialsToH3sService } from 'modules/materials/materials-to-h3s.service';
 import * as config from 'config';
 import { H3DataYearsService } from 'modules/h3-data/services/h3-data-years.service';
@@ -344,7 +347,12 @@ export class IndicatorRecordsService extends AppBaseService<
    */
 
   async createIndicatorRecordsBySourcingRecords(
-    sourcingData: any,
+    sourcingData: {
+      sourcingRecordId: string;
+      geoRegionId: string;
+      materialId: string;
+      tonnage: number;
+    },
     providedCoefficients?: IndicatorCoefficientsDto,
   ): Promise<any> {
     const { geoRegionId, materialId } = sourcingData;
@@ -355,6 +363,13 @@ export class IndicatorRecordsService extends AppBaseService<
         sourcingData,
       );
     } else {
+      const materialH3Data: MaterialToH3 | undefined =
+        await this.materialsToH3sService.findOne(materialId);
+      if (!materialH3Data) {
+        throw new MissingH3DataError(
+          `No H3 Data required for calculate Impact for Material with ID: ${materialId}`,
+        );
+      }
       const rawData: IndicatorComputedRawDataDto =
         await this.indicatorRecordRepository.getIndicatorRawDataByGeoRegionAndMaterial(
           geoRegionId as string,

--- a/api/src/modules/indicators/dto/indicator-computed-raw-data.dto.ts
+++ b/api/src/modules/indicators/dto/indicator-computed-raw-data.dto.ts
@@ -1,0 +1,13 @@
+/**
+ * @description Raw indicator data computed in DB using stored functions of migration: XXXXXX
+ * used to calculate impact for a Intervention
+ */
+
+export class IndicatorComputedRawDataDto {
+  production: number;
+  harvestedArea: number;
+  rawDeforestation: number;
+  rawBiodiversity: number;
+  rawCarbon: number;
+  rawWater: number;
+}

--- a/api/src/modules/scenario-interventions/dto/create.scenario-intervention.dto.ts
+++ b/api/src/modules/scenario-interventions/dto/create.scenario-intervention.dto.ts
@@ -81,7 +81,7 @@ export class CreateScenarioInterventionDto {
   @IsUUID()
   @IsOptional()
   @ApiPropertyOptional()
-  newSupplierT1Id?: string;
+  newT1SupplierId?: string;
 
   @IsUUID()
   @IsOptional()
@@ -105,19 +105,12 @@ export class CreateScenarioInterventionDto {
   @ApiPropertyOptional()
   newLocationType?: LOCATION_TYPES;
 
-  @ValidateIf(
-    (dto: CreateScenarioInterventionDto) =>
-      (dto.type === SCENARIO_INTERVENTION_TYPE.NEW_MATERIAL ||
-        dto.type === SCENARIO_INTERVENTION_TYPE.NEW_SUPPLIER) &&
-      (dto.newLocationType === LOCATION_TYPES.ORIGIN_COUNTRY ||
-        dto.newLocationType === LOCATION_TYPES.COUNTRY_OF_PRODUCTION),
-  )
   @IsNotEmpty({
     message:
       'New country input is required for the selected intervention and location type',
   })
-  @ApiPropertyOptional()
-  newCountryInput?: string;
+  @ApiProperty()
+  newLocationCountryInput!: string;
 
   @ValidateIf(
     (dto: CreateScenarioInterventionDto) =>

--- a/api/src/modules/scenario-interventions/dto/create.scenario-intervention.dto.ts
+++ b/api/src/modules/scenario-interventions/dto/create.scenario-intervention.dto.ts
@@ -126,11 +126,6 @@ export class CreateScenarioInterventionDto {
   @ApiPropertyOptional()
   newLocationAddressInput?: string;
 
-  @IsUUID()
-  @IsOptional()
-  @ApiPropertyOptional()
-  newGeoRegionId?: string;
-
   @ValidateIf(
     (dto: CreateScenarioInterventionDto) =>
       dto.type === SCENARIO_INTERVENTION_TYPE.NEW_MATERIAL,

--- a/api/src/modules/scenario-interventions/dto/create.scenario-intervention.dto.ts
+++ b/api/src/modules/scenario-interventions/dto/create.scenario-intervention.dto.ts
@@ -112,19 +112,14 @@ export class CreateScenarioInterventionDto {
   @ApiProperty()
   newLocationCountryInput!: string;
 
-  @ValidateIf(
-    (dto: CreateScenarioInterventionDto) =>
-      (dto.type === SCENARIO_INTERVENTION_TYPE.NEW_MATERIAL ||
-        dto.type === SCENARIO_INTERVENTION_TYPE.NEW_SUPPLIER) &&
-      (dto.newLocationType === LOCATION_TYPES.AGGREGATION_POINT ||
-        dto.newLocationType === LOCATION_TYPES.POINT_OF_PRODUCTION),
-  )
-  @IsNotEmpty({
-    message:
-      'New address or coordinates input is required for the selected intervention and location type',
-  })
   @ApiPropertyOptional()
   newLocationAddressInput?: string;
+
+  @ApiPropertyOptional()
+  newLocationLatitude?: number;
+
+  @ApiPropertyOptional()
+  newLocationLongitude?: number;
 
   @ValidateIf(
     (dto: CreateScenarioInterventionDto) =>

--- a/api/src/modules/scenario-interventions/dto/create.scenario-intervention.dto.ts
+++ b/api/src/modules/scenario-interventions/dto/create.scenario-intervention.dto.ts
@@ -13,6 +13,7 @@ import {
 } from 'class-validator';
 import { SCENARIO_INTERVENTION_TYPE } from 'modules/scenario-interventions/scenario-intervention.entity';
 import { LOCATION_TYPES } from 'modules/sourcing-locations/sourcing-location.entity';
+import { IndicatorCoefficientsInterface } from 'modules/indicator-coefficients/interfaces/indicator-coefficients.interface';
 
 export class CreateScenarioInterventionDto {
   @IsString()
@@ -76,7 +77,7 @@ export class CreateScenarioInterventionDto {
   @IsJSON()
   @IsNotEmpty()
   @ApiProperty()
-  newIndicatorCoefficients!: JSON;
+  newIndicatorCoefficients!: IndicatorCoefficientsInterface;
 
   @IsUUID()
   @IsOptional()

--- a/api/src/modules/scenario-interventions/dto/create.scenario-intervention.dto.ts
+++ b/api/src/modules/scenario-interventions/dto/create.scenario-intervention.dto.ts
@@ -107,7 +107,7 @@ export class CreateScenarioInterventionDto {
 
   @IsNotEmpty({
     message:
-      'New country input is required for the selected intervention and location type',
+      'New Location Country input is required for the selected intervention and location type',
   })
   @ApiProperty()
   newLocationCountryInput!: string;
@@ -124,7 +124,7 @@ export class CreateScenarioInterventionDto {
       'New address or coordinates input is required for the selected intervention and location type',
   })
   @ApiPropertyOptional()
-  newAddressInput?: string;
+  newLocationAddressInput?: string;
 
   @IsUUID()
   @IsOptional()

--- a/api/src/modules/scenario-interventions/dto/create.scenario-intervention.dto.ts
+++ b/api/src/modules/scenario-interventions/dto/create.scenario-intervention.dto.ts
@@ -1,7 +1,6 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import {
   IsEnum,
-  IsJSON,
   IsNotEmpty,
   IsNumber,
   IsOptional,
@@ -10,10 +9,12 @@ import {
   MaxLength,
   MinLength,
   ValidateIf,
+  ValidateNested,
 } from 'class-validator';
 import { SCENARIO_INTERVENTION_TYPE } from 'modules/scenario-interventions/scenario-intervention.entity';
 import { LOCATION_TYPES } from 'modules/sourcing-locations/sourcing-location.entity';
-import { IndicatorCoefficientsInterface } from 'modules/indicator-coefficients/interfaces/indicator-coefficients.interface';
+import { IndicatorCoefficientsDto } from 'modules/indicator-coefficients/dto/indicator-coefficients.dto';
+import { Type } from 'class-transformer';
 
 export class CreateScenarioInterventionDto {
   @IsString()
@@ -74,10 +75,15 @@ export class CreateScenarioInterventionDto {
   @ApiProperty()
   adminRegionsIds?: string[];
 
-  @IsJSON()
-  @IsNotEmpty()
-  @ApiProperty()
-  newIndicatorCoefficients!: IndicatorCoefficientsInterface;
+  @IsOptional()
+  @ApiPropertyOptional()
+  @ValidateIf(
+    (dto: CreateScenarioInterventionDto) =>
+      dto.newIndicatorCoefficients !== null,
+  )
+  @ValidateNested()
+  @Type(() => IndicatorCoefficientsDto)
+  newIndicatorCoefficients?: IndicatorCoefficientsDto;
 
   @IsUUID()
   @IsOptional()

--- a/api/src/modules/scenario-interventions/scenario-intervention.entity.ts
+++ b/api/src/modules/scenario-interventions/scenario-intervention.entity.ts
@@ -92,7 +92,7 @@ export class ScenarioIntervention extends TimestampedBaseEntity {
   @Column()
   percentage!: number;
 
-  @Column({ type: 'jsonb' })
+  @Column({ type: 'jsonb', nullable: true })
   @ApiProperty()
   newIndicatorCoefficients!: JSON;
 

--- a/api/src/modules/scenario-interventions/scenario-intervention.entity.ts
+++ b/api/src/modules/scenario-interventions/scenario-intervention.entity.ts
@@ -68,7 +68,7 @@ export class ScenarioIntervention extends TimestampedBaseEntity {
   @Column({
     type: 'enum',
     enum: SCENARIO_INTERVENTION_STATUS,
-    default: SCENARIO_INTERVENTION_STATUS.INACTIVE,
+    default: SCENARIO_INTERVENTION_STATUS.ACTIVE,
   })
   status!: SCENARIO_INTERVENTION_STATUS;
 

--- a/api/src/modules/scenario-interventions/scenario-interventions.module.ts
+++ b/api/src/modules/scenario-interventions/scenario-interventions.module.ts
@@ -6,10 +6,12 @@ import { ScenarioInterventionRepository } from 'modules/scenario-interventions/s
 import { ScenarioInterventionsController } from 'modules/scenario-interventions/scenario-interventions.controller';
 import { ScenarioInterventionsService } from 'modules/scenario-interventions/scenario-interventions.service';
 import { SourcingLocationsModule } from 'modules/sourcing-locations/sourcing-locations.module';
+import { IndicatorRecordsModule } from 'modules/indicator-records/indicator-records.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([ScenarioInterventionRepository]),
+    IndicatorRecordsModule,
     GeoCodingModule,
     SourcingLocationsModule,
   ],

--- a/api/src/modules/scenario-interventions/scenario-interventions.service.ts
+++ b/api/src/modules/scenario-interventions/scenario-interventions.service.ts
@@ -86,7 +86,8 @@ export class ScenarioInterventionsService extends AppBaseService<
     const newScenarioIntervention: ScenarioIntervention =
       new ScenarioIntervention();
     Object.assign(newScenarioIntervention, dto);
-    await this.scenarioInterventionRepository.save(newScenarioIntervention);
+    const savedNewScenarioIntervention: ScenarioIntervention =
+      await this.scenarioInterventionRepository.save(newScenarioIntervention);
     /**
      * Getting Sourcing Locations and Sourcing Records for start year of all Materials of the intervention with applied filters
      */
@@ -216,7 +217,10 @@ export class ScenarioInterventionsService extends AppBaseService<
      * and added as relations to the new Scenario Intervention, saving the new Scenario intervention in database
      */
 
-    return newScenarioIntervention.save();
+    const newScenarioInterventionSaved: ScenarioIntervention =
+      await this.scenarioInterventionRepository.save(newScenarioIntervention);
+
+    return newScenarioInterventionSaved;
   }
 
   /**
@@ -247,8 +251,8 @@ export class ScenarioInterventionsService extends AppBaseService<
         materialId: dto.newMaterialId as string,
         locationType: dto.newLocationType,
         locationAddressInput: dto.newAddressInput,
-        locationCountryInput: dto.newCountryInput,
-        t1SupplierId: dto.newSupplierT1Id,
+        locationCountryInput: dto.newLocationCountryInput,
+        t1SupplierId: dto.newT1SupplierId,
         producerId: dto.newProducerId,
         businessUnitId: sourcingData[0].businessUnitId,
         sourcingRecords: [{ year: dto.startYear, tonnage }],
@@ -287,9 +291,9 @@ export class ScenarioInterventionsService extends AppBaseService<
         materialId: sourcingData[0].materialId,
         locationType: dto.newLocationType,
         locationAddressInput: dto.newAddressInput,
-        locationCountryInput: dto.newCountryInput,
-        t1SupplierId: dto.newSupplierT1Id,
-        producerId: dto.newSupplierT1Id,
+        locationCountryInput: dto.newLocationCountryInput,
+        t1SupplierId: dto.newT1SupplierId,
+        producerId: dto.newProducerId,
         businessUnitId: sourcingData[0].businessUnitId,
         sourcingRecords: [
           {
@@ -309,8 +313,8 @@ export class ScenarioInterventionsService extends AppBaseService<
         materialId: location.materialId,
         locationType: dto.newLocationType,
         locationAddressInput: dto.newAddressInput,
-        locationCountryInput: dto.newCountryInput,
-        t1SupplierId: dto.newSupplierT1Id,
+        locationCountryInput: dto.newLocationCountryInput,
+        t1SupplierId: dto.newT1SupplierId,
         producerId: dto.newProducerId,
         businessUnitId: location.businessUnitId,
         geoRegionId: geoCodedLocationSample[0].geoRegionId,

--- a/api/src/modules/scenario-interventions/scenario-interventions.service.ts
+++ b/api/src/modules/scenario-interventions/scenario-interventions.service.ts
@@ -149,6 +149,7 @@ export class ScenarioInterventionsService extends AppBaseService<
               geoRegionId: sourcingLocation.geoRegionId,
               materialId: sourcingLocation.materialId,
             },
+            dto.newIndicatorCoefficients,
           );
         }
 
@@ -180,6 +181,7 @@ export class ScenarioInterventionsService extends AppBaseService<
               geoRegionId: sourcingLocation.geoRegionId,
               materialId: sourcingLocation.materialId,
             },
+            dto.newIndicatorCoefficients,
           );
         }
         break;
@@ -207,6 +209,7 @@ export class ScenarioInterventionsService extends AppBaseService<
               geoRegionId: sourcingLocation.geoRegionId,
               materialId: sourcingLocation.materialId,
             },
+            dto.newIndicatorCoefficients,
           );
         }
 

--- a/api/src/modules/scenario-interventions/scenario-interventions.service.ts
+++ b/api/src/modules/scenario-interventions/scenario-interventions.service.ts
@@ -86,12 +86,9 @@ export class ScenarioInterventionsService extends AppBaseService<
     const newScenarioIntervention: ScenarioIntervention =
       new ScenarioIntervention();
     Object.assign(newScenarioIntervention, dto);
-    const savedNewScenarioIntervention: ScenarioIntervention =
-      await this.scenarioInterventionRepository.save(newScenarioIntervention);
     /**
      * Getting Sourcing Locations and Sourcing Records for start year of all Materials of the intervention with applied filters
      */
-
     const actualSourcingDataWithTonnage: SourcingLocationWithRecord[] =
       await this.sourcingLocationsService.findFilteredSourcingLocationsForIntervention(
         dto,
@@ -144,10 +141,11 @@ export class ScenarioInterventionsService extends AppBaseService<
           );
 
         for await (const sourcingLocation of newInterventionSourcingLocations) {
+          const [sourcingRecord] = sourcingLocation.sourcingRecords;
           await this.indicatorRecordsService.createIndicatorRecordsBySourcingRecords(
             {
-              sourcingRecordId: sourcingLocation.sourcingRecords[0].id,
-              tonnage: sourcingLocation.sourcingRecords[0].tonnage,
+              sourcingRecordId: sourcingRecord.id,
+              tonnage: sourcingRecord.tonnage,
               geoRegionId: sourcingLocation.geoRegionId,
               materialId: sourcingLocation.materialId,
             },
@@ -174,10 +172,11 @@ export class ScenarioInterventionsService extends AppBaseService<
         newScenarioIntervention.newSourcingLocations =
           newInterventionSourcingLocations;
         for await (const sourcingLocation of newInterventionSourcingLocations) {
+          const [sourcingRecord] = sourcingLocation.sourcingRecords;
           await this.indicatorRecordsService.createIndicatorRecordsBySourcingRecords(
             {
-              sourcingRecordId: sourcingLocation.sourcingRecords[0].id,
-              tonnage: sourcingLocation.sourcingRecords[0].tonnage,
+              sourcingRecordId: sourcingRecord.id,
+              tonnage: sourcingRecord.tonnage,
               geoRegionId: sourcingLocation.geoRegionId,
               materialId: sourcingLocation.materialId,
             },
@@ -198,11 +197,13 @@ export class ScenarioInterventionsService extends AppBaseService<
           );
         newScenarioIntervention.newSourcingLocations =
           newInterventionSourcingLocations;
+
         for await (const sourcingLocation of newInterventionSourcingLocations) {
+          const [sourcingRecord] = sourcingLocation.sourcingRecords;
           await this.indicatorRecordsService.createIndicatorRecordsBySourcingRecords(
             {
-              sourcingRecordId: sourcingLocation.sourcingRecords[0].id,
-              tonnage: sourcingLocation.sourcingRecords[0].tonnage,
+              sourcingRecordId: sourcingRecord.id,
+              tonnage: sourcingRecord.tonnage,
               geoRegionId: sourcingLocation.geoRegionId,
               materialId: sourcingLocation.materialId,
             },
@@ -217,10 +218,7 @@ export class ScenarioInterventionsService extends AppBaseService<
      * and added as relations to the new Scenario Intervention, saving the new Scenario intervention in database
      */
 
-    const newScenarioInterventionSaved: ScenarioIntervention =
-      await this.scenarioInterventionRepository.save(newScenarioIntervention);
-
-    return newScenarioInterventionSaved;
+    return this.scenarioInterventionRepository.save(newScenarioIntervention);
   }
 
   /**
@@ -250,8 +248,10 @@ export class ScenarioInterventionsService extends AppBaseService<
       {
         materialId: dto.newMaterialId as string,
         locationType: dto.newLocationType,
-        locationAddressInput: dto.newAddressInput,
+        locationAddressInput: dto.newLocationAddressInput,
         locationCountryInput: dto.newLocationCountryInput,
+        locationLongitude: dto.newLocationLongitude,
+        locationLatitude: dto.newLocationLatitude,
         t1SupplierId: dto.newT1SupplierId,
         producerId: dto.newProducerId,
         businessUnitId: sourcingData[0].businessUnitId,
@@ -290,8 +290,10 @@ export class ScenarioInterventionsService extends AppBaseService<
       {
         materialId: sourcingData[0].materialId,
         locationType: dto.newLocationType,
-        locationAddressInput: dto.newAddressInput,
+        locationAddressInput: dto.newLocationAddressInput,
         locationCountryInput: dto.newLocationCountryInput,
+        locationLatitude: dto.newLocationLatitude,
+        locationLongitude: dto.newLocationLongitude,
         t1SupplierId: dto.newT1SupplierId,
         producerId: dto.newProducerId,
         businessUnitId: sourcingData[0].businessUnitId,
@@ -312,8 +314,10 @@ export class ScenarioInterventionsService extends AppBaseService<
       const newInterventionLocation: SourcingData = {
         materialId: location.materialId,
         locationType: dto.newLocationType,
-        locationAddressInput: dto.newAddressInput,
+        locationAddressInput: dto.newLocationAddressInput,
         locationCountryInput: dto.newLocationCountryInput,
+        locationLatitude: dto.newLocationLatitude,
+        locationLongitude: dto.newLocationLongitude,
         t1SupplierId: dto.newT1SupplierId,
         producerId: dto.newProducerId,
         businessUnitId: location.businessUnitId,

--- a/api/src/modules/sourcing-locations/dto/create.sourcing-location.dto.ts
+++ b/api/src/modules/sourcing-locations/dto/create.sourcing-location.dto.ts
@@ -9,7 +9,7 @@ import {
   MinLength,
 } from 'class-validator';
 import {
-  CANCELED_OR_REPLACING_BY_INTERVENTION,
+  SOURCING_LOCATION_TYPE_BY_INTERVENTION,
   LOCATION_ACCURACY,
   LOCATION_TYPES,
 } from 'modules/sourcing-locations/sourcing-location.entity';
@@ -103,7 +103,7 @@ export class CreateSourcingLocationDto {
 
   @IsString()
   @IsOptional()
-  typeAccordingToIntervention?: CANCELED_OR_REPLACING_BY_INTERVENTION;
+  interventionType?: SOURCING_LOCATION_TYPE_BY_INTERVENTION;
 
   @IsString()
   @IsOptional()

--- a/api/src/modules/sourcing-locations/sourcing-location.entity.ts
+++ b/api/src/modules/sourcing-locations/sourcing-location.entity.ts
@@ -103,7 +103,7 @@ export class SourcingLocation extends TimestampedBaseEntity {
 
   @Column({ nullable: true })
   @ApiPropertyOptional()
-  geoRegionId?: string;
+  geoRegionId: string;
 
   @Column({ type: 'jsonb', nullable: true })
   @ApiPropertyOptional()

--- a/api/src/modules/sourcing-locations/sourcing-location.entity.ts
+++ b/api/src/modules/sourcing-locations/sourcing-location.entity.ts
@@ -37,9 +37,9 @@ export enum LOCATION_ACCURACY {
   HIGH = 'HIGH',
 }
 
-export enum CANCELED_OR_REPLACING_BY_INTERVENTION {
-  CANCELED = 'Sourcing location canceled by intervention',
-  REPLACING = 'New sourcing location of the intervention',
+export enum SOURCING_LOCATION_TYPE_BY_INTERVENTION {
+  CANCELED = 'CANCELED_BY_INTERVENTION',
+  REPLACING = 'CREATED_BY_INTERVENTION',
 }
 
 export const sourcingLocationResource: BaseServiceResource = {
@@ -197,11 +197,11 @@ export class SourcingLocation extends TimestampedBaseEntity {
 
   @Column('enum', {
     nullable: true,
-    enum: CANCELED_OR_REPLACING_BY_INTERVENTION,
+    enum: SOURCING_LOCATION_TYPE_BY_INTERVENTION,
   })
   @ApiPropertyOptional()
   // TODO - come up with better naming
-  typeAccordingToIntervention?: CANCELED_OR_REPLACING_BY_INTERVENTION;
+  interventionType?: SOURCING_LOCATION_TYPE_BY_INTERVENTION;
 
   @OneToMany(
     () => SourcingRecord,

--- a/api/src/modules/sourcing-locations/sourcing-locations.service.ts
+++ b/api/src/modules/sourcing-locations/sourcing-locations.service.ts
@@ -124,7 +124,7 @@ export class SourcingLocationsService extends AppBaseService<
         .andWhere('sl.adminRegionId IN (:...adminRegion)', {
           adminRegion: createInterventionDto.adminRegionsIds,
         })
-        .andWhere('sl.typeAccordingToIntervention IS NULL')
+        .andWhere('sl.interventionType IS NULL')
         .getRawMany();
 
     return sourcingLocations;

--- a/api/src/modules/sourcing-records/sourcing-record.repository.ts
+++ b/api/src/modules/sourcing-records/sourcing-record.repository.ts
@@ -11,6 +11,7 @@ import { Logger, NotFoundException } from '@nestjs/common';
 import { GROUP_BY_VALUES } from 'modules/h3-data/dto/get-impact-map.dto';
 import { BusinessUnit } from 'modules/business-units/business-unit.entity';
 import { SourcingRecordsWithIndicatorRawDataDto } from 'modules/sourcing-records/dto/sourcing-records-with-indicator-raw-data.dto';
+import { MissingH3DataError } from 'modules/indicator-records/errors/missing-h3-data.error';
 
 export class ImpactTableData {
   year: number;
@@ -218,7 +219,9 @@ export class SourcingRecordRepository extends Repository<SourcingRecord> {
       this.logger.error(
         `Error querying data from DB to calculate Indicator Records: ${err.message}`,
       );
-      return [];
+      throw new MissingH3DataError(
+        `Could net retrieve Indicator Raw data from Sourcing Locations: ${err}`,
+      );
     }
   }
 }

--- a/api/test/e2e/scenario-interventions/scenario-interventions.spec.ts
+++ b/api/test/e2e/scenario-interventions/scenario-interventions.spec.ts
@@ -43,7 +43,9 @@ import {
   createInterventionPreconditions,
   ScenarioInterventionPreconditions,
 } from '../../utils/scenario-interventions-preconditions';
-import { GeoCodingAbstractClass } from '../../../src/modules/geo-coding/geo-coding-abstract-class';
+import { GeoCodingAbstractClass } from 'modules/geo-coding/geo-coding-abstract-class';
+import { IndicatorRecordsModule } from 'modules/indicator-records/indicator-records.module';
+import { IndicatorRecordsService } from 'modules/indicator-records/indicator-records.service';
 
 const expectedJSONAPIAttributes: string[] = [
   'title',
@@ -102,10 +104,13 @@ describe('ScenarioInterventionsModule (e2e)', () => {
         ScenarioInterventionsModule,
         SourcingLocationsModule,
         SourcingRecordsModule,
+        IndicatorRecordsModule,
       ],
     })
       .overrideProvider(GeoCodingAbstractClass)
       .useValue(geoCodingServiceMock)
+      .overrideProvider(IndicatorRecordsService)
+      .useValue({ createIndicatorRecordsBySourcingRecords: () => null })
       .compile();
 
     scenarioInterventionRepository =
@@ -158,9 +163,14 @@ describe('ScenarioInterventionsModule (e2e)', () => {
           suppliersIds: [preconditions.supplier1.id],
           businessUnitsIds: [preconditions.businessUnit1.id],
           adminRegionsIds: [preconditions.adminRegion1.id],
+          newLocationCountryInput: 'TestCountry',
           type: SCENARIO_INTERVENTION_TYPE.CHANGE_PRODUCTION_EFFICIENCY,
-          newIndicatorCoefficients:
-            '{ "ce": "11", "de": "10", "ww": "5", "bi": "3" }',
+          newIndicatorCoefficients: {
+            GHG_LUC_T: 1,
+            DF_LUC_T: 10,
+            UWU_T: 5,
+            BL_LUC_T: 3,
+          },
         });
 
       expect(HttpStatus.CREATED);
@@ -266,9 +276,13 @@ describe('ScenarioInterventionsModule (e2e)', () => {
           adminRegionsIds: [preconditions.adminRegion1.id],
           type: SCENARIO_INTERVENTION_TYPE.NEW_SUPPLIER,
           newLocationType: LOCATION_TYPES.COUNTRY_OF_PRODUCTION,
-          newCountryInput: 'Spain',
-          newIndicatorCoefficients:
-            '{ "ce": "11", "de": "10", "ww": "5", "bi": "3" }',
+          newLocationCountryInput: 'Spain',
+          newIndicatorCoefficients: {
+            GHG_LUC_T: 1,
+            DF_LUC_T: 10,
+            UWU_T: 5,
+            BL_LUC_T: 3,
+          },
         });
 
       expect(HttpStatus.CREATED);
@@ -392,10 +406,14 @@ describe('ScenarioInterventionsModule (e2e)', () => {
           ],
           type: SCENARIO_INTERVENTION_TYPE.NEW_MATERIAL,
           newLocationType: LOCATION_TYPES.COUNTRY_OF_PRODUCTION,
-          newCountryInput: 'Spain',
+          newLocationCountryInput: 'Spain',
           newMaterialId: replacingMaterial.id,
-          newIndicatorCoefficients:
-            '{ "ce": "11", "de": "10", "ww": "5", "bi": "3" }',
+          newIndicatorCoefficients: {
+            GHG_LUC_T: 1,
+            DF_LUC_T: 10,
+            UWU_T: 5,
+            BL_LUC_T: 3,
+          },
         });
 
       expect(HttpStatus.CREATED);
@@ -455,7 +473,7 @@ describe('ScenarioInterventionsModule (e2e)', () => {
         });
 
       expect(newSourcingRecords.length).toBe(1);
-      expect(newSourcingRecords[0].tonnage).toEqual('1100');
+      expect(newSourcingRecords[0].tonnage).toEqual('550');
     });
   });
 
@@ -476,9 +494,14 @@ describe('ScenarioInterventionsModule (e2e)', () => {
           suppliersIds: [preconditions.supplier1.id],
           businessUnitsIds: [preconditions.businessUnit1.id],
           adminRegionsIds: [preconditions.adminRegion1.id],
+          newLocationCountryInput: 'TestCountry',
           type: SCENARIO_INTERVENTION_TYPE.CHANGE_PRODUCTION_EFFICIENCY,
-          newIndicatorCoefficients:
-            '{ "ce": "11", "de": "10", "ww": "5", "bi": "3" }',
+          newIndicatorCoefficients: {
+            GHG_LUC_T: 1,
+            DF_LUC_T: 10,
+            UWU_T: 5,
+            BL_LUC_T: 3,
+          },
         });
 
       expect(HttpStatus.BAD_REQUEST);
@@ -503,9 +526,8 @@ describe('ScenarioInterventionsModule (e2e)', () => {
           suppliersIds: [preconditions.supplier2.id],
           businessUnitsIds: [preconditions.businessUnit2.id],
           adminRegionsIds: [preconditions.adminRegion2.id],
+          newLocationCountryInput: 'TestCountry',
           type: SCENARIO_INTERVENTION_TYPE.CHANGE_PRODUCTION_EFFICIENCY,
-          newIndicatorCoefficients:
-            '{ "ce": "11", "de": "10", "ww": "5", "bi": "3" }',
         });
 
       expect(HttpStatus.BAD_REQUEST);
@@ -521,6 +543,8 @@ describe('ScenarioInterventionsModule (e2e)', () => {
         .post('/api/v1/scenario-interventions')
         .set('Authorization', `Bearer ${jwtToken}`)
         .send();
+
+      console.log(JSON.stringify(response.body));
 
       expect(HttpStatus.BAD_REQUEST);
       expect(response).toHaveErrorMessage(
@@ -546,8 +570,7 @@ describe('ScenarioInterventionsModule (e2e)', () => {
           'each value in businessUnitsIds must be a UUID',
           'suppliersIds should not be empty',
           'each value in suppliersIds must be a UUID',
-          'newIndicatorCoefficients should not be empty',
-          'newIndicatorCoefficients must be a json string',
+          'New Location Country input is required for the selected intervention and location type',
         ],
       );
     });
@@ -569,8 +592,12 @@ describe('ScenarioInterventionsModule (e2e)', () => {
           suppliersIds: [supplier.id],
           businessUnitsIds: [businessUnit.id],
           type: SCENARIO_INTERVENTION_TYPE.NEW_SUPPLIER,
-          newIndicatorCoefficients:
-            '{ "ce": "11", "de": "10", "ww": "5", "bi": "3" }',
+          newIndicatorCoefficients: {
+            GHG_LUC_T: 1,
+            DF_LUC_T: 10,
+            UWU_T: 5,
+            BL_LUC_T: 3,
+          },
         });
 
       expect(HttpStatus.BAD_REQUEST);
@@ -580,6 +607,7 @@ describe('ScenarioInterventionsModule (e2e)', () => {
         [
           'Available columns for new location type: production unit, processing facility, tier 1 Trade facility, tier 2 Trade facility, origin Country, unknown, aggregation point, point of production, country of production',
           'New location type input is required for the selected intervention type',
+          'New Location Country input is required for the selected intervention and location type',
         ],
       );
     });
@@ -602,8 +630,6 @@ describe('ScenarioInterventionsModule (e2e)', () => {
           businessUnitsIds: [businessUnit.id],
           type: SCENARIO_INTERVENTION_TYPE.NEW_SUPPLIER,
           newLocationType: LOCATION_TYPES.COUNTRY_OF_PRODUCTION,
-          newIndicatorCoefficients:
-            '{ "ce": "11", "de": "10", "ww": "5", "bi": "3" }',
         });
 
       expect(HttpStatus.BAD_REQUEST);
@@ -611,7 +637,7 @@ describe('ScenarioInterventionsModule (e2e)', () => {
         HttpStatus.BAD_REQUEST,
         'Bad Request Exception',
         [
-          'New country input is required for the selected intervention and location type',
+          'New Location Country input is required for the selected intervention and location type',
         ],
       );
 
@@ -628,8 +654,6 @@ describe('ScenarioInterventionsModule (e2e)', () => {
           businessUnitsIds: [businessUnit.id],
           type: SCENARIO_INTERVENTION_TYPE.NEW_SUPPLIER,
           newLocationType: LOCATION_TYPES.ORIGIN_COUNTRY,
-          newIndicatorCoefficients:
-            '{ "ce": "11", "de": "10", "ww": "5", "bi": "3" }',
         });
 
       expect(HttpStatus.BAD_REQUEST);
@@ -637,12 +661,14 @@ describe('ScenarioInterventionsModule (e2e)', () => {
         HttpStatus.BAD_REQUEST,
         'Bad Request Exception',
         [
-          'New country input is required for the selected intervention and location type',
+          'New Location Country input is required for the selected intervention and location type',
         ],
       );
     });
 
-    test('Create new intervention with replacing supplier with new location type point of Production or Aggregation point and no address/coordinates data should fail with a 400 error', async () => {
+    // TODO: Add custom validation to check if either newLocationAddressInput or LAT LONG properties are provided for intervention types needing geocoding.
+    //       This can't be done by class-validator
+    test.skip('Create new intervention with replacing supplier with new location type point of Production or Aggregation point and no address/coordinates data should fail with a 400 error', async () => {
       const scenario: Scenario = await createScenario();
       const material: Material = await createMaterial();
       const supplier: Supplier = await createSupplier();
@@ -660,8 +686,6 @@ describe('ScenarioInterventionsModule (e2e)', () => {
           businessUnitsIds: [businessUnit.id],
           type: SCENARIO_INTERVENTION_TYPE.NEW_SUPPLIER,
           newLocationType: LOCATION_TYPES.AGGREGATION_POINT,
-          newIndicatorCoefficients:
-            '{ "ce": "11", "de": "10", "ww": "5", "bi": "3" }',
         });
 
       expect(HttpStatus.BAD_REQUEST);
@@ -669,7 +693,7 @@ describe('ScenarioInterventionsModule (e2e)', () => {
         HttpStatus.BAD_REQUEST,
         'Bad Request Exception',
         [
-          'New address or coordinates input is required for the selected intervention and location type',
+          'New Location Country input is required for the selected intervention and location type',
         ],
       );
 
@@ -686,8 +710,7 @@ describe('ScenarioInterventionsModule (e2e)', () => {
           businessUnitsIds: [businessUnit.id],
           type: SCENARIO_INTERVENTION_TYPE.NEW_SUPPLIER,
           newLocationType: LOCATION_TYPES.POINT_OF_PRODUCTION,
-          newIndicatorCoefficients:
-            '{ "ce": "11", "de": "10", "ww": "5", "bi": "3" }',
+          newLocationCountryInput: 'TestCountry',
         });
 
       expect(HttpStatus.BAD_REQUEST);
@@ -696,6 +719,7 @@ describe('ScenarioInterventionsModule (e2e)', () => {
         'Bad Request Exception',
         [
           'New address or coordinates input is required for the selected intervention and location type',
+          'New Location Country input is required for the selected intervention and location type',
         ],
       );
     });
@@ -717,8 +741,7 @@ describe('ScenarioInterventionsModule (e2e)', () => {
           suppliersIds: [supplier.id],
           businessUnitsIds: [businessUnit.id],
           type: SCENARIO_INTERVENTION_TYPE.NEW_MATERIAL,
-          newIndicatorCoefficients:
-            '{ "ce": "11", "de": "10", "ww": "5", "bi": "3" }',
+          newLocationCountryInput: 'TestCountry',
         });
 
       expect(HttpStatus.BAD_REQUEST);
@@ -727,9 +750,9 @@ describe('ScenarioInterventionsModule (e2e)', () => {
         'Bad Request Exception',
         [
           'Available columns for new location type: production unit, processing facility, tier 1 Trade facility, tier 2 Trade facility, origin Country, unknown, aggregation point, point of production, country of production',
-          'New location type input is required for the selected intervention type',
           'newMaterialId must be a UUID',
           'New Material is required for the selected intervention type',
+          'New location type input is required for the selected intervention type',
         ],
       );
     });

--- a/api/test/e2e/scenario-interventions/scenario-interventions.spec.ts
+++ b/api/test/e2e/scenario-interventions/scenario-interventions.spec.ts
@@ -4,8 +4,8 @@ import * as request from 'supertest';
 import { AppModule } from 'app.module';
 import {
   SCENARIO_INTERVENTION_STATUS,
-  ScenarioIntervention,
   SCENARIO_INTERVENTION_TYPE,
+  ScenarioIntervention,
 } from 'modules/scenario-interventions/scenario-intervention.entity';
 import { ScenarioInterventionsModule } from 'modules/scenario-interventions/scenario-interventions.module';
 import { ScenarioInterventionRepository } from 'modules/scenario-interventions/scenario-intervention.repository';
@@ -26,6 +26,7 @@ import { Supplier } from 'modules/suppliers/supplier.entity';
 import { BusinessUnit } from 'modules/business-units/business-unit.entity';
 import {
   LOCATION_TYPES,
+  SOURCING_LOCATION_TYPE_BY_INTERVENTION,
   SourcingLocation,
 } from 'modules/sourcing-locations/sourcing-location.entity';
 import { SourcingLocationRepository } from 'modules/sourcing-locations/sourcing-location.repository';
@@ -188,8 +189,7 @@ describe('ScenarioInterventionsModule (e2e)', () => {
       const canceledSourcingLocations: SourcingLocation[] =
         await sourcingLocationRepository.find({
           where: {
-            typeAccordingToIntervention:
-              'Sourcing location canceled by intervention',
+            interventionType: SOURCING_LOCATION_TYPE_BY_INTERVENTION.CANCELED,
           },
         });
 
@@ -217,8 +217,7 @@ describe('ScenarioInterventionsModule (e2e)', () => {
       const newSourcingLocations: SourcingLocation[] =
         await sourcingLocationRepository.find({
           where: {
-            typeAccordingToIntervention:
-              'New sourcing location of the intervention',
+            interventionType: SOURCING_LOCATION_TYPE_BY_INTERVENTION.REPLACING,
           },
         });
 
@@ -298,8 +297,7 @@ describe('ScenarioInterventionsModule (e2e)', () => {
       const canceledSourcingLocations: SourcingLocation[] =
         await sourcingLocationRepository.find({
           where: {
-            typeAccordingToIntervention:
-              'Sourcing location canceled by intervention',
+            interventionType: SOURCING_LOCATION_TYPE_BY_INTERVENTION.CANCELED,
           },
         });
 
@@ -327,8 +325,7 @@ describe('ScenarioInterventionsModule (e2e)', () => {
       const newSourcingLocations: SourcingLocation[] =
         await sourcingLocationRepository.find({
           where: {
-            typeAccordingToIntervention:
-              'New sourcing location of the intervention',
+            interventionType: SOURCING_LOCATION_TYPE_BY_INTERVENTION.REPLACING,
           },
         });
 
@@ -427,8 +424,7 @@ describe('ScenarioInterventionsModule (e2e)', () => {
       const canceledSourcingLocations: SourcingLocation[] =
         await sourcingLocationRepository.find({
           where: {
-            typeAccordingToIntervention:
-              'Sourcing location canceled by intervention',
+            interventionType: SOURCING_LOCATION_TYPE_BY_INTERVENTION.CANCELED,
           },
         });
 
@@ -437,8 +433,7 @@ describe('ScenarioInterventionsModule (e2e)', () => {
       const newSourcingLocations: SourcingLocation[] =
         await sourcingLocationRepository.find({
           where: {
-            typeAccordingToIntervention:
-              'New sourcing location of the intervention',
+            interventionType: SOURCING_LOCATION_TYPE_BY_INTERVENTION.REPLACING,
           },
         });
 

--- a/api/test/integration/stored-procedures/stored-procedures.spec.ts
+++ b/api/test/integration/stored-procedures/stored-procedures.spec.ts
@@ -1,0 +1,241 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AppModule } from 'app.module';
+import {
+  createGeoRegion,
+  createMaterial,
+  createMaterialToH3,
+} from '../../entity-mocks';
+import { getManager } from 'typeorm';
+import {
+  h3IndicatorExampleDataFixture,
+  h3MaterialExampleDataFixture,
+} from '../../e2e/h3-data/mocks/h3-fixtures';
+import { H3DataRepository } from 'modules/h3-data/h3-data.repository';
+import {
+  dropH3DataMock,
+  h3DataMock,
+} from '../../e2e/h3-data/mocks/h3-data.mock';
+import { H3DataModule } from 'modules/h3-data/h3-data.module';
+import { createWorldToCalculateIndicatorRecords } from '../../utils/indicator-records-preconditions';
+import { IndicatorsModule } from 'modules/indicators/indicators.module';
+import { IndicatorRepository } from 'modules/indicators/indicator.repository';
+import { Material } from 'modules/materials/material.entity';
+import { MATERIAL_TO_H3_TYPE } from 'modules/materials/material-to-h3.entity';
+import { MaterialsToH3sService } from 'modules/materials/materials-to-h3s.service';
+import { MaterialRepository } from 'modules/materials/material.repository';
+import { MaterialsModule } from 'modules/materials/materials.module';
+import { snakeCase } from 'typeorm/util/StringUtils';
+import { GeoRegionsModule } from 'modules/geo-regions/geo-regions.module';
+import { GeoRegionRepository } from 'modules/geo-regions/geo-region.repository';
+
+describe('Stored Procedures Tests', () => {
+  let h3DataRepository: H3DataRepository;
+  let geoRegionRepository: GeoRegionRepository;
+  let indicatorRepository: IndicatorRepository;
+  let materialToH3Service: MaterialsToH3sService;
+  let materialRepository: MaterialRepository;
+  let indicatorWorld: any;
+  const h3MockTableName = snakeCase('h3tableMock');
+  const h3MockColumnName = 'h3columnName';
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [
+        AppModule,
+        IndicatorsModule,
+        H3DataModule,
+        MaterialsModule,
+        GeoRegionsModule,
+      ],
+    }).compile();
+    h3DataRepository = moduleFixture.get<H3DataRepository>(H3DataRepository);
+    indicatorRepository =
+      moduleFixture.get<IndicatorRepository>(IndicatorRepository);
+    materialToH3Service = moduleFixture.get<MaterialsToH3sService>(
+      MaterialsToH3sService,
+    );
+    materialRepository =
+      moduleFixture.get<MaterialRepository>(MaterialRepository);
+
+    geoRegionRepository =
+      moduleFixture.get<GeoRegionRepository>(GeoRegionRepository);
+  });
+
+  afterEach(async () => {
+    await indicatorRepository.delete({});
+    await materialToH3Service.delete({});
+    await geoRegionRepository.delete({});
+    await materialRepository.delete({});
+    await h3DataRepository.delete({});
+    if (indicatorWorld?.h3tableNames.length)
+      await dropH3DataMock([...indicatorWorld.h3tableNames]);
+  });
+
+  test('It should return the h3 table and column name and resolution of a given Material Id and a Type', async () => {
+    const materialMockH3 = await h3DataMock({
+      h3TableName: h3MockTableName,
+      h3ColumnName: h3MockColumnName,
+      year: 2020,
+    });
+    const materialMock: Material = await createMaterial({
+      name: 'materialMock',
+    });
+    await createMaterialToH3(
+      materialMock.id,
+      materialMockH3.id,
+      MATERIAL_TO_H3_TYPE.PRODUCER,
+    );
+
+    const h3TableResult = await getManager().query(
+      `select get_h3_table_column_for_material('${materialMock.id}', '${MATERIAL_TO_H3_TYPE.PRODUCER}') as "h3TableResult"`,
+    );
+    expect(h3TableResult[0]).toEqual({
+      h3TableResult: `(${snakeCase(materialMockH3.h3tableName)},${
+        materialMockH3.h3columnName
+      },6)`,
+    });
+    await dropH3DataMock([h3MockTableName]);
+  });
+  test('It should return a uncompacted array of h3 index given a GeoRegion Id', async () => {
+    const geoRegion = await createGeoRegion({
+      h3Compact: [
+        '8667737afffffff',
+        '8667737a7ffffff',
+        '86677378fffffff',
+        '866773637ffffff',
+        '86677362fffffff',
+        '866773607ffffff',
+        '861203a4fffffff',
+      ],
+      h3Flat: [
+        '8667737afffffff',
+        '8667737a7ffffff',
+        '86677378fffffff',
+        '866773637ffffff',
+        '86677362fffffff',
+        '866773607ffffff',
+        '861203a4fffffff',
+      ],
+      h3FlatLength: 7,
+    });
+
+    const uncompactedGeoregion = await getManager().query(
+      `select get_h3_uncompact_geo_region('${geoRegion.id}', 6) as "h3indexes"`,
+    );
+    uncompactedGeoregion.forEach(
+      (h3indexes: { h3indexes: string }, index: number) => {
+        if (geoRegion.h3Compact)
+          expect(h3indexes.h3indexes).toEqual(geoRegion.h3Compact[index]);
+      },
+    );
+  });
+  test('It should return a SUM of all values over all the grids given a GeoRegion', async () => {
+    const mockH3Data = await h3DataMock({
+      h3TableName: h3MockTableName,
+      h3ColumnName: h3MockColumnName,
+      additionalH3Data: h3MaterialExampleDataFixture,
+      year: 2020,
+    });
+    const geoRegion = await createGeoRegion({
+      h3Compact: Object.keys(h3MaterialExampleDataFixture),
+      h3Flat: Object.keys(h3MaterialExampleDataFixture),
+      h3FlatLength: Object.keys(h3MaterialExampleDataFixture).length,
+    });
+
+    const sumOfAllGrids = await getManager().query(
+      `select sum_h3_grid_over_georegion('${geoRegion.id}', 6, '${snakeCase(
+        mockH3Data.h3tableName,
+      )}', '${mockH3Data.h3columnName}') as "sum"`,
+    );
+
+    expect(sumOfAllGrids[0].sum).toEqual(
+      Object.values(h3MaterialExampleDataFixture).reduce(
+        (acc: any, cur: any) => acc + cur,
+        0,
+      ),
+    );
+    await dropH3DataMock([h3MockTableName]);
+  });
+
+  test('It should return the SUM of the weighted water applying a calculation factor given a GeoRegion', async () => {
+    const expectedResultForGivenGrids = 0.8054600000604988;
+    indicatorWorld = await createWorldToCalculateIndicatorRecords();
+    const geoRegion = await createGeoRegion({
+      h3Compact: Object.keys(h3IndicatorExampleDataFixture),
+      h3Flat: Object.keys(h3IndicatorExampleDataFixture),
+      h3FlatLength: Object.keys(h3IndicatorExampleDataFixture).length,
+    });
+
+    const weightedWaterSum = await getManager().query(
+      `select sum_weighted_water_over_georegion('${geoRegion.id}') as sum`,
+    );
+
+    expect(weightedWaterSum[0].sum).toEqual(expectedResultForGivenGrids);
+  });
+
+  test('It should return the SUM of weighted carbon for harvested Materials given a GeoRegion', async () => {
+    const expectedResultForConvergingMaterialAnd2IndicatorH3values = 39500000;
+    indicatorWorld = await createWorldToCalculateIndicatorRecords();
+    const geoRegion = await createGeoRegion({
+      h3Compact: Object.keys(h3IndicatorExampleDataFixture),
+      h3Flat: Object.keys(h3IndicatorExampleDataFixture),
+      h3FlatLength: Object.keys(h3IndicatorExampleDataFixture).length,
+    });
+    await Promise.all([]);
+    const materialMockH3 = await h3DataMock({
+      h3TableName: h3MockTableName,
+      h3ColumnName: h3MockColumnName,
+      additionalH3Data: h3IndicatorExampleDataFixture,
+      year: 2020,
+    });
+    const materialMock: Material = await createMaterial({
+      name: 'materialMock',
+    });
+    await createMaterialToH3(
+      materialMock.id,
+      materialMockH3.id,
+      MATERIAL_TO_H3_TYPE.HARVEST,
+    );
+
+    const sumOfWeightedCarbon = await getManager().query(
+      `select sum_weighted_carbon_over_georegion('${geoRegion.id}', '${materialMock.id}', '${MATERIAL_TO_H3_TYPE.HARVEST}') as sum `,
+    );
+
+    expect(sumOfWeightedCarbon[0].sum).toEqual(
+      expectedResultForConvergingMaterialAnd2IndicatorH3values,
+    );
+    await dropH3DataMock([h3MockTableName]);
+  });
+
+  test('It should return the SUM of weighted biodiversity loss for harvested materials after applying a calculus factor given a GeoRegion', async () => {
+    const expectedResultsMultiplyingByMaterial2IndicatorsAndCalculusFacotr = 395000011157.11926;
+    indicatorWorld = await createWorldToCalculateIndicatorRecords();
+    const geoRegion = await createGeoRegion({
+      h3Compact: Object.keys(h3IndicatorExampleDataFixture),
+      h3Flat: Object.keys(h3IndicatorExampleDataFixture),
+      h3FlatLength: Object.keys(h3IndicatorExampleDataFixture).length,
+    });
+    const materialMockH3 = await h3DataMock({
+      h3TableName: h3MockTableName,
+      h3ColumnName: h3MockColumnName,
+      additionalH3Data: h3IndicatorExampleDataFixture,
+      year: 2020,
+    });
+    const materialMock: Material = await createMaterial({
+      name: 'materialMock',
+    });
+    await createMaterialToH3(
+      materialMock.id,
+      materialMockH3.id,
+      MATERIAL_TO_H3_TYPE.HARVEST,
+    );
+
+    const sumOfWeightedBiodiversituy = await getManager().query(
+      `select sum_weighted_biodiversity_over_georegion('${geoRegion.id}', '${materialMock.id}', '${MATERIAL_TO_H3_TYPE.HARVEST}') as sum `,
+    );
+    expect(sumOfWeightedBiodiversituy[0].sum).toEqual(
+      expectedResultsMultiplyingByMaterial2IndicatorsAndCalculusFacotr,
+    );
+    await dropH3DataMock([h3MockTableName]);
+  });
+});

--- a/api/test/utils/indicator-records-preconditions.ts
+++ b/api/test/utils/indicator-records-preconditions.ts
@@ -1,0 +1,88 @@
+/**
+ * @description Preconditions needed for the time being due to hardcoded Indicator H3 data names
+ * in stored procedures. We can avoid this once we improve said functions to retrieve Indicator data
+ * dynamically and follow the standard approach
+ */
+
+import { createH3Data, createIndicator } from '../entity-mocks';
+import { getManager } from 'typeorm';
+import { h3IndicatorExampleDataFixture } from '../e2e/h3-data/mocks/h3-fixtures';
+import { INDICATOR_TYPES } from '../../src/modules/indicators/indicator.entity';
+
+export const createWorldToCalculateIndicatorRecords =
+  async (): Promise<any> => {
+    const defoIndicator = await createIndicator({
+      name: '1',
+      nameCode: INDICATOR_TYPES.DEFORESTATION,
+    });
+    const waterIndicator = await createIndicator({
+      name: '2',
+      nameCode: INDICATOR_TYPES.UNSUSTAINABLE_WATER_USE,
+    });
+    const carbonEmissions = await createIndicator({
+      name: '3',
+      nameCode: INDICATOR_TYPES.CARBON_EMISSIONS,
+    });
+    const biodiversityLoss = await createIndicator({
+      name: '4',
+      nameCode: INDICATOR_TYPES.BIODIVERSITY_LOSS,
+    });
+
+    const deforestationH3Data = await createH3Data({
+      h3tableName: 'h3_grid_deforestation_global',
+      h3columnName: 'hansenLoss2019',
+      year: 2000,
+      indicatorId: defoIndicator.id,
+    });
+    const biodiversityLossH3Data = await createH3Data({
+      h3tableName: 'h3_grid_bio_global',
+      h3columnName: 'lciaPslRPermanentCrops',
+      year: 2000,
+      indicatorId: biodiversityLoss.id,
+    });
+    const carbonEmissionsH3Data = await createH3Data({
+      h3tableName: 'h3_grid_carbon_global',
+      h3columnName: 'earthstat2000GlobalHectareEmissions',
+      year: 2000,
+      indicatorId: carbonEmissions.id,
+    });
+    const waterRiskH3Data = await createH3Data({
+      h3tableName: 'h3_grid_wf_global',
+      h3columnName: 'wfBltotMmyr',
+      year: 2000,
+      indicatorId: waterIndicator.id,
+    });
+
+    for await (const indicatorH3 of [
+      deforestationH3Data,
+      biodiversityLossH3Data,
+      carbonEmissionsH3Data,
+      waterRiskH3Data,
+    ]) {
+      await getManager().query(
+        `CREATE TABLE "${indicatorH3.h3tableName}" (h3index h3index, "${indicatorH3.h3columnName}" float4);`,
+      );
+      let query = `INSERT INTO ${indicatorH3.h3tableName} (h3index, "${indicatorH3.h3columnName}") VALUES `;
+      const queryArr = [];
+      for (const [key, value] of Object.entries(
+        h3IndicatorExampleDataFixture,
+      )) {
+        queryArr.push(`('${key}', ${value})`);
+      }
+      query = query.concat(queryArr.join());
+      await getManager().query(query);
+    }
+
+    return {
+      deforestation: deforestationH3Data,
+      waterRisk: waterRiskH3Data,
+      biodiversityLoss: biodiversityLossH3Data,
+      carbonEmissions: carbonEmissionsH3Data,
+      h3tableNames: [
+        deforestationH3Data.h3tableName,
+        waterRiskH3Data.h3tableName,
+        biodiversityLossH3Data.h3tableName,
+        carbonEmissionsH3Data.h3tableName,
+      ],
+    };
+  };


### PR DESCRIPTION
This PR adds:

Service to calculate Indicator (Impact) Records for new Scenario Interventions.

Updates/Refactors some DTOs and implementation for the Scenario Intervention workflow to match some props and a little performance improvement

Better error handling on GeoCoding, to avoid caching location info that cannot be geocoded and raise and exception

**NOTE:** Tech debt on testing the service including the stored procedures, but you can review this while I am solving the debt