### PR TITLE
Infinite scroll for scenarios list

### DIFF
--- a/client/src/containers/scenarios/component.tsx
+++ b/client/src/containers/scenarios/component.tsx
@@ -5,14 +5,14 @@ import ScenariosFilters from 'containers/scenarios/filters';
 import ScenariosList from 'containers/scenarios/list';
 import { AnchorLink } from 'components/button';
 import Lottie from 'lottie-react';
-import { useScenarios } from 'hooks/scenarios';
+import { useInfiniteScenarios } from 'hooks/scenarios';
 
 import noScenariosAnimationData from 'containers/scenarios/animations/noScenariosAnimationData.json';
 
-const ScenariosComponent: React.FC = () => {
+const ScenariosComponent: React.FC = (scrollRef) => {
   const { query } = useRouter();
   const params = query ? { sort: query.sortBy as string } : null;
-  const { data, isLoading, error } = useScenarios(params);
+  const { fetchNextPage, hasNextPage, data, isLoading, error } = useInfiniteScenarios(params);
 
   return (
     <div className="bg-white overscroll-contain text-gray-900">
@@ -28,7 +28,12 @@ const ScenariosComponent: React.FC = () => {
       {isLoading && <p>Loading scenarios...</p>}
       {!isLoading && data && (
         <div className="flex-1 z-10 pb-4">
-          <ScenariosList data={data} />
+          <ScenariosList
+            data={data}
+            fetchNextPage={fetchNextPage}
+            hasNextPage={hasNextPage}
+            scrollRef={scrollRef}
+          />
         </div>
       )}
       {!isLoading && error && (

--- a/client/src/containers/scenarios/component.tsx
+++ b/client/src/containers/scenarios/component.tsx
@@ -15,7 +15,7 @@ import noScenariosAnimationData from 'containers/scenarios/animations/noScenario
 
 import type { Scenario } from './types';
 
-const ScenariosComponent: React.FC<{ scrollRef: MutableRefObject<HTMLDivElement> }> = ({
+const ScenariosComponent: React.FC<{ scrollRef?: MutableRefObject<HTMLDivElement> }> = ({
   scrollRef,
 }) => {
   const { query } = useRouter();

--- a/client/src/containers/scenarios/item/component.tsx
+++ b/client/src/containers/scenarios/item/component.tsx
@@ -7,6 +7,7 @@ import { useRouter } from 'next/router';
 
 import ScenariosComparison from 'containers/scenarios/comparison';
 import { useDeleteScenario } from 'hooks/scenarios';
+import useBottomScrollListener from 'hooks/scroll';
 import type { Scenario } from '../types';
 
 type ScenariosItemProps = {
@@ -21,7 +22,7 @@ const DROPDOWN_ITEM_CLASSNAME = 'block px-4 py-2 text-sm w-full text-left';
 const DROPDOWN_ITEM_ACTIVE_CLASSNAME = 'bg-gray-100 text-gray-900';
 
 const ScenariosList: React.FC<ScenariosItemProps> = (props: ScenariosItemProps) => {
-  const { data, isSelected, isComparisonAvailable } = props;
+  const { data, isSelected, isComparisonAvailable, hasNextPage, fetchNextPage } = props;
   const [isComparisonEnabled, setComparisonEnabled] = useState<boolean>(false);
   const router = useRouter();
 

--- a/client/src/containers/scenarios/item/component.tsx
+++ b/client/src/containers/scenarios/item/component.tsx
@@ -7,7 +7,6 @@ import { useRouter } from 'next/router';
 
 import ScenariosComparison from 'containers/scenarios/comparison';
 import { useDeleteScenario } from 'hooks/scenarios';
-import useBottomScrollListener from 'hooks/scroll';
 import type { Scenario } from '../types';
 
 type ScenariosItemProps = {
@@ -22,7 +21,7 @@ const DROPDOWN_ITEM_CLASSNAME = 'block px-4 py-2 text-sm w-full text-left';
 const DROPDOWN_ITEM_ACTIVE_CLASSNAME = 'bg-gray-100 text-gray-900';
 
 const ScenariosList: React.FC<ScenariosItemProps> = (props: ScenariosItemProps) => {
-  const { data, isSelected, isComparisonAvailable, hasNextPage, fetchNextPage } = props;
+  const { data, isSelected, isComparisonAvailable } = props;
   const [isComparisonEnabled, setComparisonEnabled] = useState<boolean>(false);
   const router = useRouter();
 

--- a/client/src/containers/scenarios/list/component.tsx
+++ b/client/src/containers/scenarios/list/component.tsx
@@ -1,36 +1,26 @@
-import { useEffect, useState, useCallback, MutableRefObject } from 'react';
-import { UseInfiniteQueryResult } from 'react-query';
+import { useEffect, useState, useCallback } from 'react';
 import { useRouter } from 'next/router';
 import { RadioGroup } from '@headlessui/react';
-import ScenarioItem from 'containers/scenarios/item';
+
 import { useAppSelector, useAppDispatch } from 'store/hooks';
-import useBottomScrollListener from 'hooks/scroll';
 import { scenarios, setCurrentScenario } from 'store/features/analysis/scenarios';
+
+import ScenarioItem from 'containers/scenarios/item';
 
 import type { Scenario, Scenarios } from '../types';
 
 type ScenariosListProps = {
   data: Scenarios;
-  scrollRef: MutableRefObject<HTMLDivElement | null>;
-} & UseInfiniteQueryResult;
+};
 
 const isScenarioSelected: (scenarioId: Scenario['id'], currentId: Scenario['id']) => boolean = (
   scenarioId,
   currentId,
 ): boolean => scenarioId.toString() === currentId?.toString();
 
-const ScenariosList: React.FC<ScenariosListProps> = ({
-  data,
-  hasNextPage,
-  fetchNextPage,
-  scrollRef,
-}: ScenariosListProps) => {
+const ScenariosList: React.FC<ScenariosListProps> = ({ data }: ScenariosListProps) => {
   const { currentScenario } = useAppSelector(scenarios);
   const dispatch = useAppDispatch();
-
-  useBottomScrollListener(() => {
-    if (hasNextPage) fetchNextPage();
-  }, scrollRef);
 
   const router = useRouter();
   const { query } = router;

--- a/client/src/hooks/scenarios/index.ts
+++ b/client/src/hooks/scenarios/index.ts
@@ -6,15 +6,20 @@ import {
   UseQueryOptions,
   useMutation,
   UseInfiniteQueryResult,
-  UseInfiniteQueryOptions,
 } from 'react-query';
 import { useQueryClient } from 'react-query';
 
 import { apiService } from 'services/api';
 import type { Scenario } from 'containers/scenarios/types';
+import { AxiosResponse } from 'axios';
 
 type ResponseData = UseQueryResult<Scenario[]>;
-type ResponseInfiniteData = UseInfiniteQueryResult<Scenario[]>;
+type ResponseInfiniteData = UseInfiniteQueryResult<
+  AxiosResponse<{
+    data: Scenario[];
+    meta: Record<string, unknown>;
+  }>
+>;
 type ResponseDataScenario = UseQueryResult<Scenario>;
 type QueryParams = {
   sort?: string;
@@ -88,16 +93,7 @@ export function useInfiniteScenarios(QueryParams: QueryParams): ResponseInfinite
     },
   });
 
-  const { data } = query;
-  const { pages } = data || {};
-
-  return useMemo(() => {
-    const parsedData = pages?.reduce((acc, { data }) => acc.concat(data?.data), []);
-    return {
-      ...query,
-      data: parsedData,
-    };
-  }, [pages, query]);
+  return useMemo<ResponseInfiniteData>((): ResponseInfiniteData => query, [query]);
 }
 
 export function useScenario(id: string, queryParams: { sort: string }): ResponseDataScenario {

--- a/client/src/hooks/scroll/index.ts
+++ b/client/src/hooks/scroll/index.ts
@@ -85,7 +85,7 @@ function useBottomScrollListener<T extends HTMLDivElement>(
       }
     }
     // ref dependency needed for the tests, doesn't matter for normal execution
-  }, [offset, debouncedOnBottom]);
+  }, [containerRef, offset, debouncedOnBottom]);
 
   useEffect((): (() => void) => {
     const ref = containerRef.current;
@@ -107,7 +107,7 @@ function useBottomScrollListener<T extends HTMLDivElement>(
         window.removeEventListener('scroll', handleOnScroll);
       }
     };
-  }, [handleOnScroll, triggerOnNoScroll, debounce]);
+  }, [handleOnScroll, triggerOnNoScroll, debounce, containerRef]);
 
   return containerRef as RefObject<T>;
 }

--- a/client/src/hooks/scroll/index.ts
+++ b/client/src/hooks/scroll/index.ts
@@ -1,0 +1,115 @@
+import { useCallback, useEffect, useRef, useMemo, RefObject, MutableRefObject } from 'react';
+
+import lodashDebounce from 'lodash/debounce';
+
+export type DebounceOptions = Parameters<typeof lodashDebounce>[2];
+
+const createCallback = (
+  debounce: number,
+  handleOnScroll: () => void,
+  options: DebounceOptions,
+): (() => void) => {
+  if (debounce) {
+    return lodashDebounce(handleOnScroll, debounce, options);
+  }
+  return handleOnScroll;
+};
+
+/**
+ * @description
+ *  A react hook that invokes a callback when user scrolls to the bottom
+ *
+ * @param onBottom
+ * - Required callback that will be invoked when scrolled to bottom
+ * @param {Object} options
+ * - Optional parameters
+ * @param {number} [options.offset=0]
+ * - Offset from bottom of page in pixels.
+ * E.g. 300 will trigger onBottom 300px from the bottom of the page
+ * @param {number} [options.debounce=200]
+ * - Optional debounce in milliseconds, defaults to 200ms
+ * @param {DebounceOptions} [options.debounceOptions={leading=true}]
+ * - Options passed to lodash.debounce, see https://lodash.com/docs/4.17.15#debounce
+ * @param {boolean} [options.triggerOnNoScroll=false]
+ * - Triggers the onBottom callback when the page has no scrollbar
+ * @returns {RefObject} ref
+ * - If passed to a element as a ref, e.g. a div it will register scrolling
+ * to the bottom of that div instead of document viewport
+ */
+
+function useBottomScrollListener<T extends HTMLDivElement>(
+  onBottom: () => void,
+  scrollRef?: MutableRefObject<HTMLDivElement | null>,
+  options?: {
+    offset?: number;
+    debounce?: number;
+    debounceOptions?: DebounceOptions;
+    triggerOnNoScroll?: boolean;
+  },
+): RefObject<T> {
+  const { offset, triggerOnNoScroll, debounce, debounceOptions } = useMemo(
+    () => ({
+      offset: options?.offset ?? 0,
+      debounce: options?.debounce ?? 200,
+      debounceOptions: options?.debounceOptions ?? { leading: true },
+      triggerOnNoScroll: options?.triggerOnNoScroll ?? false,
+    }),
+    [options?.offset, options?.debounce, options?.debounceOptions, options?.triggerOnNoScroll],
+  );
+
+  const debouncedOnBottom = useMemo(
+    () => createCallback(debounce, onBottom, debounceOptions),
+    [debounce, debounceOptions, onBottom],
+  );
+
+  const noRef = useRef<T>(null);
+  const containerRef = scrollRef || noRef;
+  const handleOnScroll = useCallback(() => {
+    if (containerRef.current != null) {
+      const scrollNode = containerRef.current;
+      const scrollContainerBottomPosition = Math.round(
+        scrollNode.scrollTop + scrollNode.clientHeight,
+      );
+      const scrollPosition = Math.round(scrollNode.scrollHeight - offset);
+
+      if (scrollPosition <= scrollContainerBottomPosition) {
+        debouncedOnBottom();
+      }
+    } else {
+      const scrollNode: Element = document.scrollingElement || document.documentElement;
+      const scrollContainerBottomPosition = Math.round(scrollNode.scrollTop + window.innerHeight);
+      const scrollPosition = Math.round(scrollNode.scrollHeight - offset);
+
+      if (scrollPosition <= scrollContainerBottomPosition) {
+        debouncedOnBottom();
+      }
+    }
+    // ref dependency needed for the tests, doesn't matter for normal execution
+  }, [offset, debouncedOnBottom]);
+
+  useEffect((): (() => void) => {
+    const ref = containerRef.current;
+
+    if (ref != null) {
+      ref.addEventListener('scroll', handleOnScroll);
+    } else {
+      window.addEventListener('scroll', handleOnScroll);
+    }
+
+    if (triggerOnNoScroll) {
+      handleOnScroll();
+    }
+
+    return () => {
+      if (ref != null) {
+        ref.removeEventListener('scroll', handleOnScroll);
+      } else {
+        window.removeEventListener('scroll', handleOnScroll);
+      }
+    };
+  }, [handleOnScroll, triggerOnNoScroll, debounce]);
+
+  return containerRef as RefObject<T>;
+}
+
+export default useBottomScrollListener;

--- a/client/src/layouts/analysis/component.tsx
+++ b/client/src/layouts/analysis/component.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState, Children, isValidElement, cloneElement } from 'react';
 import dynamic from 'next/dynamic';
 import { createPortal } from 'react-dom';
 import { Transition } from '@headlessui/react';
@@ -31,6 +31,15 @@ const AnalysisLayout: React.FC<AnalysisLayoutProps> = ({
       setPosition(asideRef.current.getBoundingClientRect());
     }
   }, [asideRef]);
+
+  const scrollRef = useRef(null);
+
+  const clonedChildren = Children.map(children, (Child) => {
+    if (isValidElement(Child)) {
+      return cloneElement(Child, scrollRef);
+    }
+    return null;
+  });
 
   return (
     <ApplicationLayout>
@@ -79,8 +88,11 @@ const AnalysisLayout: React.FC<AnalysisLayoutProps> = ({
           afterEnter={() => setPosition(asideRef?.current?.getBoundingClientRect())}
           afterLeave={() => setPosition(asideRef?.current?.getBoundingClientRect())}
         >
-          <div className="h-full lg:h-screen relative flex flex-col border-r border-gray-200 bg-white overflow-y-auto w-96 px-6">
-            {children}
+          <div
+            ref={scrollRef}
+            className="h-full lg:h-screen relative flex flex-col border-r border-gray-200 bg-white overflow-y-auto w-96 px-6"
+          >
+            {clonedChildren}
           </div>
         </Transition>
       </aside>

--- a/client/src/layouts/analysis/component.tsx
+++ b/client/src/layouts/analysis/component.tsx
@@ -32,11 +32,10 @@ const AnalysisLayout: React.FC<AnalysisLayoutProps> = ({
     }
   }, [asideRef]);
 
-  const scrollRef = useRef(null);
-
+  const scrollRef = useRef<HTMLDivElement>(null);
   const clonedChildren = Children.map(children, (Child) => {
     if (isValidElement(Child)) {
-      return cloneElement(Child, scrollRef);
+      return cloneElement(Child, { scrollRef });
     }
     return null;
   });


### PR DESCRIPTION
This PR adds an infinite scroll of scenarios to the Analysis Page.

- We need to pass the reference of the wrapper (scenarios layout) to the List of scenarios, so we know when to trigger the fetch for the next page
