### PR TITLE
Api/spread user id to required entities

### DIFF
--- a/api/src/decorators/get-user.decorator.ts
+++ b/api/src/decorators/get-user.decorator.ts
@@ -1,7 +1,7 @@
 import { createParamDecorator, ExecutionContext } from '@nestjs/common';
 import { User } from 'modules/users/user.entity';
 
-export const GetUser: ParameterDecorator = createParamDecorator(
+export const GetUser: any = createParamDecorator(
   (_data: unknown, context: ExecutionContext): User => {
     const request: any = context.switchToHttp().getRequest();
     return request.user;

--- a/api/src/decorators/set-user.interceptor.ts
+++ b/api/src/decorators/set-user.interceptor.ts
@@ -15,11 +15,6 @@ export class SetUserInterceptor implements NestInterceptor {
         request.body.userId = request.user.id;
         break;
     }
-    // const token: string = request.headers['authorization'];
-    // if (token) {
-    //   const decoded = jwt_decode(token);
-    //   request.body['userId'] = decoded['id'];
-    // }
 
     return next.handle();
   }

--- a/api/src/decorators/set-user.interceptor.ts
+++ b/api/src/decorators/set-user.interceptor.ts
@@ -1,0 +1,26 @@
+import { CallHandler, ExecutionContext, NestInterceptor } from '@nestjs/common';
+import { Observable } from 'rxjs';
+
+export class SetUserInterceptor implements NestInterceptor {
+  intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
+    const request: any = context.switchToHttp().getRequest();
+    if (!request.user) return next.handle();
+
+    switch (request.method) {
+      case 'PUT':
+      case 'PATCH':
+        request.body.updatedById = request.user.id;
+        break;
+      case 'POST':
+        request.body.userId = request.user.id;
+        break;
+    }
+    // const token: string = request.headers['authorization'];
+    // if (token) {
+    //   const decoded = jwt_decode(token);
+    //   request.body['userId'] = decoded['id'];
+    // }
+
+    return next.handle();
+  }
+}

--- a/api/src/modules/import-data/import-data.controller.ts
+++ b/api/src/modules/import-data/import-data.controller.ts
@@ -11,6 +11,8 @@ import { fileUploadInterceptor } from 'modules/import-data/file-upload.intercept
 import { XlsxPayloadInterceptor } from 'modules/import-data/xlsx-payload.interceptor';
 import { ImportDataService } from 'modules/import-data/import-data.service';
 import { Task } from 'modules/tasks/task.entity';
+import { GetUser } from 'decorators/get-user.decorator';
+import { User } from 'modules/users/user.entity';
 
 @ApiTags('Import Data')
 @Controller(`/api/v1/import`)
@@ -32,9 +34,9 @@ export class ImportDataController {
   @Post('/sourcing-data')
   async importSourcingRecords(
     @UploadedFile() xlsxFile: Express.Multer.File,
+    @GetUser() user: User,
   ): Promise<Partial<Task>> {
-    // TODO: Add userId once auth is in place
-    const userId: string = '2a833cc7-5a6f-492d-9a60-0d6d056923ea';
+    const userId: string = user.id;
     const task: Task = await this.importDataService.validateAndLoadXlsxFile(
       userId,
       xlsxFile,
@@ -44,7 +46,7 @@ export class ImportDataController {
         id: task.id,
         createdAt: task.createdAt,
         status: task.status,
-        createdBy: task.createdBy,
+        createdBy: task.userId,
       },
     };
   }

--- a/api/src/modules/scenario-interventions/dto/update.scenario-intervention.dto.ts
+++ b/api/src/modules/scenario-interventions/dto/update.scenario-intervention.dto.ts
@@ -1,6 +1,11 @@
 import { PartialType } from '@nestjs/swagger';
 import { CreateScenarioInterventionDto } from 'modules/scenario-interventions/dto/create.scenario-intervention.dto';
+import { IsNotEmpty, IsUUID } from 'class-validator';
 
 export class UpdateScenarioInterventionDto extends PartialType(
   CreateScenarioInterventionDto,
-) {}
+) {
+  @IsNotEmpty()
+  @IsUUID()
+  updatedById: string;
+}

--- a/api/src/modules/scenario-interventions/scenario-intervention.entity.ts
+++ b/api/src/modules/scenario-interventions/scenario-intervention.entity.ts
@@ -196,12 +196,12 @@ export class ScenarioIntervention extends TimestampedBaseEntity {
     eager: false,
   })
   @ApiProperty({ type: () => User })
-  lastEditedUser?: User;
+  updatedBy?: User;
 
   /**
    * @debt Auto-assign user and make not nullable
    */
   @Column({ nullable: true })
   @ApiPropertyOptional()
-  lastEditedUserId?: string;
+  updatedById?: string;
 }

--- a/api/src/modules/scenario-interventions/scenario-interventions.controller.ts
+++ b/api/src/modules/scenario-interventions/scenario-interventions.controller.ts
@@ -6,6 +6,7 @@ import {
   Param,
   Patch,
   Post,
+  UseInterceptors,
   UsePipes,
   ValidationPipe,
 } from '@nestjs/common';
@@ -34,6 +35,7 @@ import {
 import { CreateScenarioInterventionDto } from 'modules/scenario-interventions/dto/create.scenario-intervention.dto';
 import { UpdateScenarioInterventionDto } from 'modules/scenario-interventions/dto/update.scenario-intervention.dto';
 import { PaginationMeta } from 'utils/app-base.service';
+import { SetUserInterceptor } from 'decorators/set-user.interceptor';
 
 @Controller(`/api/v1/scenario-interventions`)
 @ApiTags(scenarioResource.className)
@@ -93,6 +95,7 @@ export class ScenarioInterventionsController {
   @ApiOkResponse({ type: ScenarioIntervention })
   @ApiNotFoundResponse({ description: 'Scenario intervention not found' })
   @UsePipes(ValidationPipe)
+  @UseInterceptors(SetUserInterceptor)
   @Patch(':id')
   async update(
     @Body(new ValidationPipe()) dto: UpdateScenarioInterventionDto,

--- a/api/src/modules/scenarios/dto/create.scenario.dto.ts
+++ b/api/src/modules/scenarios/dto/create.scenario.dto.ts
@@ -5,6 +5,7 @@ import {
   IsNotEmpty,
   IsOptional,
   IsString,
+  IsUUID,
   MaxLength,
   MinLength,
 } from 'class-validator';
@@ -28,6 +29,10 @@ export class CreateScenarioDto {
   @IsEnum(Object.values(SCENARIO_STATUS))
   @ApiPropertyOptional()
   status?: string;
+
+  @IsNotEmpty()
+  @IsUUID()
+  userId: string;
 
   @IsString()
   @IsOptional()

--- a/api/src/modules/scenarios/dto/update.scenario.dto.ts
+++ b/api/src/modules/scenarios/dto/update.scenario.dto.ts
@@ -1,6 +1,13 @@
 import { ApiProperty, PartialType } from '@nestjs/swagger';
 import { CreateScenarioDto } from 'modules/scenarios/dto/create.scenario.dto';
-import { IsOptional, IsString, MaxLength, MinLength } from 'class-validator';
+import {
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  IsUUID,
+  MaxLength,
+  MinLength,
+} from 'class-validator';
 
 export class UpdateScenarioDto extends PartialType(CreateScenarioDto) {
   @IsString()
@@ -9,4 +16,12 @@ export class UpdateScenarioDto extends PartialType(CreateScenarioDto) {
   @MaxLength(40)
   @ApiProperty()
   title?: string;
+
+  @IsOptional()
+  @IsUUID()
+  userId?: string;
+
+  @IsNotEmpty()
+  @IsUUID()
+  updatedById: string;
 }

--- a/api/src/modules/scenarios/scenarios.controller.ts
+++ b/api/src/modules/scenarios/scenarios.controller.ts
@@ -6,6 +6,7 @@ import {
   Param,
   Patch,
   Post,
+  UseInterceptors,
   ValidationPipe,
 } from '@nestjs/common';
 import { ScenariosService } from 'modules/scenarios/scenarios.service';
@@ -30,6 +31,7 @@ import { Scenario, scenarioResource } from 'modules/scenarios/scenario.entity';
 import { CreateScenarioDto } from 'modules/scenarios/dto/create.scenario.dto';
 import { UpdateScenarioDto } from 'modules/scenarios/dto/update.scenario.dto';
 import { PaginationMeta } from 'utils/app-base.service';
+import { SetUserInterceptor } from 'decorators/set-user.interceptor';
 
 @Controller(`/api/v1/scenarios`)
 @ApiTags(scenarioResource.className)
@@ -81,6 +83,7 @@ export class ScenariosController {
   @ApiBadRequestResponse({
     description: 'Bad Request. Incorrect or missing parameters',
   })
+  @UseInterceptors(SetUserInterceptor)
   @Post()
   async create(@Body() dto: CreateScenarioDto): Promise<Scenario> {
     return await this.scenariosService.serialize(
@@ -91,6 +94,7 @@ export class ScenariosController {
   @ApiOperation({ description: 'Updates a scenario' })
   @ApiOkResponse({ type: Scenario })
   @ApiNotFoundResponse({ description: 'Scenario not found' })
+  @UseInterceptors(SetUserInterceptor)
   @Patch(':id')
   async update(
     @Body(new ValidationPipe()) dto: UpdateScenarioDto,

--- a/api/src/modules/sourcing-location-groups/dto/update.sourcing-location-group.dto.ts
+++ b/api/src/modules/sourcing-location-groups/dto/update.sourcing-location-group.dto.ts
@@ -1,6 +1,13 @@
 import { ApiProperty, PartialType } from '@nestjs/swagger';
 import { CreateSourcingLocationGroupDto } from 'modules/sourcing-location-groups/dto/create.sourcing-location-group.dto';
-import { IsOptional, IsString, MaxLength, MinLength } from 'class-validator';
+import {
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  IsUUID,
+  MaxLength,
+  MinLength,
+} from 'class-validator';
 
 export class UpdateSourcingLocationGroupDto extends PartialType(
   CreateSourcingLocationGroupDto,
@@ -11,4 +18,8 @@ export class UpdateSourcingLocationGroupDto extends PartialType(
   @MaxLength(40)
   @ApiProperty()
   title?: string;
+
+  @IsNotEmpty()
+  @IsUUID()
+  updatedById: string;
 }

--- a/api/src/modules/sourcing-location-groups/sourcing-location-groups.controller.ts
+++ b/api/src/modules/sourcing-location-groups/sourcing-location-groups.controller.ts
@@ -6,6 +6,7 @@ import {
   Param,
   Patch,
   Post,
+  UseInterceptors,
   UsePipes,
   ValidationPipe,
 } from '@nestjs/common';
@@ -34,6 +35,7 @@ import {
 import { CreateSourcingLocationGroupDto } from 'modules/sourcing-location-groups/dto/create.sourcing-location-group.dto';
 import { UpdateSourcingLocationGroupDto } from 'modules/sourcing-location-groups/dto/update.sourcing-location-group.dto';
 import { PaginationMeta } from 'utils/app-base.service';
+import { SetUserInterceptor } from 'decorators/set-user.interceptor';
 
 @Controller(`/api/v1/sourcing-location-groups`)
 @ApiTags(sourcingLocationGroupResource.className)
@@ -105,6 +107,7 @@ export class SourcingLocationGroupsController {
   @ApiOperation({ description: 'Updates a sourcing location group' })
   @ApiOkResponse({ type: SourcingLocationGroup })
   @ApiNotFoundResponse({ description: 'Sourcing location group not found' })
+  @UseInterceptors(SetUserInterceptor)
   @Patch(':id')
   async update(
     @Body(new ValidationPipe()) dto: UpdateSourcingLocationGroupDto,

--- a/api/src/modules/sourcing-locations/dto/update.sourcing-location.dto.ts
+++ b/api/src/modules/sourcing-locations/dto/update.sourcing-location.dto.ts
@@ -1,6 +1,11 @@
 import { PartialType } from '@nestjs/swagger';
 import { CreateSourcingLocationDto } from 'modules/sourcing-locations/dto/create.sourcing-location.dto';
+import { IsNotEmpty, IsUUID } from 'class-validator';
 
 export class UpdateSourcingLocationDto extends PartialType(
   CreateSourcingLocationDto,
-) {}
+) {
+  @IsNotEmpty()
+  @IsUUID()
+  updatedById: string;
+}

--- a/api/src/modules/sourcing-locations/sourcing-locations.controller.ts
+++ b/api/src/modules/sourcing-locations/sourcing-locations.controller.ts
@@ -7,6 +7,7 @@ import {
   Patch,
   Post,
   Query,
+  UseInterceptors,
   UsePipes,
   ValidationPipe,
 } from '@nestjs/common';
@@ -39,6 +40,7 @@ import { PaginationMeta } from 'utils/app-base.service';
 import { SourcingLocationsMaterialsResponseDto } from 'modules/sourcing-locations/dto/materials.sourcing-location.dto';
 import { GetSourcingMaterialsQueryDto } from 'modules/sourcing-locations/dto/materials-query.sourcing-location.dto';
 import { SourcingLocationsMaterialsService } from 'modules/sourcing-locations/sourcing-locations-materials.service';
+import { SetUserInterceptor } from 'decorators/set-user.interceptor';
 
 @Controller(`/api/v1/sourcing-locations`)
 @ApiTags(sourcingLocationResource.className)
@@ -147,6 +149,7 @@ export class SourcingLocationsController {
   @ApiOperation({ description: 'Updates a sourcing location' })
   @ApiOkResponse({ type: SourcingLocation })
   @ApiNotFoundResponse({ description: 'Sourcing location not found' })
+  @UseInterceptors(SetUserInterceptor)
   @Patch(':id')
   async update(
     @Body(new ValidationPipe()) dto: UpdateSourcingLocationDto,

--- a/api/src/modules/sourcing-records/dto/update.sourcing-record.dto.ts
+++ b/api/src/modules/sourcing-records/dto/update.sourcing-record.dto.ts
@@ -1,6 +1,6 @@
 import { ApiPropertyOptional, PartialType } from '@nestjs/swagger';
 import { CreateSourcingRecordDto } from 'modules/sourcing-records/dto/create.sourcing-record.dto';
-import { IsNumber } from 'class-validator';
+import { IsNotEmpty, IsNumber, IsUUID } from 'class-validator';
 
 export class UpdateSourcingRecordDto extends PartialType(
   CreateSourcingRecordDto,
@@ -12,4 +12,8 @@ export class UpdateSourcingRecordDto extends PartialType(
   @IsNumber()
   @ApiPropertyOptional()
   year?: number;
+
+  @IsNotEmpty()
+  @IsUUID()
+  updatedById: string;
 }

--- a/api/src/modules/sourcing-records/sourcing-record.entity.ts
+++ b/api/src/modules/sourcing-records/sourcing-record.entity.ts
@@ -63,5 +63,5 @@ export class SourcingRecord extends TimestampedBaseEntity {
    */
   @ManyToOne(() => User, (user: User) => user.id)
   @ApiProperty()
-  updatedBy?: string;
+  updatedById?: string;
 }

--- a/api/src/modules/sourcing-records/sourcing-records.controller.ts
+++ b/api/src/modules/sourcing-records/sourcing-records.controller.ts
@@ -6,6 +6,7 @@ import {
   Param,
   Patch,
   Post,
+  UseInterceptors,
   UsePipes,
   ValidationPipe,
 } from '@nestjs/common';
@@ -34,6 +35,7 @@ import {
 import { CreateSourcingRecordDto } from 'modules/sourcing-records/dto/create.sourcing-record.dto';
 import { UpdateSourcingRecordDto } from 'modules/sourcing-records/dto/update.sourcing-record.dto';
 import { PaginationMeta } from 'utils/app-base.service';
+import { SetUserInterceptor } from 'decorators/set-user.interceptor';
 
 @Controller(`/api/v1/sourcing-records`)
 @ApiTags(sourcingRecordResource.className)
@@ -129,6 +131,7 @@ export class SourcingRecordsController {
   @ApiOperation({ description: 'Updates a sourcing record' })
   @ApiOkResponse({ type: SourcingRecord })
   @ApiNotFoundResponse({ description: 'Sourcing record not found' })
+  @UseInterceptors(SetUserInterceptor)
   @Patch(':id')
   async update(
     @Body(new ValidationPipe()) dto: UpdateSourcingRecordDto,

--- a/api/src/modules/sourcing-records/sourcing-records.service.ts
+++ b/api/src/modules/sourcing-records/sourcing-records.service.ts
@@ -52,7 +52,7 @@ export class SourcingRecordsService extends AppBaseService<
         'metadata',
         'createdAt',
         'updatedAt',
-        'updatedBy',
+        'updatedById',
       ],
       keyForAttribute: 'camelCase',
     };

--- a/api/src/modules/targets/dto/create-target.dto.ts
+++ b/api/src/modules/targets/dto/create-target.dto.ts
@@ -22,8 +22,7 @@ export class CreateTargetDto {
   @IsNotEmpty()
   indicatorId!: string;
 
-  @ApiProperty()
   @IsString()
   @IsOptional()
-  lastEditedUserId?: string;
+  updatedById?: string;
 }

--- a/api/src/modules/targets/dto/update-target.dto.ts
+++ b/api/src/modules/targets/dto/update-target.dto.ts
@@ -12,8 +12,7 @@ export class UpdateTargetDto {
   @IsNumber()
   value?: number;
 
-  @ApiProperty()
   @IsOptional()
   @IsString()
-  lastEditedUserId?: string;
+  updatedById?: string;
 }

--- a/api/src/modules/targets/target.entity.ts
+++ b/api/src/modules/targets/target.entity.ts
@@ -51,5 +51,5 @@ export class Target extends TimestampedBaseEntity {
   @ManyToOne(() => User, (user: User) => user.id)
   @ApiProperty()
   @Column({ nullable: true })
-  lastEditedUserId?: string;
+  updatedById?: string;
 }

--- a/api/src/modules/targets/targets.controller.ts
+++ b/api/src/modules/targets/targets.controller.ts
@@ -6,6 +6,7 @@ import {
   Param,
   Patch,
   Post,
+  UseInterceptors,
   UsePipes,
   ValidationPipe,
 } from '@nestjs/common';
@@ -28,6 +29,7 @@ import { CreateTargetDto } from 'modules/targets/dto/create-target.dto';
 import { UpdateTargetDto } from 'modules/targets/dto/update-target.dto';
 import { Target, targetResource } from 'modules/targets/target.entity';
 import { TargetsService } from 'modules/targets/targets.service';
+import { SetUserInterceptor } from 'decorators/set-user.interceptor';
 
 @Controller('api/v1/targets')
 @ApiTags(targetResource.className)
@@ -85,6 +87,7 @@ export class TargetsController {
   @ApiOkResponse({ type: Target })
   @ApiNotFoundResponse({ description: 'Target not found' })
   @UsePipes(ValidationPipe)
+  @UseInterceptors(SetUserInterceptor)
   @Patch(':id')
   async update(
     @Body() dto: UpdateTargetDto,

--- a/api/src/modules/tasks/dto/create-task.dto.ts
+++ b/api/src/modules/tasks/dto/create-task.dto.ts
@@ -13,10 +13,9 @@ export class CreateTaskDto {
   @IsString()
   status!: TASK_STATUS;
 
-  @ApiProperty()
   @IsNotEmpty()
   @IsUUID()
-  createdBy: string;
+  userId: string;
 
   @ApiProperty()
   @IsOptional()

--- a/api/src/modules/tasks/task.entity.ts
+++ b/api/src/modules/tasks/task.entity.ts
@@ -41,7 +41,7 @@ export class Task extends TimestampedBaseEntity {
 
   @ApiProperty()
   @Column({ type: 'uuid' })
-  createdBy!: string;
+  userId!: string;
 
   @ApiProperty()
   @Column({ type: 'enum', enum: TASK_STATUS, default: TASK_STATUS.PROCESSING })

--- a/api/src/modules/tasks/tasks.controller.ts
+++ b/api/src/modules/tasks/tasks.controller.ts
@@ -6,6 +6,7 @@ import {
   Param,
   Post,
   Put,
+  UseInterceptors,
   UsePipes,
   ValidationPipe,
 } from '@nestjs/common';
@@ -27,6 +28,7 @@ import { Task, taskResource } from 'modules/tasks/task.entity';
 import { TasksService } from 'modules/tasks/tasks.service';
 import { UpdateTaskWithControllerDto } from 'modules/tasks/dto/update-task-with-controller.dto';
 import { CreateTaskDto } from 'modules/tasks/dto/create-task.dto';
+import { SetUserInterceptor } from 'decorators/set-user.interceptor';
 
 @Controller('/api/v1/tasks')
 @ApiTags(taskResource.className)
@@ -67,6 +69,7 @@ export class TasksController {
   @ApiBadRequestResponse({
     description: 'Bad Request. Incorrect or missing parameters',
   })
+  @UseInterceptors(SetUserInterceptor)
   @Post()
   @UsePipes(ValidationPipe)
   async create(@Body() dto: CreateTaskDto): Promise<Task> {

--- a/api/src/modules/tasks/tasks.service.ts
+++ b/api/src/modules/tasks/tasks.service.ts
@@ -42,7 +42,7 @@ export class TasksService extends AppBaseService<
         'data',
         'errors',
         'logs',
-        'createdBy',
+        'userId',
       ],
       keyForAttribute: 'camelCase',
     };
@@ -64,7 +64,7 @@ export class TasksService extends AppBaseService<
     return this.create({
       type: TASK_TYPE.SOURCING_DATA_IMPORT,
       status: TASK_STATUS.PROCESSING,
-      createdBy: userId,
+      userId,
       data: data ?? {},
     });
   }

--- a/api/src/modules/users/user.entity.ts
+++ b/api/src/modules/users/user.entity.ts
@@ -102,7 +102,7 @@ export class User extends BaseEntity {
   @OneToMany(
     () => ScenarioIntervention,
     (scenarioIntervention: ScenarioIntervention) =>
-      scenarioIntervention.lastEditedUser,
+      scenarioIntervention.updatedBy,
   )
   scenarioInterventionsLastEdited: ScenarioIntervention[];
 }

--- a/api/test/e2e/scenario-interventions/scenario-interventions.spec.ts
+++ b/api/test/e2e/scenario-interventions/scenario-interventions.spec.ts
@@ -18,7 +18,7 @@ import {
   createScenarioIntervention,
   createSupplier,
 } from '../../entity-mocks';
-import { saveUserAndGetToken } from '../../utils/userAuth';
+import { saveUserAndGetTokenWithUserId } from '../../utils/userAuth';
 import { getApp } from '../../utils/getApp';
 import { Scenario } from 'modules/scenarios/scenario.entity';
 import { Material } from 'modules/materials/material.entity';
@@ -96,6 +96,7 @@ describe('ScenarioInterventionsModule (e2e)', () => {
   let adminRegionRepository: AdminRegionRepository;
   let geoRegionRepository: GeoRegionRepository;
   let jwtToken: string;
+  let userId: string;
 
   beforeAll(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
@@ -131,7 +132,9 @@ describe('ScenarioInterventionsModule (e2e)', () => {
 
     app = getApp(moduleFixture);
     await app.init();
-    jwtToken = await saveUserAndGetToken(moduleFixture, app);
+    const tokenWithId = await saveUserAndGetTokenWithUserId(moduleFixture, app);
+    jwtToken = tokenWithId.jwtToken;
+    userId = tokenWithId.userId;
   });
 
   afterEach(async () => {
@@ -770,6 +773,12 @@ describe('ScenarioInterventionsModule (e2e)', () => {
           title: 'updated test scenario intervention',
         })
         .expect(HttpStatus.OK);
+
+      const updatedScenarioIntervention =
+        await scenarioInterventionRepository.findOneOrFail(
+          scenarioIntervention.id,
+        );
+      expect(updatedScenarioIntervention.updatedById).toEqual(userId);
 
       expect(response.body.data.attributes.title).toEqual(
         'updated test scenario intervention',

--- a/api/test/e2e/scenarios/scenarios.spec.ts
+++ b/api/test/e2e/scenarios/scenarios.spec.ts
@@ -6,7 +6,7 @@ import { Scenario, SCENARIO_STATUS } from 'modules/scenarios/scenario.entity';
 import { ScenariosModule } from 'modules/scenarios/scenarios.module';
 import { ScenarioRepository } from 'modules/scenarios/scenario.repository';
 import { createScenario } from '../../entity-mocks';
-import { saveUserAndGetToken } from '../../utils/userAuth';
+import { saveUserAndGetTokenWithUserId } from '../../utils/userAuth';
 import { getApp } from '../../utils/getApp';
 
 const expectedJSONAPIAttributes: string[] = [
@@ -22,6 +22,7 @@ describe('ScenariosModule (e2e)', () => {
   let app: INestApplication;
   let scenarioRepository: ScenarioRepository;
   let jwtToken: string;
+  let userId: string;
 
   beforeAll(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
@@ -33,7 +34,9 @@ describe('ScenariosModule (e2e)', () => {
 
     app = getApp(moduleFixture);
     await app.init();
-    jwtToken = await saveUserAndGetToken(moduleFixture, app);
+    const tokenWithId = await saveUserAndGetTokenWithUserId(moduleFixture, app);
+    jwtToken = tokenWithId.jwtToken;
+    userId = tokenWithId.userId;
   });
 
   afterEach(async () => {
@@ -63,6 +66,7 @@ describe('ScenariosModule (e2e)', () => {
       }
 
       expect(createdScenario.title).toEqual('test scenario');
+      expect(createdScenario.userId).toEqual(userId);
 
       expect(response).toHaveJSONAPIAttributes(expectedJSONAPIAttributes);
     });
@@ -102,6 +106,10 @@ describe('ScenariosModule (e2e)', () => {
       expect(response.body.data.attributes.title).toEqual(
         'updated test scenario',
       );
+      const updatedScenario: Scenario = await scenarioRepository.findOneOrFail(
+        scenario.id,
+      );
+      expect(updatedScenario.updatedById).toEqual(userId);
 
       expect(response).toHaveJSONAPIAttributes(expectedJSONAPIAttributes);
     });

--- a/api/test/e2e/sourcing-locations/sourcing-locations.spec.ts
+++ b/api/test/e2e/sourcing-locations/sourcing-locations.spec.ts
@@ -7,7 +7,7 @@ import { SourcingLocationsModule } from 'modules/sourcing-locations/sourcing-loc
 import { SourcingLocationRepository } from 'modules/sourcing-locations/sourcing-location.repository';
 import { createMaterial, createSourcingLocation } from '../../entity-mocks';
 import { Material } from 'modules/materials/material.entity';
-import { saveUserAndGetToken } from '../../utils/userAuth';
+import { saveUserAndGetTokenWithUserId } from '../../utils/userAuth';
 import { getApp } from '../../utils/getApp';
 
 /**
@@ -18,6 +18,7 @@ describe('SourcingLocationsModule (e2e)', () => {
   let app: INestApplication;
   let sourcingLocationRepository: SourcingLocationRepository;
   let jwtToken: string;
+  let userId: string;
 
   beforeAll(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
@@ -30,7 +31,10 @@ describe('SourcingLocationsModule (e2e)', () => {
 
     app = getApp(moduleFixture);
     await app.init();
-    jwtToken = await saveUserAndGetToken(moduleFixture, app);
+
+    const tokenWithId = await saveUserAndGetTokenWithUserId(moduleFixture, app);
+    jwtToken = tokenWithId.jwtToken;
+    userId = tokenWithId.userId;
   });
 
   afterEach(async () => {
@@ -102,6 +106,11 @@ describe('SourcingLocationsModule (e2e)', () => {
           title: 'updated test sourcing location',
         })
         .expect(HttpStatus.OK);
+
+      const updatedSourcingLocation =
+        await sourcingLocationRepository.findOneOrFail(sourcingLocation.id);
+
+      expect(updatedSourcingLocation.updatedById).toEqual(userId);
 
       expect(response.body.data.attributes.title).toEqual(
         'updated test sourcing location',

--- a/api/test/e2e/tasks/tasks.spec.ts
+++ b/api/test/e2e/tasks/tasks.spec.ts
@@ -48,7 +48,7 @@ describe('Tasks Module (e2e)', () => {
         .send({
           type: TASK_TYPE.SOURCING_DATA_IMPORT,
           status: TASK_STATUS.PROCESSING,
-          createdBy: '2a833cc7-5a6f-492d-9a60-0d6d056923ea',
+          userId: '2a833cc7-5a6f-492d-9a60-0d6d056923ea',
           data: {
             filename: 'fakeFile.xlsx',
           },
@@ -61,7 +61,7 @@ describe('Tasks Module (e2e)', () => {
         throw new Error('Error loading created Task');
       }
 
-      expect(createdTask.createdBy).toEqual(
+      expect(createdTask.userId).toEqual(
         '2a833cc7-5a6f-492d-9a60-0d6d056923ea',
       );
       expect(createdTask.data.filename).toEqual('fakeFile.xlsx');
@@ -82,8 +82,8 @@ describe('Tasks Module (e2e)', () => {
         'type should not be empty',
         'status must be a string',
         'status should not be empty',
-        'createdBy must be a UUID',
-        'createdBy should not be empty',
+        'userId must be a UUID',
+        'userId should not be empty',
       ],
     );
   });
@@ -92,7 +92,7 @@ describe('Tasks Module (e2e)', () => {
     test('Updating a task should be successful (happy case)', async () => {
       const task: Task = await createTask({
         status: TASK_STATUS.ABORTED,
-        createdBy: '2a833cc7-5a6f-492d-9a60-0d6d056923eb',
+        userId: '2a833cc7-5a6f-492d-9a60-0d6d056923eb',
       });
 
       const response = await request(app.getHttpServer())
@@ -107,7 +107,7 @@ describe('Tasks Module (e2e)', () => {
         .expect(HttpStatus.OK);
 
       expect(response.body.data.attributes.status).toEqual('failed');
-      expect(response.body.data.attributes.createdBy).toEqual(
+      expect(response.body.data.attributes.userId).toEqual(
         '2a833cc7-5a6f-492d-9a60-0d6d056923eb',
       );
       expect(response.body.data.attributes.data.file2).toEqual('File2');

--- a/api/test/entity-mocks.ts
+++ b/api/test/entity-mocks.ts
@@ -316,7 +316,7 @@ async function createTask(additionalData: Partial<Task> = {}): Promise<Task> {
   const task: Task = Task.merge(
     new Task(),
     {
-      createdBy: '2a833cc7-5a6f-492d-9a60-0d6d056923ea',
+      userId: '2a833cc7-5a6f-492d-9a60-0d6d056923ea',
       type: TASK_TYPE.SOURCING_DATA_IMPORT,
       data: {
         filename: 'fakeFile.xlsx',

--- a/api/test/integration/import-data/xlsx-uploads/import-data-produce-jobs.spec.ts
+++ b/api/test/integration/import-data/xlsx-uploads/import-data-produce-jobs.spec.ts
@@ -49,7 +49,7 @@ describe('XLSX Upload Feature Job Producer Tests', () => {
       xlsxFileData,
     });
     expect(tasks[0].status).toEqual('processing');
-    expect(tasks[0].createdBy).toEqual(userId);
+    expect(tasks[0].userId).toEqual(userId);
   }, 100000);
   test('When loadXlsxFile is called with required file data and a userId, but the Job can not be added to the queue, and the related tasks should be removed', async () => {
     await bootstrapTestingApp(importQueueFail);

--- a/api/test/utils/userAuth.ts
+++ b/api/test/utils/userAuth.ts
@@ -9,6 +9,14 @@ export async function saveUserAndGetToken(
   moduleFixture: TestingModule,
   app: INestApplication,
 ): Promise<string> {
+  const tokenWithUser = await saveUserAndGetTokenWithUserId(moduleFixture, app);
+  return tokenWithUser.jwtToken;
+}
+
+export async function saveUserAndGetTokenWithUserId(
+  moduleFixture: TestingModule,
+  app: INestApplication,
+): Promise<{ jwtToken: string; userId: string }> {
   const salt = await genSalt();
   const userRepository = moduleFixture.get<UserRepository>(UserRepository);
   await userRepository.save({
@@ -21,5 +29,5 @@ export async function saveUserAndGetToken(
   const response = await request(app.getHttpServer())
     .post('/auth/sign-in')
     .send(E2E_CONFIG.users.signIn);
-  return response.body.accessToken;
+  return { jwtToken: response.body.accessToken, userId: response.body.user.id };
 }


### PR DESCRIPTION
automatically set userId/updatedById on all entities where userId or updatedById  columns where set.

In some cases naming was different, for example createdId instead of userId, and in such cases i renamed columns to be consistent throughout project.