### PR TITLE
Fix/client/tree selector query

### DIFF
--- a/client/src/components/tree-select/component.tsx
+++ b/client/src/components/tree-select/component.tsx
@@ -25,14 +25,14 @@ const THEMES = {
       'flex-wrap w-full bg-white relative border border-gray-300 rounded-md shadow-sm py-2 pr-10 pl-3 cursor-pointer',
     arrow: 'inset-y-0 right-0 items-center pr-2  text-gray-900',
     treeNodes:
-      'flex items-center space-x-2 pr-1 py-2 whitespace-nowrap text-sm cursor-pointer hover:bg-green-50 hover:text-green-700',
+      'flex items-center space-x-2 px-1 py-2 whitespace-nowrap text-sm cursor-pointer hover:bg-green-50 hover:text-green-700',
   },
   'inline-primary': {
     label: 'truncate text-ellipsis font-bold cursor-pointer px-0 py-0',
     wrapper: 'border-b-2 border-green-700 max-w-[190px] overflow-x-hidden truncate text-ellipsis',
     arrow: '-bottom-3  transform left-1/2 -translate-x-1/2 text-green-700',
     treeNodes:
-      'flex items-center space-x-2 pr-1 py-2 whitespace-nowrap text-sm cursor-pointer hover:bg-green-50 hover:text-green-700',
+      'flex items-center space-x-2 px-1 py-2 whitespace-nowrap text-sm cursor-pointer hover:bg-green-50 hover:text-green-700',
     treeContent: 'max-w-xl',
   },
 };
@@ -71,21 +71,18 @@ const TreeSelect: React.FC<TreeSelectProps> = ({
   const renderTreeNodes = useMemo(
     () =>
       (data, counter = 0) =>
-        data.map((item) => {
-          const padding = counter * 4;
-          return (
-            <TreeNode
-              key={item.value}
-              title={item.label}
-              className={classNames(THEMES[theme].treeNodes, {
-                [`pl-${padding}`]: !!padding,
-                'bg-green-50 text-green-700 font-semibold': selectedKeys.includes(item.value),
-              })}
-            >
-              {item.children && renderTreeNodes(item.children, counter + 1)}
-            </TreeNode>
-          );
-        }),
+        data.map((item) => (
+          <TreeNode
+            key={item.value}
+            title={item.label}
+            className={classNames(THEMES[theme].treeNodes, {
+              'bg-green-50 text-green-700 font-semibold': selectedKeys.includes(item.value),
+            })}
+            style={{ paddingLeft: 16 * counter }}
+          >
+            {item.children && renderTreeNodes(item.children, counter + 1)}
+          </TreeNode>
+        )),
     [selectedKeys, theme],
   );
 

--- a/client/src/components/tree-select/component.tsx
+++ b/client/src/components/tree-select/component.tsx
@@ -17,7 +17,6 @@ import Loading from 'components/loading';
 import { CHECKED_STRATEGIES } from './utils';
 
 import type { TreeSelectProps, TreeSelectOption } from './types';
-import { some } from 'lodash';
 
 const THEMES = {
   default: {
@@ -26,14 +25,14 @@ const THEMES = {
       'flex-wrap w-full bg-white relative border border-gray-300 rounded-md shadow-sm py-2 pr-10 pl-3 cursor-pointer',
     arrow: 'inset-y-0 right-0 items-center pr-2  text-gray-900',
     treeNodes:
-      'flex items-center space-x-2 px-1 py-2 whitespace-nowrap text-sm cursor-pointer hover:bg-green-50 hover:text-green-700',
+      'flex items-center space-x-2 pr-1 py-2 whitespace-nowrap text-sm cursor-pointer hover:bg-green-50 hover:text-green-700',
   },
   'inline-primary': {
     label: 'truncate text-ellipsis font-bold cursor-pointer px-0 py-0',
     wrapper: 'border-b-2 border-green-700 max-w-[190px] overflow-x-hidden truncate text-ellipsis',
     arrow: '-bottom-3  transform left-1/2 -translate-x-1/2 text-green-700',
     treeNodes:
-      'flex items-center space-x-2 px-1 py-2 whitespace-nowrap text-sm cursor-pointer hover:bg-green-50 hover:text-green-700',
+      'flex items-center space-x-2 pr-1 py-2 whitespace-nowrap text-sm cursor-pointer hover:bg-green-50 hover:text-green-700',
     treeContent: 'max-w-xl',
   },
 };
@@ -72,17 +71,21 @@ const TreeSelect: React.FC<TreeSelectProps> = ({
   const renderTreeNodes = useMemo(
     () =>
       (data, counter = 0) =>
-        data.map((item) => (
-          <TreeNode
-            key={item.value}
-            title={item.label}
-            className={classNames(THEMES[theme].treeNodes, `pl-${4 * counter}`, {
-              'bg-green-50 text-green-700 font-semibold': selectedKeys.includes(item.value),
-            })}
-          >
-            {item.children && renderTreeNodes(item.children, counter + 1)}
-          </TreeNode>
-        )),
+        data.map((item) => {
+          const padding = counter * 4;
+          return (
+            <TreeNode
+              key={item.value}
+              title={item.label}
+              className={classNames(THEMES[theme].treeNodes, {
+                [`pl-${padding}`]: !!padding,
+                'bg-green-50 text-green-700 font-semibold': selectedKeys.includes(item.value),
+              })}
+            >
+              {item.children && renderTreeNodes(item.children, counter + 1)}
+            </TreeNode>
+          );
+        }),
     [selectedKeys, theme],
   );
 
@@ -111,16 +114,7 @@ const TreeSelect: React.FC<TreeSelectProps> = ({
   // Selection for multiple
   const handleCheck = useCallback(
     (checkedKeys, info) => {
-      const { checkedNodes, halfCheckedKeys } = info;
-
-      // TO DO - API
-      // Find nodes of half selected options (parent that has no all children selected)
-      // const halfCheckedNodes = options
-      //   .filter(({ value }) => halfCheckedKeys.includes(value))
-      //   .map(({ label, value }) => ({
-      //     label,
-      //     value,
-      //   }));
+      const { checkedNodes } = info;
 
       // Depending of the checked strategy apply different filters
       const filteredValues = CHECKED_STRATEGIES[checkedStrategy](checkedKeys, checkedNodes);
@@ -138,7 +132,6 @@ const TreeSelect: React.FC<TreeSelectProps> = ({
           recursiveSearch(options);
         });
       }
-
 
       if (onChange) onChange(checkedOptions);
       setCheckedKeys(filteredValues);

--- a/client/src/components/tree-select/component.tsx
+++ b/client/src/components/tree-select/component.tsx
@@ -17,6 +17,7 @@ import Loading from 'components/loading';
 import { CHECKED_STRATEGIES } from './utils';
 
 import type { TreeSelectProps, TreeSelectOption } from './types';
+import { some } from 'lodash';
 
 const THEMES = {
   default: {
@@ -110,7 +111,16 @@ const TreeSelect: React.FC<TreeSelectProps> = ({
   // Selection for multiple
   const handleCheck = useCallback(
     (checkedKeys, info) => {
-      const { checkedNodes } = info;
+      const { checkedNodes, halfCheckedKeys } = info;
+
+      // TO DO - API
+      // Find nodes of half selected options (parent that has no all children selected)
+      // const halfCheckedNodes = options
+      //   .filter(({ value }) => halfCheckedKeys.includes(value))
+      //   .map(({ label, value }) => ({
+      //     label,
+      //     value,
+      //   }));
 
       // Depending of the checked strategy apply different filters
       const filteredValues = CHECKED_STRATEGIES[checkedStrategy](checkedKeys, checkedNodes);
@@ -128,6 +138,7 @@ const TreeSelect: React.FC<TreeSelectProps> = ({
           recursiveSearch(options);
         });
       }
+
 
       if (onChange) onChange(checkedOptions);
       setCheckedKeys(filteredValues);

--- a/client/src/containers/analysis-visualization/analysis-filters/origin-regions/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-filters/origin-regions/component.tsx
@@ -36,7 +36,11 @@ const OriginRegionsFilter: React.FC<OriginRegionsFilterProps> = ({
         data?.map(({ name, id, children }) => ({
           label: name,
           value: id,
-          children: children?.map(({ name, id }) => ({ label: name, value: id })),
+          children: children?.map(({ name, id, children }) => ({
+            label: name,
+            value: id,
+            children: children?.map(({ name, id }) => ({ label: name, value: id })),
+          })),
         })),
         'label',
       ),

--- a/client/src/containers/filters/years-range/component.tsx
+++ b/client/src/containers/filters/years-range/component.tsx
@@ -7,7 +7,6 @@ import Select from 'components/select';
 import type { SelectOption } from 'components/select/types';
 
 import { YearsRangeFilterProps } from './types';
-import { start } from 'repl';
 
 export const YearsRangeFilter: React.FC<YearsRangeFilterProps> = ({
   startYear,

--- a/client/src/containers/filters/years-range/component.tsx
+++ b/client/src/containers/filters/years-range/component.tsx
@@ -7,6 +7,7 @@ import Select from 'components/select';
 import type { SelectOption } from 'components/select/types';
 
 import { YearsRangeFilterProps } from './types';
+import { start } from 'repl';
 
 export const YearsRangeFilter: React.FC<YearsRangeFilterProps> = ({
   startYear,
@@ -32,7 +33,6 @@ export const YearsRangeFilter: React.FC<YearsRangeFilterProps> = ({
 
   useEffect(() => {
     if (!years.length) return;
-
     setStartYearOptions(
       years?.map((year) => ({
         label: year.toString(),
@@ -54,7 +54,13 @@ export const YearsRangeFilter: React.FC<YearsRangeFilterProps> = ({
 
   useEffect(() => {
     if (!startYearOptions || !endYearOptions) return;
-    setStartYearOption(startYearOptions.find((option) => option.value === startYear));
+
+    const startYearForRange =
+      startYear === endYear
+        ? startYearOptions[0]
+        : startYearOptions.find((option) => option.value === startYear);
+
+    setStartYearOption(startYearForRange);
     setEndYearOption(endYearOptions.find((option) => option.value === endYear));
   }, [startYearOptions, endYearOptions, startYear, endYear]);
 

--- a/client/src/hooks/impact/index.ts
+++ b/client/src/hooks/impact/index.ts
@@ -41,6 +41,7 @@ export function useImpactData(): ImpactDataResponse {
   const { data: indicators } = useIndicators();
   const { layer } = useAppSelector(analysisFilters);
   const filters = filtersForTabularAPI(store.getState());
+
   const isEnable =
     !!filters?.indicatorId && !!indicators?.length && !!filters.startYear && !!filters.endYear;
 
@@ -56,6 +57,7 @@ export function useImpactData(): ImpactDataResponse {
             startYear: filters.startYear,
             endYear: filters.endYear,
             groupBy: filters.groupBy,
+            ...filters,
           },
         })
         .then((response) => response.data),

--- a/client/src/store/features/analysis/selector.ts
+++ b/client/src/store/features/analysis/selector.ts
@@ -8,6 +8,7 @@ import type {
   ImpactH3APIParams,
   ImpactTabularAPIParams,
 } from 'types';
+import material from 'containers/interventions/new/step2/material';
 
 export const filtersForH3API = createSelector(
   [analysisFilters],


### PR DESCRIPTION
**DESCRIPTION**
bug: Filters for materials, regions, and suppliers were not included in the API call for impact data.

This PR adds the filters to the query and forces the table and chart to start with a range of years instead of a single one. It also shows a third level for the tree select component and forces padding to change for the deepest levels.


**JIRA**
https://vizzuality.atlassian.net/browse/LANDGRIF-570?atlOrigin=eyJpIjoiZDlkYmQ2ZDFhNmMxNGJiMTg4ZTY0NDVhOTMzNDg2YmEiLCJwIjoiaiJ9