### PR TITLE
fixing the tooltip view in the analysis chart

### DIFF
--- a/client/src/components/chart/area-stacked/component.tsx
+++ b/client/src/components/chart/area-stacked/component.tsx
@@ -61,6 +61,7 @@ const AreaStacked: React.FC<AreaStackedProps> = ({
   },
 }: AreaStackedProps) => {
   const { showTooltip, hideTooltip, tooltipData, tooltipTop, tooltipLeft } = useTooltip();
+  const limitedKeys = keys.slice(0, 6);
 
   const lastCurrentIndex = useMemo(() => {
     const i = data.findIndex((d) => !d.current);
@@ -374,7 +375,7 @@ const AreaStacked: React.FC<AreaStackedProps> = ({
           tooltipTop={tooltipTop}
           tooltipLeft={tooltipLeft + margin.left}
           tooltipData={tooltipData}
-          keys={keys}
+          keys={limitedKeys}
           colors={colors}
         />
       )}

--- a/client/src/components/chart/area-stacked/tooltip/component.tsx
+++ b/client/src/components/chart/area-stacked/tooltip/component.tsx
@@ -36,7 +36,7 @@ const AreaStackedTooltip: React.FC<AreaStackedTooltipProps> = ({
   if (!tooltipData) return null;
 
   return (
-    <TooltipWithBounds top={tooltipTop} left={tooltipLeft}>
+    <TooltipWithBounds top={tooltipTop} left={tooltipLeft} className="z-10">
       <div className="flex flex-col p-2.5 space-y-2">
         <h3>{title}</h3>
 

--- a/client/src/components/chart/area-stacked/tooltip/component.tsx
+++ b/client/src/components/chart/area-stacked/tooltip/component.tsx
@@ -36,7 +36,7 @@ const AreaStackedTooltip: React.FC<AreaStackedTooltipProps> = ({
   if (!tooltipData) return null;
 
   return (
-    <TooltipWithBounds top={tooltipTop} left={tooltipLeft} className="z-10">
+    <TooltipWithBounds top={tooltipTop} left={tooltipLeft}>
       <div className="flex flex-col p-2.5 space-y-2">
         <h3>{title}</h3>
 


### PR DESCRIPTION
 in the `area-stacked` component  adding a slice to the tooltip keys to limit the long data view
and since the data will be limited in tooltip no bug will appear


![Screenshot 2022-03-24 at 9 23 15 AM](https://user-images.githubusercontent.com/59052222/159873531-f7a1f1e5-8a2e-4df1-a19f-2adaf0bacca7.png)

[LANDGRIF-552](https://vizzuality.atlassian.net/browse/LANDGRIF-552?atlOrigin=eyJpIjoiM2YxMjMyZmRiZWI1NDFmZDgwYTNmMWFlNDUxYWI2Y2UiLCJwIjoiaiJ9)