### PR TITLE
chore: Add Country to geoCodeByAddress for more accuracy

### DIFF
--- a/api/src/modules/admin-regions/admin-regions.service.ts
+++ b/api/src/modules/admin-regions/admin-regions.service.ts
@@ -77,10 +77,10 @@ export class AdminRegionsService extends AppBaseService<
   // TODO: proper typing after validating this works
   async getAdminAndGeoRegionIdByCountryIsoAlpha2(
     countryIsoAlpha2Code: string,
-  ): Promise<{ id: string; geoRegionId: string }> {
+  ): Promise<{ adminRegionId: string; geoRegionId: string }> {
     const adminAndGeoRegionId: any = await this.adminRegionRepository
       .createQueryBuilder('ar')
-      .select('id')
+      .select('id', 'adminRegionId')
       .addSelect('"geoRegionId"')
       .where('ar.isoA2 = :countryIsoAlpha2Code', {
         countryIsoAlpha2Code: countryIsoAlpha2Code,

--- a/api/src/modules/geo-coding/geo-coding-abstract-class.ts
+++ b/api/src/modules/geo-coding/geo-coding-abstract-class.ts
@@ -1,7 +1,8 @@
 import { SourcingData } from 'modules/import-data/sourcing-data/dto-processor.service';
+import { SourcingLocation } from 'modules/sourcing-locations/sourcing-location.entity';
 
 export abstract class GeoCodingAbstractClass {
   abstract geoCodeLocations(
     sourcingData: SourcingData[],
-  ): Promise<SourcingData[]>;
+  ): Promise<SourcingLocation[]>;
 }

--- a/api/src/modules/geo-coding/geo-coding.service.ts
+++ b/api/src/modules/geo-coding/geo-coding.service.ts
@@ -4,7 +4,10 @@ import { PointOfProductionGeocodingStrategy } from 'modules/geo-coding/strategie
 import { CountryOfProductionGeoCodingStrategy } from 'modules/geo-coding/strategies/country-of-production.geocoding.service';
 import { UnknownLocationGeoCodingStrategy } from 'modules/geo-coding/strategies/unknown-location.geocoding.service';
 import { SourcingData } from 'modules/import-data/sourcing-data/dto-processor.service';
-import { LOCATION_TYPES } from 'modules/sourcing-locations/sourcing-location.entity';
+import {
+  LOCATION_TYPES,
+  SourcingLocation,
+} from 'modules/sourcing-locations/sourcing-location.entity';
 import { GeoCodingAbstractClass } from 'modules/geo-coding/geo-coding-abstract-class';
 
 @Injectable()
@@ -22,11 +25,11 @@ export class GeoCodingService extends GeoCodingAbstractClass {
 
   async geoCodeLocations(
     sourcingData: SourcingData[],
-  ): Promise<SourcingData[]> {
+  ): Promise<SourcingLocation[]> {
     this.logger.log(
       `Geocoding locations for ${sourcingData.length} sourcing record elements`,
     );
-    const geoCodedSourcingData: SourcingData[] = [];
+    const geoCodedSourcingData: SourcingLocation[] = [];
     await Promise.all(
       sourcingData.map(async (sourcingData: SourcingData) => {
         if (sourcingData.locationType === LOCATION_TYPES.UNKNOWN) {
@@ -59,7 +62,7 @@ export class GeoCodingService extends GeoCodingAbstractClass {
 
   async geoCodeAggregationPoint(
     sourcingData: SourcingData,
-  ): Promise<SourcingData> {
+  ): Promise<SourcingLocation> {
     return this.aggregationPointGeocodingService.geoCodeAggregationPoint(
       sourcingData,
     );
@@ -67,7 +70,7 @@ export class GeoCodingService extends GeoCodingAbstractClass {
 
   async geoCodePointOfProduction(
     sourcingData: SourcingData,
-  ): Promise<SourcingData> {
+  ): Promise<SourcingLocation> {
     return this.pointOfProductionGeocodingService.geoCodePointOfProduction(
       sourcingData,
     );
@@ -75,7 +78,7 @@ export class GeoCodingService extends GeoCodingAbstractClass {
 
   async geoCodeCountryOfProduction(
     sourcingData: SourcingData,
-  ): Promise<SourcingData> {
+  ): Promise<SourcingLocation> {
     return this.countryOfProductionService.geoCodeCountryOfProduction(
       sourcingData,
     );
@@ -83,7 +86,7 @@ export class GeoCodingService extends GeoCodingAbstractClass {
 
   async geoCodeUnknownLocationType(
     sourcingData: SourcingData,
-  ): Promise<SourcingData> {
+  ): Promise<SourcingLocation> {
     return this.unknownLocationService.geoCodeUnknownLocationType(sourcingData);
   }
 }

--- a/api/src/modules/geo-coding/strategies/aggregation-point.geocoding.service.ts
+++ b/api/src/modules/geo-coding/strategies/aggregation-point.geocoding.service.ts
@@ -52,6 +52,7 @@ export class AggregationPointGeocodingStrategy extends BaseStrategy {
     if (sourcingData.locationAddressInput) {
       const geocodedResponseData: GeocodeResponse = await this.geoCodeByAddress(
         sourcingData.locationAddressInput,
+        sourcingData.locationCountryInput,
       );
 
       /**

--- a/api/src/modules/geo-coding/strategies/base-strategy.ts
+++ b/api/src/modules/geo-coding/strategies/base-strategy.ts
@@ -31,9 +31,12 @@ export abstract class BaseStrategy {
     return geocodeResponseData;
   }
 
-  async geoCodeByAddress(locationAddress: string): Promise<GeocodeResponse> {
+  async geoCodeByAddress(
+    locationAddress: string,
+    locationCountry: string,
+  ): Promise<GeocodeResponse> {
     const geocodeResponseData: GeocodeResponse = await this.geocoder.geocode({
-      address: locationAddress,
+      address: `${locationAddress}, ${locationCountry}`,
     });
     return geocodeResponseData;
   }

--- a/api/src/modules/geo-coding/strategies/country-of-production.geocoding.service.ts
+++ b/api/src/modules/geo-coding/strategies/country-of-production.geocoding.service.ts
@@ -28,7 +28,7 @@ export class CountryOfProductionGeoCodingStrategy extends BaseStrategy {
       sourcingData?.locationCountryInput,
     );
 
-    const { id: adminRegionId, geoRegionId } =
+    const { adminRegionId, geoRegionId } =
       await this.adminRegionService.getAdminAndGeoRegionIdByCountryIsoAlpha2(
         geoCodedResponse.results[0]?.address_components?.[0]?.short_name,
       );

--- a/api/src/modules/geo-coding/strategies/point-of-production.geocoding.service.ts
+++ b/api/src/modules/geo-coding/strategies/point-of-production.geocoding.service.ts
@@ -41,6 +41,7 @@ export class PointOfProductionGeocodingStrategy extends BaseStrategy {
     if (sourcingData.locationAddressInput) {
       const geoCodeResponseData: GeocodeResponse = await this.geoCodeByAddress(
         sourcingData.locationAddressInput,
+        sourcingData.locationCountryInput,
       );
 
       const geoRegionId: Pick<GeoRegion, 'id'> =

--- a/api/src/modules/geo-coding/strategies/unknown-location.geocoding.service.ts
+++ b/api/src/modules/geo-coding/strategies/unknown-location.geocoding.service.ts
@@ -27,7 +27,7 @@ export class UnknownLocationGeoCodingStrategy extends BaseStrategy {
       sourcingData?.locationCountryInput,
     );
 
-    const { id: adminRegionId, geoRegionId } =
+    const { adminRegionId, geoRegionId } =
       await this.adminRegionService.getAdminAndGeoRegionIdByCountryIsoAlpha2(
         geoCodedResponse.results[0]?.address_components?.[0]?.short_name,
       );

--- a/api/src/modules/sourcing-locations/dto/create.sourcing-location.dto.ts
+++ b/api/src/modules/sourcing-locations/dto/create.sourcing-location.dto.ts
@@ -66,11 +66,10 @@ export class CreateSourcingLocationDto {
   @ApiPropertyOptional()
   locationAddressInput?: string;
 
-  @IsOptional()
   @IsString()
   @MinLength(2)
-  @ApiPropertyOptional()
-  locationCountryInput?: string;
+  @ApiProperty()
+  locationCountryInput!: string;
 
   @IsString()
   @IsOptional()


### PR DESCRIPTION
I realised for some 'special' locations the geocode can't determine the geolocation data, which can be easily solved by addring:
`address: 'addressInfo', 'countryInfo'`

This PR adds a new mandatory param to geoCodeByAddress to consume this info
Also makes the locationCountryInput mandatory for sourcingLocations DTO as it the minimal required geo-info for any location