### PR TITLE
Client/feature/landgrif 581 zoom controls

### DIFF
--- a/client/src/components/map/controls/zoom/component.tsx
+++ b/client/src/components/map/controls/zoom/component.tsx
@@ -11,20 +11,27 @@ export interface ZoomControlProps {
   onZoomChange: (zoom: number) => void;
 }
 
-const HOVER_CLASSES = 'hover:bg-gray-300 active:bg-gray-200 cursor-pointer';
+const ENABLED_CLASSES = 'hover:bg-gray-300 active:bg-gray-200 cursor-pointer';
 const DISABLED_CLASSES = 'opacity-50 cursor-default';
 
 export const ZoomControl: React.FC<ZoomControlProps> = ({
   className,
-  viewport: { zoom, maxZoom, minZoom },
+  viewport: { zoom, maxZoom },
   onZoomChange,
 }) => {
+  // Something weird happens with zooms below 1, the maps's min zoom is 1.28.
+  // Values below 1 move the data as if the map were zoomed out, but it is not
+  // The minZoom we receive is 0, so we need to check for that.
+  const minZoom = 1.29;
+
   const increaseZoom = useCallback(
     (e) => {
       e.stopPropagation();
 
       if (zoom + 1 <= maxZoom) {
         onZoomChange(zoom + 1);
+      } else {
+        onZoomChange(maxZoom);
       }
     },
     [zoom, maxZoom, onZoomChange],
@@ -35,7 +42,9 @@ export const ZoomControl: React.FC<ZoomControlProps> = ({
       e.stopPropagation();
 
       if (zoom - 1 >= minZoom) {
-        onZoomChange(Math.ceil(zoom - 1));
+        onZoomChange(zoom - 1);
+      } else {
+        onZoomChange(minZoom);
       }
     },
     [zoom, minZoom, onZoomChange],
@@ -54,24 +63,24 @@ export const ZoomControl: React.FC<ZoomControlProps> = ({
     >
       <button
         className={cx('p-2', {
-          [HOVER_CLASSES]: zoom !== maxZoom,
-          [DISABLED_CLASSES]: zoom === maxZoom,
+          [ENABLED_CLASSES]: zoom < maxZoom,
+          [DISABLED_CLASSES]: zoom >= maxZoom,
         })}
         aria-label="Zoom in"
         type="button"
-        disabled={zoom === maxZoom}
+        disabled={zoom >= maxZoom}
         onClick={increaseZoom}
       >
         <PlusIcon className="w-5 h-5" />
       </button>
       <button
         className={cx('p-2', {
-          [HOVER_CLASSES]: zoom !== minZoom,
-          [DISABLED_CLASSES]: zoom === minZoom,
+          [ENABLED_CLASSES]: zoom > minZoom,
+          [DISABLED_CLASSES]: zoom <= minZoom,
         })}
         aria-label="Zoom out"
         type="button"
-        disabled={zoom === minZoom}
+        disabled={zoom <= minZoom}
         onClick={decreaseZoom}
       >
         <MinusIcon className="w-5 h-5" />

--- a/client/src/components/map/controls/zoom/component.tsx
+++ b/client/src/components/map/controls/zoom/component.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 import cx from 'classnames';
 
 import { MinusIcon, PlusIcon } from '@heroicons/react/solid';
@@ -11,13 +11,14 @@ export interface ZoomControlProps {
   onZoomChange: (zoom: number) => void;
 }
 
+const HOVER_CLASSES = 'hover:bg-gray-300 active:bg-gray-200 cursor-pointer';
+const DISABLED_CLASSES = 'opacity-50 cursor-default';
+
 export const ZoomControl: React.FC<ZoomControlProps> = ({
   className,
-  viewport,
+  viewport: { zoom, maxZoom, minZoom },
   onZoomChange,
-}: ZoomControlProps) => {
-  const { zoom, maxZoom, minZoom } = viewport;
-
+}) => {
   const increaseZoom = useCallback(
     (e) => {
       e.stopPropagation();
@@ -33,25 +34,28 @@ export const ZoomControl: React.FC<ZoomControlProps> = ({
     (e) => {
       e.stopPropagation();
 
-      if (zoom + 1 >= minZoom) {
-        onZoomChange(zoom - 1);
+      if (zoom - 1 >= minZoom) {
+        onZoomChange(Math.ceil(zoom - 1));
       }
     },
     [zoom, minZoom, onZoomChange],
   );
 
+  useEffect(() => {
+    onZoomChange(zoom);
+  }, [onZoomChange, zoom]);
+
   return (
     <div
-      className={cx({
-        'inline-flex flex-col': true,
-        [className]: !!className,
-      })}
+      className={cx(
+        'bg-white text-gray-900 w-fit ml-auto mr-0 mb-4 text-4xl flex flex-col justify-center select-none divide-y-[1.5px] rounded-lg border border-gray-200 overflow-hidden',
+        className,
+      )}
     >
       <button
-        className={cx({
-          'mb-0.5 p-0.5 rounded-t-3xl text-white bg-black': true,
-          'hover:bg-gray-700 active:bg-gray-600': zoom !== maxZoom,
-          'opacity-50 cursor-default': zoom === maxZoom,
+        className={cx('p-2', {
+          [HOVER_CLASSES]: zoom !== maxZoom,
+          [DISABLED_CLASSES]: zoom === maxZoom,
         })}
         aria-label="Zoom in"
         type="button"
@@ -61,10 +65,9 @@ export const ZoomControl: React.FC<ZoomControlProps> = ({
         <PlusIcon className="w-5 h-5" />
       </button>
       <button
-        className={cx({
-          'p-0.5 rounded-b-3xl text-white bg-black': true,
-          'hover:bg-gray-700 active:bg-gray-600': zoom !== minZoom,
-          'opacity-50 cursor-default': zoom === minZoom,
+        className={cx('p-2', {
+          [HOVER_CLASSES]: zoom !== minZoom,
+          [DISABLED_CLASSES]: zoom === minZoom,
         })}
         aria-label="Zoom out"
         type="button"

--- a/client/src/components/map/legend/component.tsx
+++ b/client/src/components/map/legend/component.tsx
@@ -50,7 +50,7 @@ export const Legend: React.FC<LegendProps> = ({
 
       {active && (
         <div
-          className="relative flex flex-col flex-grow overflow-hidden rounded rounded-tr-none border border-gray-200 shadow-sm bg-white rounded"
+          className="relative flex flex-col flex-grow overflow-hidden rounded rounded-tr-none border border-gray-200 shadow-sm bg-white"
           style={{
             maxHeight,
           }}

--- a/client/src/containers/analysis-visualization/analysis-map/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-map/component.tsx
@@ -2,7 +2,7 @@ import type { PopUpProps } from 'components/map/popup/types';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import DeckGL from '@deck.gl/react';
 import { H3HexagonLayer } from '@deck.gl/geo-layers';
-import { StaticMap, NavigationControl } from 'react-map-gl';
+import { StaticMap } from 'react-map-gl';
 import { XCircleIcon } from '@heroicons/react/solid';
 
 import { useAppSelector } from 'store/hooks';
@@ -242,9 +242,7 @@ const AnalysisMap: React.FC = () => {
       {(isFetching || isRendering) && <PageLoading />}
       <DeckGL
         viewState={viewState}
-        onViewStateChange={({ viewState, ...x }) => {
-          console.log({ ...x, viewState });
-
+        onViewStateChange={({ viewState }) => {
           setViewState(viewState);
         }}
         controller


### PR DESCRIPTION
This PR adds zoom controls to the map, just above the legend
![image](https://user-images.githubusercontent.com/1385934/161963257-5eb08fcd-5420-4a30-bf12-22262780f5bc.png)

# Things to take into account
- When the legend opens the arrow is positioned wrong. Because David is working on redesigning it I left it as is to avoid conflicts as much as possible.
![image](https://user-images.githubusercontent.com/1385934/161963361-4e052a73-0b0e-4a7a-baee-923928bf8c59.png)

- As I explain in a comment, there's some weird behaviour with the map and the zoom level. DeckGL returns the `minZoom` as 0, but the map itself only zooms out until 1.28. Because of this, if the zoom is below than value the data is misaligned (as if the map were zoomed out). I hacked a fix hardcoding the true `minZoom` value, because I couldn't find a way to retrieve it otherwise.
