### PR TITLE
return impact table data with children and aggregated data for parents

### DIFF
--- a/api/src/modules/admin-regions/admin-region.repository.ts
+++ b/api/src/modules/admin-regions/admin-region.repository.ts
@@ -105,7 +105,11 @@ export class AdminRegionRepository extends ExtendedTreeRepository<
         .select('ar.id')
         .innerJoin(SourcingLocation, 'sl', 'sl.adminRegionId = ar.id')
         .distinct(true);
-
+    if (adminRegionTreeOptions.originIds) {
+      queryBuilder.andWhere('ar.id IN (:...originIds)', {
+        originIds: adminRegionTreeOptions.originIds,
+      });
+    }
     if (adminRegionTreeOptions.supplierIds) {
       queryBuilder.andWhere('sl.t1SupplierId IN (:...supplierIds)', {
         supplierIds: adminRegionTreeOptions.supplierIds,

--- a/api/src/modules/admin-regions/dto/get-admin-region-tree-with-options.dto.ts
+++ b/api/src/modules/admin-regions/dto/get-admin-region-tree-with-options.dto.ts
@@ -36,4 +36,9 @@ export class GetAdminRegionTreeWithOptionsDto {
   @ApiPropertyOptional()
   @IsOptional()
   businessUnitIds?: string[];
+
+  @IsUUID('4', { each: true })
+  @ApiPropertyOptional()
+  @IsOptional()
+  originIds?: string[];
 }

--- a/api/src/modules/impact/dto/response-impact-table.dto.ts
+++ b/api/src/modules/impact/dto/response-impact-table.dto.ts
@@ -37,6 +37,8 @@ export class ImpactTableRows {
   name: string;
   @ApiProperty({ type: () => ImpactTableRowsValues, isArray: true })
   values: ImpactTableRowsValues[];
+  @ApiProperty({ type: () => ImpactTableRows, isArray: true })
+  children: ImpactTableRows[];
 }
 
 export class YearSumData {

--- a/api/src/modules/impact/impact.module.ts
+++ b/api/src/modules/impact/impact.module.ts
@@ -3,9 +3,20 @@ import { ImpactService } from 'modules/impact/impact.service';
 import { ImpactController } from 'modules/impact/impact.controller';
 import { IndicatorsModule } from 'modules/indicators/indicators.module';
 import { SourcingRecordsModule } from 'modules/sourcing-records/sourcing-records.module';
+import { BusinessUnitsModule } from 'modules/business-units/business-units.module';
+import { AdminRegionsModule } from 'modules/admin-regions/admin-regions.module';
+import { SuppliersModule } from 'modules/suppliers/suppliers.module';
+import { MaterialsModule } from 'modules/materials/materials.module';
 
 @Module({
-  imports: [IndicatorsModule, SourcingRecordsModule],
+  imports: [
+    IndicatorsModule,
+    SourcingRecordsModule,
+    BusinessUnitsModule,
+    AdminRegionsModule,
+    SuppliersModule,
+    MaterialsModule,
+  ],
   providers: [ImpactService],
   controllers: [ImpactController],
   exports: [ImpactService],

--- a/api/src/modules/materials/dto/get-material-tree-with-options.dto.ts
+++ b/api/src/modules/materials/dto/get-material-tree-with-options.dto.ts
@@ -36,4 +36,9 @@ export class GetMaterialTreeWithOptionsDto {
   @ApiPropertyOptional()
   @IsOptional()
   originIds?: string[];
+
+  @IsUUID('4', { each: true })
+  @ApiPropertyOptional()
+  @IsOptional()
+  materialIds?: string[];
 }

--- a/api/src/modules/materials/material.repository.ts
+++ b/api/src/modules/materials/material.repository.ts
@@ -27,7 +27,11 @@ export class MaterialRepository extends ExtendedTreeRepository<
       .select('m.id')
       .innerJoin(SourcingLocation, 'sl', 'sl.materialId = m.id')
       .distinct(true);
-
+    if (materialTreeOptions.materialIds) {
+      queryBuilder.andWhere('m.id IN (:...materialIds)', {
+        materialIds: materialTreeOptions.materialIds,
+      });
+    }
     if (materialTreeOptions.supplierIds) {
       queryBuilder.andWhere('sl.t1SupplierId IN (:...supplierIds)', {
         supplierIds: materialTreeOptions.supplierIds,

--- a/api/src/modules/sourcing-records/sourcing-record.repository.ts
+++ b/api/src/modules/sourcing-records/sourcing-record.repository.ts
@@ -160,7 +160,7 @@ export class SourcingRecordRepository extends Repository<SourcingRecord> {
       default:
     }
     impactDataQueryBuilder
-      .addGroupBy(`sourcingRecords.year, sourcingRecords.id, indicator.id`)
+      .addGroupBy(`sourcingRecords.year, indicator.id`)
       .orderBy('year', 'ASC')
       .orderBy('name');
     const dataForImpactTable: ImpactTableData[] =
@@ -209,7 +209,7 @@ export class SourcingRecordRepository extends Repository<SourcingRecord> {
                       "interventionType"
                   FROM
                       sourcing_location
-                  WHERE "scenarioInterventionId" IS NULL 
+                  WHERE "scenarioInterventionId" IS NULL
                   AND "interventionType" IS NULL
               ) as sl
               on sr."sourcingLocationId" = sl.id`);

--- a/api/src/modules/suppliers/dto/get-supplier-tree-with-options.dto.ts
+++ b/api/src/modules/suppliers/dto/get-supplier-tree-with-options.dto.ts
@@ -36,4 +36,9 @@ export class GetSupplierTreeWithOptions {
   @ApiPropertyOptional()
   @IsOptional()
   originIds?: string[];
+
+  @IsUUID('4', { each: true })
+  @ApiPropertyOptional()
+  @IsOptional()
+  supplierIds?: string[];
 }

--- a/api/src/modules/suppliers/supplier.repository.ts
+++ b/api/src/modules/suppliers/supplier.repository.ts
@@ -31,6 +31,12 @@ export class SupplierRepository extends ExtendedTreeRepository<
         '(s.id = sl.t1SupplierId OR s.id = sl.producerId)',
       )
       .distinct(true);
+
+    if (supplierTreeOptions.supplierIds) {
+      queryBuilder.andWhere('s.id IN (:...supplierIds)', {
+        supplierIds: supplierTreeOptions.supplierIds,
+      });
+    }
     if (supplierTreeOptions.materialIds) {
       queryBuilder.andWhere('sl.materialId IN (:...materialIds)', {
         materialIds: supplierTreeOptions.materialIds,

--- a/api/src/types/impact-table-entity.type.ts
+++ b/api/src/types/impact-table-entity.type.ts
@@ -1,0 +1,10 @@
+import { BusinessUnit } from 'modules/business-units/business-unit.entity';
+import { AdminRegion } from 'modules/admin-regions/admin-region.entity';
+import { Supplier } from 'modules/suppliers/supplier.entity';
+import { Material } from 'modules/materials/material.entity';
+
+export type ImpactTableEntityType =
+  | BusinessUnit
+  | AdminRegion
+  | Supplier
+  | Material;

--- a/api/test/e2e/impact/impact.spec.ts
+++ b/api/test/e2e/impact/impact.spec.ts
@@ -540,6 +540,28 @@ describe('Impact Table and Charts test suite (e2e)', () => {
       expect(response.body.data.impactTable[0].yearSum).toEqual(
         expect.arrayContaining(groupByMaterialNestedResponseData.yearSum),
       );
+      /*
+       * Even if we pass only one material id,
+       * full tree for that id shoudl be returned
+       */
+      const responseWithFilter = await request(app.getHttpServer())
+        .get('/api/v1/impact/table')
+        .set('Authorization', `Bearer ${jwtToken}`)
+        .query({
+          'indicatorIds[]': [indicator.id],
+          'materialIds[]': [grandchildMaterial.id],
+          endYear: 2013,
+          startYear: 2010,
+          groupBy: 'material',
+        })
+        .expect(HttpStatus.OK);
+      expect(responseWithFilter.body.data.impactTable[0].rows).toHaveLength(1);
+      expect(responseWithFilter.body.data.impactTable[0].rows).toEqual(
+        expect.arrayContaining(groupByMaterialNestedResponseData.rows),
+      );
+      expect(responseWithFilter.body.data.impactTable[0].yearSum).toEqual(
+        expect.arrayContaining(groupByMaterialNestedResponseData.yearSum),
+      );
     });
 
     test('Impact table grouped by Region should be successful', async () => {

--- a/api/test/e2e/impact/response-mocks.impact.ts
+++ b/api/test/e2e/impact/response-mocks.impact.ts
@@ -24,6 +24,7 @@ export const groupByMaterialResponseData = {
           isProjected: true,
         },
       ],
+      children: [],
     },
     {
       name: 'Fake Material 2',
@@ -47,6 +48,110 @@ export const groupByMaterialResponseData = {
           year: 2013,
           value: 2131.5,
           isProjected: true,
+        },
+      ],
+      children: [],
+    },
+  ],
+  yearSum: [
+    {
+      year: 2010,
+      value: 3000,
+    },
+    {
+      year: 2011,
+      value: 3100,
+    },
+    {
+      year: 2012,
+      value: 3200,
+    },
+    {
+      year: 2013,
+      value: 3248,
+    },
+  ],
+};
+
+export const groupByMaterialNestedResponseData = {
+  rows: [
+    {
+      name: 'Fake Material Parent',
+      values: [
+        {
+          year: 2010,
+          value: 3000,
+          isProjected: false,
+        },
+        {
+          year: 2011,
+          value: 3100,
+          isProjected: false,
+        },
+        {
+          year: 2012,
+          value: 3200,
+          isProjected: false,
+        },
+        {
+          year: 2013,
+          value: 3248,
+          isProjected: true,
+        },
+      ],
+      children: [
+        {
+          name: 'Fake Material Child',
+          values: [
+            {
+              year: 2010,
+              value: 3000,
+              isProjected: false,
+            },
+            {
+              year: 2011,
+              value: 3100,
+              isProjected: false,
+            },
+            {
+              year: 2012,
+              value: 3200,
+              isProjected: false,
+            },
+            {
+              year: 2013,
+              value: 3248,
+              isProjected: true,
+            },
+          ],
+          children: [
+            {
+              name: 'Fake Material Grandchild',
+              values: [
+                {
+                  year: 2010,
+                  value: 1000,
+                  isProjected: false,
+                },
+                {
+                  year: 2011,
+                  value: 1050,
+                  isProjected: false,
+                },
+                {
+                  year: 2012,
+                  value: 1100,
+                  isProjected: false,
+                },
+                {
+                  year: 2013,
+                  value: 1116.5,
+                  isProjected: true,
+                },
+              ],
+              children: [],
+            },
+          ],
         },
       ],
     },
@@ -81,6 +186,7 @@ export const groupByOriginResponseData = {
         { isProjected: false, value: 700, year: 2012 },
         { isProjected: true, value: 710.5, year: 2013 },
       ],
+      children: [],
     },
     {
       name: 'Fake AdminRegion 2',
@@ -90,6 +196,7 @@ export const groupByOriginResponseData = {
         { isProjected: false, value: 600, year: 2012 },
         { isProjected: true, value: 609, year: 2013 },
       ],
+      children: [],
     },
   ],
   yearSum: [
@@ -122,6 +229,7 @@ export const groupBySupplierResponseData = {
         { isProjected: false, value: 200, year: 2012 },
         { isProjected: true, value: 203, year: 2013 },
       ],
+      children: [],
     },
     {
       name: 'Fake Supplier 2',
@@ -131,6 +239,7 @@ export const groupBySupplierResponseData = {
         { isProjected: false, value: 400, year: 2012 },
         { isProjected: true, value: 406, year: 2013 },
       ],
+      children: [],
     },
   ],
   yearSum: [
@@ -151,6 +260,7 @@ export const groupByBusinessUnitResponseData = {
         { isProjected: false, value: 200, year: 2012 },
         { isProjected: true, value: 203, year: 2013 },
       ],
+      children: [],
     },
     {
       name: 'Fake BusinessUnit 2',
@@ -160,6 +270,7 @@ export const groupByBusinessUnitResponseData = {
         { isProjected: false, value: 400, year: 2012 },
         { isProjected: true, value: 406, year: 2013 },
       ],
+      children: [],
     },
   ],
   yearSum: [


### PR DESCRIPTION
modify impacts table endpoint to return full trees of entities, with parents having the aggregated values of the children