### PR TITLE
Add service to get Admin Regions descendants ids

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -15,7 +15,7 @@
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "test": "NODE_OPTIONS=\"--max-old-space-size=4096\" node ./node_modules/.bin/jest --config test/jest-config.json -i --logHeapUsage --detectOpenHandles --forceExit",
     "test:watch": "jest --config test/jest-config.json --watch",
-    "test:cov": "NODE_OPTIONS=\"--max-old-space-size=4096\" node ./node_modules/.bin/jest --config test/jest-config.json --coverage -i --logHeapUsage --detectOpenHandles --forceExit",
+    "test:cov": "NODE_OPTIONS=\"--max-old-space-size=5120\" node ./node_modules/.bin/jest --config test/jest-config.json --coverage -i --logHeapUsage --detectOpenHandles --forceExit",
     "test:debug": "node --inspect-brk --expose-gc -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --config test/jest-config.json --runInBand --detectOpenHandles --forceExit",
     "migration:revert": "ts-node -r tsconfig-paths/register ./node_modules/typeorm/cli.js migration:revert --config src/migration.config.ts"
   },

--- a/api/src/modules/admin-regions/admin-regions.service.ts
+++ b/api/src/modules/admin-regions/admin-regions.service.ts
@@ -160,12 +160,13 @@ export class AdminRegionsService extends AppBaseService<
   }
 
   async getAdminRegionDescendants(adminRegionIds: string[]): Promise<string[]> {
+    // using type casting not to search for and provide the full entity, since only id is used by the method (to improve performance)
     let adminRegions: AdminRegion[] = [];
     for (const id of adminRegionIds) {
       const result: AdminRegion[] =
         await this.adminRegionRepository.findDescendants({
           id,
-        } as AdminRegion); // using type casting not to search for and provide the full entity, since only id is used by the method (to improve performance)
+        } as AdminRegion);
       adminRegions = [...adminRegions, ...result];
     }
 

--- a/api/src/modules/admin-regions/admin-regions.service.ts
+++ b/api/src/modules/admin-regions/admin-regions.service.ts
@@ -159,7 +159,7 @@ export class AdminRegionsService extends AppBaseService<
     return this.adminRegionRepository.findByIds(ids);
   }
 
-  async getAdminRegionDescendants(adminRegionIds: string[]): Promise<any> {
+  async getAdminRegionDescendants(adminRegionIds: string[]): Promise<string[]> {
     let adminRegions: AdminRegion[] = [];
     for (const id of adminRegionIds) {
       const adminRegion: AdminRegion | undefined =

--- a/api/src/modules/admin-regions/admin-regions.service.ts
+++ b/api/src/modules/admin-regions/admin-regions.service.ts
@@ -162,18 +162,10 @@ export class AdminRegionsService extends AppBaseService<
   async getAdminRegionDescendants(adminRegionIds: string[]): Promise<string[]> {
     let adminRegions: AdminRegion[] = [];
     for (const id of adminRegionIds) {
-      const adminRegion: AdminRegion | undefined =
-        await this.adminRegionRepository.findOne(id);
-
-      if (!adminRegion)
-        throw new NotFoundException(
-          `There is no Admin region for Material with ID: ${id}`,
-        );
-
       const result: AdminRegion[] =
-        await this.adminRegionRepository.findDescendants(
-          adminRegion as AdminRegion,
-        );
+        await this.adminRegionRepository.findDescendants({
+          id,
+        } as AdminRegion); // using type casting not to search for and provide the full entity, since only id is used by the method (to improve performance)
       adminRegions = [...adminRegions, ...result];
     }
 

--- a/api/src/modules/admin-regions/admin-regions.service.ts
+++ b/api/src/modules/admin-regions/admin-regions.service.ts
@@ -158,4 +158,25 @@ export class AdminRegionsService extends AppBaseService<
   async getAdminRegionByIds(ids: string[]): Promise<AdminRegion[]> {
     return this.adminRegionRepository.findByIds(ids);
   }
+
+  async getAdminRegionDescendants(adminRegionIds: string[]): Promise<any> {
+    let adminRegions: AdminRegion[] = [];
+    for (const id of adminRegionIds) {
+      const adminRegion: AdminRegion | undefined =
+        await this.adminRegionRepository.findOne(id);
+
+      if (!adminRegion)
+        throw new NotFoundException(
+          `There is no Admin region for Material with ID: ${id}`,
+        );
+
+      const result: AdminRegion[] =
+        await this.adminRegionRepository.findDescendants(
+          adminRegion as AdminRegion,
+        );
+      adminRegions = [...adminRegions, ...result];
+    }
+
+    return adminRegions.map((adminRegion: AdminRegion) => adminRegion.id);
+  }
 }

--- a/api/src/modules/business-units/business-units.service.ts
+++ b/api/src/modules/business-units/business-units.service.ts
@@ -97,12 +97,13 @@ export class BusinessUnitsService extends AppBaseService<
   async getBusinessUnitsDescendants(
     businessUnitIds: string[],
   ): Promise<string[]> {
+    // using type casting not to search for and provide the full entity, since only id is used by the method (to improve performance)
     let businessUnits: BusinessUnit[] = [];
     for (const id of businessUnitIds) {
       const result: BusinessUnit[] =
         await this.businessUnitRepository.findDescendants({
           id,
-        } as BusinessUnit); // using type casting not to search for and provide the full entity, since only id is used by the method (to improve performance)
+        } as BusinessUnit);
       businessUnits = [...businessUnits, ...result];
     }
 

--- a/api/src/modules/business-units/business-units.service.ts
+++ b/api/src/modules/business-units/business-units.service.ts
@@ -93,4 +93,25 @@ export class BusinessUnitsService extends AppBaseService<
       );
     return this.buildTree<BusinessUnit>(businessUnitsLineage, null);
   }
+
+  async getBusinessUnitsDescendants(
+    businessUnitIds: string[],
+  ): Promise<string[]> {
+    let businessUnits: BusinessUnit[] = [];
+    for (const id of businessUnitIds) {
+      const businessUnit: BusinessUnit | undefined =
+        await this.businessUnitRepository.findOne(id);
+
+      if (!businessUnit)
+        throw new NotFoundException(`There is no Business Unit with ID: ${id}`);
+
+      const result: BusinessUnit[] =
+        await this.businessUnitRepository.findDescendants(
+          businessUnit as BusinessUnit,
+        );
+      businessUnits = [...businessUnits, ...result];
+    }
+
+    return businessUnits.map((businessUnit: BusinessUnit) => businessUnit.id);
+  }
 }

--- a/api/src/modules/business-units/business-units.service.ts
+++ b/api/src/modules/business-units/business-units.service.ts
@@ -99,16 +99,10 @@ export class BusinessUnitsService extends AppBaseService<
   ): Promise<string[]> {
     let businessUnits: BusinessUnit[] = [];
     for (const id of businessUnitIds) {
-      const businessUnit: BusinessUnit | undefined =
-        await this.businessUnitRepository.findOne(id);
-
-      if (!businessUnit)
-        throw new NotFoundException(`There is no Business Unit with ID: ${id}`);
-
       const result: BusinessUnit[] =
-        await this.businessUnitRepository.findDescendants(
-          businessUnit as BusinessUnit,
-        );
+        await this.businessUnitRepository.findDescendants({
+          id,
+        } as BusinessUnit); // using type casting not to search for and provide the full entity, since only id is used by the method (to improve performance)
       businessUnits = [...businessUnits, ...result];
     }
 

--- a/api/src/modules/impact/impact.service.ts
+++ b/api/src/modules/impact/impact.service.ts
@@ -45,10 +45,33 @@ export class ImpactService {
     let entities: ImpactTableEntityType[] = [];
 
     /*
+     * Getting Descendants Ids for the filters, in case Parent Ids were received
+     */
+
+    if (impactTableDto.originIds)
+      impactTableDto.originIds =
+        await this.adminRegionsService.getAdminRegionDescendants(
+          impactTableDto.originIds,
+        );
+    if (impactTableDto.materialIds)
+      impactTableDto.materialIds =
+        await this.materialsService.getMaterialsDescendants(
+          impactTableDto.materialIds,
+        );
+    if (impactTableDto.supplierIds)
+      impactTableDto.supplierIds =
+        await this.suppliersService.getSuppliersDescendants(
+          impactTableDto.supplierIds,
+        );
+
+    /*
      * Get full entity tree in cate ids are not passed,
      * otherwise get trees based on given ids and add children and parent
      * ids to them to get full data for aggregations
      */
+
+    // TODO check if tree ids search is redundant
+
     switch (impactTableDto.groupBy) {
       case GROUP_BY_VALUES.MATERIAL:
         if (impactTableDto.materialIds) {

--- a/api/src/modules/materials/materials.service.ts
+++ b/api/src/modules/materials/materials.service.ts
@@ -170,12 +170,13 @@ export class MaterialsService extends AppBaseService<
     return this.findTreesWithOptions({ depth: materialTreeOptions.depth });
   }
 
-  async getMaterialsDescendants(materialIds: string[]): Promise<any> {
+  async getMaterialsDescendants(materialIds: string[]): Promise<string[]> {
+    // using type casting not to search for and provide the full entity, since only id is used by the method (to improve performance)
     let materials: Material[] = [];
     for (const id of materialIds) {
       const result: Material[] = await this.materialRepository.findDescendants({
         id,
-      } as Material); // using type casting not to search for and provide the full entity, since only id is used by the method (to improve performance)
+      } as Material);
       materials = [...materials, ...result];
     }
 

--- a/api/src/modules/materials/materials.service.ts
+++ b/api/src/modules/materials/materials.service.ts
@@ -173,15 +173,9 @@ export class MaterialsService extends AppBaseService<
   async getMaterialsDescendants(materialIds: string[]): Promise<any> {
     let materials: Material[] = [];
     for (const id of materialIds) {
-      const material: Material | undefined =
-        await this.materialRepository.findOne(id);
-
-      if (!material)
-        throw new NotFoundException(`There is no Material with ID: ${id}`);
-
-      const result: Material[] = await this.materialRepository.findDescendants(
-        material as Material,
-      );
+      const result: Material[] = await this.materialRepository.findDescendants({
+        id,
+      } as Material); // using type casting not to search for and provide the full entity, since only id is used by the method (to improve performance)
       materials = [...materials, ...result];
     }
 

--- a/api/src/modules/materials/materials.service.ts
+++ b/api/src/modules/materials/materials.service.ts
@@ -169,4 +169,22 @@ export class MaterialsService extends AppBaseService<
       return this.getMaterialsTreeWithSourcingLocations(materialTreeOptions);
     return this.findTreesWithOptions({ depth: materialTreeOptions.depth });
   }
+
+  async getMaterialsDescendants(materialIds: string[]): Promise<any> {
+    let materials: Material[] = [];
+    for (const id of materialIds) {
+      const material: Material | undefined =
+        await this.materialRepository.findOne(id);
+
+      if (!material)
+        throw new NotFoundException(`There is no Material with ID: ${id}`);
+
+      const result: Material[] = await this.materialRepository.findDescendants(
+        material as Material,
+      );
+      materials = [...materials, ...result];
+    }
+
+    return materials.map((material: Material) => material.id);
+  }
 }

--- a/api/src/modules/scenario-interventions/dto/create.scenario-intervention.dto.ts
+++ b/api/src/modules/scenario-interventions/dto/create.scenario-intervention.dto.ts
@@ -119,7 +119,7 @@ export class CreateScenarioInterventionDto {
     type: [String],
     example: 'bc5e4933-cd9a-4afc-bd53-56941b8adca3',
   })
-  adminRegionsIds!: string[];
+  adminRegionIds!: string[];
 
   @IsOptional()
   @ApiPropertyOptional({

--- a/api/src/modules/scenario-interventions/dto/create.scenario-intervention.dto.ts
+++ b/api/src/modules/scenario-interventions/dto/create.scenario-intervention.dto.ts
@@ -119,7 +119,7 @@ export class CreateScenarioInterventionDto {
     type: [String],
     example: 'bc5e4933-cd9a-4afc-bd53-56941b8adca3',
   })
-  adminRegionIds!: string[];
+  adminRegionsIds!: string[];
 
   @IsOptional()
   @ApiPropertyOptional({

--- a/api/src/modules/scenario-interventions/scenario-interventions.service.ts
+++ b/api/src/modules/scenario-interventions/scenario-interventions.service.ts
@@ -109,9 +109,9 @@ export class ScenarioInterventionsService extends AppBaseService<
       dto.materialIds,
     );
 
-    dto.adminRegionsIds =
+    dto.adminRegionIds =
       await this.adminRegionService.getAdminRegionDescendants(
-        dto.adminRegionsIds,
+        dto.adminRegionIds,
       );
 
     dto.supplierIds = await this.suppliersService.getSuppliersDescendants(

--- a/api/src/modules/scenario-interventions/scenario-interventions.service.ts
+++ b/api/src/modules/scenario-interventions/scenario-interventions.service.ts
@@ -156,7 +156,7 @@ export class ScenarioInterventionsService extends AppBaseService<
       newScenarioIntervention.replacedSuppliers =
         await this.suppliersService.getSuppliersById(dto.supplierIds);
     }
-    if (dto.adminRegionsIds?.length) {
+    if (dto.adminRegionIds?.length) {
       newScenarioIntervention.replacedAdminRegions =
         await this.adminRegionService.getAdminRegionsById(dto.adminRegionIds);
     }

--- a/api/src/modules/scenario-interventions/scenario-interventions.service.ts
+++ b/api/src/modules/scenario-interventions/scenario-interventions.service.ts
@@ -102,6 +102,27 @@ export class ScenarioInterventionsService extends AppBaseService<
     dto: CreateScenarioInterventionDto,
   ): Promise<ScenarioIntervention> {
     /**
+     *  Getting descendants of adminRegions, materials, suppliers adn businessUnits received as filters, if exists
+     */
+
+    dto.materialIds = await this.materialService.getMaterialsDescendants(
+      dto.materialIds,
+    );
+
+    dto.adminRegionsIds =
+      await this.adminRegionService.getAdminRegionDescendants(
+        dto.adminRegionsIds,
+      );
+
+    dto.supplierIds = await this.suppliersService.getSuppliersDescendants(
+      dto.supplierIds,
+    );
+
+    dto.businessUnitIds =
+      await this.businessUnitService.getBusinessUnitsDescendants(
+        dto.businessUnitIds,
+      );
+    /**
      *  Creating New Intervention to be saved in scenario_interventions table
      */
     const newScenarioIntervention: ScenarioIntervention =
@@ -135,7 +156,7 @@ export class ScenarioInterventionsService extends AppBaseService<
       newScenarioIntervention.replacedSuppliers =
         await this.suppliersService.getSuppliersById(dto.supplierIds);
     }
-    if (dto.adminRegionIds?.length) {
+    if (dto.adminRegionsIds?.length) {
       newScenarioIntervention.replacedAdminRegions =
         await this.adminRegionService.getAdminRegionsById(dto.adminRegionIds);
     }

--- a/api/src/modules/suppliers/suppliers.service.ts
+++ b/api/src/modules/suppliers/suppliers.service.ts
@@ -153,11 +153,12 @@ export class SuppliersService extends AppBaseService<
   }
 
   async getSuppliersDescendants(supplierIds: string[]): Promise<string[]> {
+    // using type casting not to search for and provide the full entity, since only id is used by the method (to improve performance)
     let suppliers: Supplier[] = [];
     for (const id of supplierIds) {
       const result: Supplier[] = await this.supplierRepository.findDescendants({
         id,
-      } as Supplier); // using type casting not to search for and provide the full entity, since only id is used by the method (to improve performance)
+      } as Supplier);
       suppliers = [...suppliers, ...result];
     }
 

--- a/api/src/modules/suppliers/suppliers.service.ts
+++ b/api/src/modules/suppliers/suppliers.service.ts
@@ -151,4 +151,22 @@ export class SuppliersService extends AppBaseService<
     }
     return queryBuilder.getMany();
   }
+
+  async getSuppliersDescendants(supplierIds: string[]): Promise<string[]> {
+    let suppliers: Supplier[] = [];
+    for (const id of supplierIds) {
+      const supplier: Supplier | undefined =
+        await this.supplierRepository.findOne(id);
+
+      if (!supplier)
+        throw new NotFoundException(`There is no Supplier with ID: ${id}`);
+
+      const result: Supplier[] = await this.supplierRepository.findDescendants(
+        supplier as Supplier,
+      );
+      suppliers = [...suppliers, ...result];
+    }
+
+    return suppliers.map((supplier: Supplier) => supplier.id);
+  }
 }

--- a/api/src/modules/suppliers/suppliers.service.ts
+++ b/api/src/modules/suppliers/suppliers.service.ts
@@ -155,15 +155,9 @@ export class SuppliersService extends AppBaseService<
   async getSuppliersDescendants(supplierIds: string[]): Promise<string[]> {
     let suppliers: Supplier[] = [];
     for (const id of supplierIds) {
-      const supplier: Supplier | undefined =
-        await this.supplierRepository.findOne(id);
-
-      if (!supplier)
-        throw new NotFoundException(`There is no Supplier with ID: ${id}`);
-
-      const result: Supplier[] = await this.supplierRepository.findDescendants(
-        supplier as Supplier,
-      );
+      const result: Supplier[] = await this.supplierRepository.findDescendants({
+        id,
+      } as Supplier); // using type casting not to search for and provide the full entity, since only id is used by the method (to improve performance)
       suppliers = [...suppliers, ...result];
     }
 

--- a/api/test/e2e/scenario-interventions/scenario-interventions.spec.ts
+++ b/api/test/e2e/scenario-interventions/scenario-interventions.spec.ts
@@ -237,7 +237,7 @@ describe('ScenarioInterventionsModule (e2e)', () => {
         response.body.data.id,
       );
       expect(canceledSourcingLocations[0].materialId).toEqual(
-        preconditions.material1.id,
+        preconditions.material1Descendant.id,
       );
       expect(canceledSourcingLocations[0].adminRegionId).toEqual(
         preconditions.adminRegion1.id,
@@ -355,10 +355,10 @@ describe('ScenarioInterventionsModule (e2e)', () => {
         response.body.data.id,
       );
       expect(canceledSourcingLocations[0].materialId).toEqual(
-        preconditions.material1.id,
+        preconditions.material1Descendant.id,
       );
       expect(canceledSourcingLocations[0].adminRegionId).toEqual(
-        preconditions.adminRegion1.id,
+        preconditions.adminRegion1Descendant.id,
       );
 
       const canceledSourcingRecords: SourcingRecord[] =
@@ -383,10 +383,10 @@ describe('ScenarioInterventionsModule (e2e)', () => {
         response.body.data.id,
       );
       expect(newSourcingLocations[0].materialId).toEqual(
-        preconditions.material1.id,
+        preconditions.material1Descendant.id,
       );
       expect(newSourcingLocations[0].adminRegionId).not.toEqual(
-        preconditions.adminRegion1.id,
+        preconditions.adminRegion1Descendant.id,
       );
       expect(newSourcingLocations[0].geoRegionId).toEqual(geoRegion.id);
 

--- a/api/test/e2e/scenario-interventions/scenario-interventions.spec.ts
+++ b/api/test/e2e/scenario-interventions/scenario-interventions.spec.ts
@@ -240,7 +240,11 @@ describe('ScenarioInterventionsModule (e2e)', () => {
         preconditions.material1Descendant.id,
       );
       expect(canceledSourcingLocations[0].adminRegionId).toEqual(
-        preconditions.adminRegion1.id,
+        preconditions.adminRegion1Descendant.id,
+      );
+
+      expect(canceledSourcingLocations[0].businessUnitId).toEqual(
+        preconditions.businessUnit1Descendant.id,
       );
 
       const canceledSourcingRecords: SourcingRecord[] =
@@ -265,7 +269,7 @@ describe('ScenarioInterventionsModule (e2e)', () => {
         response.body.data.id,
       );
       expect(newSourcingLocations[0].adminRegionId).toEqual(
-        preconditions.adminRegion1.id,
+        preconditions.adminRegion1Descendant.id,
       );
 
       const newSourcingRecords: SourcingRecord[] =

--- a/api/test/integration/admin-regions/admin-regions-get-descendants.spec.ts
+++ b/api/test/integration/admin-regions/admin-regions-get-descendants.spec.ts
@@ -1,15 +1,12 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { INestApplication } from '@nestjs/common';
 import { AppModule } from 'app.module';
 import { AdminRegion } from 'modules/admin-regions/admin-region.entity';
 import { AdminRegionsModule } from 'modules/admin-regions/admin-regions.module';
 import { AdminRegionRepository } from 'modules/admin-regions/admin-region.repository';
 import { createAdminRegion } from '../../entity-mocks';
-import { getApp } from '../../utils/getApp';
 import { AdminRegionsService } from 'modules/admin-regions/admin-regions.service';
 
 describe('AdminRegions - Get descendants by Admin Region Ids', () => {
-  let app: INestApplication;
   let adminRegionRepository: AdminRegionRepository;
   let adminRegionService: AdminRegionsService;
 
@@ -23,7 +20,6 @@ describe('AdminRegions - Get descendants by Admin Region Ids', () => {
     );
     adminRegionService = moduleFixture.get(AdminRegionsService);
 
-    app = getApp(moduleFixture);
     await adminRegionRepository.delete({});
   });
 

--- a/api/test/integration/admin-regions/admin-regions-get-descendants.spec.ts
+++ b/api/test/integration/admin-regions/admin-regions-get-descendants.spec.ts
@@ -24,16 +24,11 @@ describe('AdminRegions - Get descendants by Admin Region Ids', () => {
     adminRegionService = moduleFixture.get(AdminRegionsService);
 
     app = getApp(moduleFixture);
-    await app.init();
     await adminRegionRepository.delete({});
   });
 
   afterEach(async () => {
     await adminRegionRepository.delete({});
-  });
-
-  afterAll(async () => {
-    await app.close();
   });
 
   test('Get Admin Region descendants ids service should return ids of the requested Admin regions and the ids of their descendants', async () => {

--- a/api/test/integration/admin-regions/admin-regions-get-descendants.spec.ts
+++ b/api/test/integration/admin-regions/admin-regions-get-descendants.spec.ts
@@ -1,0 +1,150 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import { AppModule } from 'app.module';
+import { AdminRegion } from 'modules/admin-regions/admin-region.entity';
+import { AdminRegionsModule } from 'modules/admin-regions/admin-regions.module';
+import { AdminRegionRepository } from 'modules/admin-regions/admin-region.repository';
+import { createAdminRegion } from '../../entity-mocks';
+import { getApp } from '../../utils/getApp';
+import { AdminRegionsService } from 'modules/admin-regions/admin-regions.service';
+
+describe('AdminRegions - Get descendants by Admin Region Ids', () => {
+  let app: INestApplication;
+  let adminRegionRepository: AdminRegionRepository;
+  let adminRegionService: AdminRegionsService;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule, AdminRegionsModule],
+    }).compile();
+
+    adminRegionRepository = moduleFixture.get<AdminRegionRepository>(
+      AdminRegionRepository,
+    );
+    adminRegionService = moduleFixture.get(AdminRegionsService);
+
+    app = getApp(moduleFixture);
+    await app.init();
+    await adminRegionRepository.delete({});
+  });
+
+  afterEach(async () => {
+    await adminRegionRepository.delete({});
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  test('Get Admin Region descendants ids service should return ids of the requested Admin regions and the ids of their descendants', async () => {
+    const adminRegion1: AdminRegion = await createAdminRegion({
+      name: 'Admin Region 1',
+      level: 0,
+    });
+    const adminRegion1Level1Descendant1: AdminRegion = await createAdminRegion({
+      name: 'Admin Region 1 Level 1 Descendant 1',
+      parent: adminRegion1,
+      level: 1,
+    });
+    const adminRegion1Level1Descendant2: AdminRegion = await createAdminRegion({
+      name: 'Admin Region 1 Level 1 Descendant 2',
+      parent: adminRegion1,
+      level: 1,
+    });
+
+    const adminRegion1Level2Descendant1: AdminRegion = await createAdminRegion({
+      name: 'Admin Region 1 Level 2 Descendant 1',
+      parent: adminRegion1Level1Descendant1,
+      level: 2,
+    });
+    const adminRegion1Level2Descendant2: AdminRegion = await createAdminRegion({
+      name: 'Admin Region 1 Level 2 Descendant 2',
+      parent: adminRegion1Level1Descendant1,
+      level: 2,
+    });
+
+    const adminRegion1Level2Descendant3: AdminRegion = await createAdminRegion({
+      name: 'Admin Region 1 Level 2 Descendant 3',
+      parent: adminRegion1Level1Descendant2,
+      level: 2,
+    });
+    const adminRegion2: AdminRegion = await createAdminRegion({
+      name: 'Admin Region 2',
+      level: 0,
+    });
+    const adminRegion2Level1Descendant1: AdminRegion = await createAdminRegion({
+      name: 'Admin Region 2 Level 1 Descendant 1',
+      parent: adminRegion2,
+      level: 1,
+    });
+
+    const adminRegion2Level2Descendant1: AdminRegion = await createAdminRegion({
+      name: 'Admin Region 2 GrandChild 1',
+      parent: adminRegion2Level1Descendant1,
+      level: 2,
+    });
+
+    const adminRegion1AllDescendants: string[] =
+      await adminRegionService.getAdminRegionDescendants([adminRegion1.id]);
+
+    expect(adminRegion1AllDescendants.length).toBe(6);
+    expect(adminRegion1AllDescendants).toEqual(
+      expect.arrayContaining([
+        adminRegion1.id,
+        adminRegion1Level1Descendant1.id,
+        adminRegion1Level1Descendant2.id,
+        adminRegion1Level2Descendant1.id,
+        adminRegion1Level2Descendant2.id,
+        adminRegion1Level2Descendant3.id,
+      ]),
+    );
+
+    const adminRegionsOfLevel2: string[] =
+      await adminRegionService.getAdminRegionDescendants([
+        adminRegion1Level2Descendant2.id,
+        adminRegion1Level2Descendant3.id,
+      ]);
+    expect(adminRegionsOfLevel2.length).toBe(2);
+    expect(adminRegion1AllDescendants).toEqual(
+      expect.arrayContaining([
+        adminRegion1Level2Descendant2.id,
+        adminRegion1Level2Descendant3.id,
+      ]),
+    );
+
+    const adminRegionsOfLevel1: string[] =
+      await adminRegionService.getAdminRegionDescendants([
+        adminRegion1Level1Descendant1.id,
+        adminRegion2Level1Descendant1.id,
+      ]);
+    expect(adminRegionsOfLevel1.length).toBe(5);
+    expect(adminRegionsOfLevel1).toEqual(
+      expect.arrayContaining([
+        adminRegion1Level1Descendant1.id,
+        adminRegion1Level2Descendant1.id,
+        adminRegion1Level2Descendant2.id,
+        adminRegion2Level1Descendant1.id,
+        adminRegion2Level2Descendant1.id,
+      ]),
+    );
+
+    const adminRegionsOfDifferentLevels: string[] =
+      await adminRegionService.getAdminRegionDescendants([
+        adminRegion1Level1Descendant1.id,
+        adminRegion1Level2Descendant3.id,
+        adminRegion2.id,
+      ]);
+    expect(adminRegionsOfDifferentLevels.length).toBe(7);
+    expect(adminRegionsOfDifferentLevels).toEqual(
+      expect.arrayContaining([
+        adminRegion1Level1Descendant1.id,
+        adminRegion1Level2Descendant1.id,
+        adminRegion1Level2Descendant2.id,
+        adminRegion1Level2Descendant3.id,
+        adminRegion2.id,
+        adminRegion2Level1Descendant1.id,
+        adminRegion2Level2Descendant1.id,
+      ]),
+    );
+  });
+});

--- a/api/test/integration/business-units/business-units-get-descendants.spec.ts
+++ b/api/test/integration/business-units/business-units-get-descendants.spec.ts
@@ -1,15 +1,12 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { INestApplication } from '@nestjs/common';
 import { AppModule } from 'app.module';
 import { BusinessUnit } from 'modules/business-units/business-unit.entity';
 import { BusinessUnitsModule } from 'modules/business-units/business-units.module';
 import { BusinessUnitRepository } from 'modules/business-units/business-unit.repository';
 import { createBusinessUnit } from '../../entity-mocks';
-import { getApp } from '../../utils/getApp';
 import { BusinessUnitsService } from 'modules/business-units/business-units.service';
 
 describe('BusinessUnits - Get descendants by BusinessUnit Ids', () => {
-  let app: INestApplication;
   let businessUnitRepository: BusinessUnitRepository;
   let businessUnitsService: BusinessUnitsService;
 
@@ -23,7 +20,6 @@ describe('BusinessUnits - Get descendants by BusinessUnit Ids', () => {
     );
     businessUnitsService = moduleFixture.get(BusinessUnitsService);
 
-    app = getApp(moduleFixture);
     await businessUnitRepository.delete({});
   });
 

--- a/api/test/integration/business-units/business-units-get-descendants.spec.ts
+++ b/api/test/integration/business-units/business-units-get-descendants.spec.ts
@@ -1,0 +1,145 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import { AppModule } from 'app.module';
+import { BusinessUnit } from 'modules/business-units/business-unit.entity';
+import { BusinessUnitsModule } from 'modules/business-units/business-units.module';
+import { BusinessUnitRepository } from 'modules/business-units/business-unit.repository';
+import { createBusinessUnit } from '../../entity-mocks';
+import { getApp } from '../../utils/getApp';
+import { BusinessUnitsService } from 'modules/business-units/business-units.service';
+
+describe('BusinessUnits - Get descendants by BusinessUnit Ids', () => {
+  let app: INestApplication;
+  let businessUnitRepository: BusinessUnitRepository;
+  let businessUnitsService: BusinessUnitsService;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule, BusinessUnitsModule],
+    }).compile();
+
+    businessUnitRepository = moduleFixture.get<BusinessUnitRepository>(
+      BusinessUnitRepository,
+    );
+    businessUnitsService = moduleFixture.get(BusinessUnitsService);
+
+    app = getApp(moduleFixture);
+    await businessUnitRepository.delete({});
+  });
+
+  afterEach(async () => {
+    await businessUnitRepository.delete({});
+  });
+
+  test('Get Business Unit descendants ids service should return ids of the requested BusinessUnits and the ids of their descendants', async () => {
+    const businessUnit1: BusinessUnit = await createBusinessUnit({
+      name: 'BusinessUnit 1',
+    });
+    const businessUnit1Level1Descendant1: BusinessUnit =
+      await createBusinessUnit({
+        name: 'BusinessUnit 1 Level 1 Descendant 1',
+        parent: businessUnit1,
+      });
+    const businessUnit1Level1Descendant2: BusinessUnit =
+      await createBusinessUnit({
+        name: 'BusinessUnit 1 Level 1 Descendant 2',
+        parent: businessUnit1,
+      });
+
+    const businessUnit1Level2Descendant1: BusinessUnit =
+      await createBusinessUnit({
+        name: 'BusinessUnit 1 Level 2 Descendant 1',
+        parent: businessUnit1Level1Descendant1,
+      });
+    const businessUnit1Level2Descendant2: BusinessUnit =
+      await createBusinessUnit({
+        name: 'BusinessUnit 1 Level 2 Descendant 2',
+        parent: businessUnit1Level1Descendant1,
+      });
+
+    const businessUnit1Level2Descendant3: BusinessUnit =
+      await createBusinessUnit({
+        name: 'BusinessUnit 1 Level 2 Descendant 3',
+        parent: businessUnit1Level1Descendant2,
+      });
+    const businessUnit2: BusinessUnit = await createBusinessUnit({
+      name: 'BusinessUnit 2',
+    });
+    const businessUnit2Level1Descendant1: BusinessUnit =
+      await createBusinessUnit({
+        name: 'BusinessUnit 2 Level 1 Descendant 1',
+        parent: businessUnit2,
+      });
+
+    const businessUnit2Level2Descendant1: BusinessUnit =
+      await createBusinessUnit({
+        name: 'BusinessUnit 2 GrandChild 1',
+        parent: businessUnit2Level1Descendant1,
+      });
+
+    const businessUnit1AllDescendants: string[] =
+      await businessUnitsService.getBusinessUnitsDescendants([
+        businessUnit1.id,
+      ]);
+
+    expect(businessUnit1AllDescendants.length).toBe(6);
+    expect(businessUnit1AllDescendants).toEqual(
+      expect.arrayContaining([
+        businessUnit1.id,
+        businessUnit1Level1Descendant1.id,
+        businessUnit1Level1Descendant2.id,
+        businessUnit1Level2Descendant1.id,
+        businessUnit1Level2Descendant2.id,
+        businessUnit1Level2Descendant3.id,
+      ]),
+    );
+
+    const businessUnitsOfLevel2: string[] =
+      await businessUnitsService.getBusinessUnitsDescendants([
+        businessUnit1Level2Descendant2.id,
+        businessUnit1Level2Descendant3.id,
+      ]);
+    expect(businessUnitsOfLevel2.length).toBe(2);
+    expect(businessUnit1AllDescendants).toEqual(
+      expect.arrayContaining([
+        businessUnit1Level2Descendant2.id,
+        businessUnit1Level2Descendant3.id,
+      ]),
+    );
+
+    const businessUnitsOfLevel1: string[] =
+      await businessUnitsService.getBusinessUnitsDescendants([
+        businessUnit1Level1Descendant1.id,
+        businessUnit2Level1Descendant1.id,
+      ]);
+    expect(businessUnitsOfLevel1.length).toBe(5);
+    expect(businessUnitsOfLevel1).toEqual(
+      expect.arrayContaining([
+        businessUnit1Level1Descendant1.id,
+        businessUnit1Level2Descendant1.id,
+        businessUnit1Level2Descendant2.id,
+        businessUnit2Level1Descendant1.id,
+        businessUnit2Level2Descendant1.id,
+      ]),
+    );
+
+    const businessUnitsOfDifferentLevels: string[] =
+      await businessUnitsService.getBusinessUnitsDescendants([
+        businessUnit1Level1Descendant1.id,
+        businessUnit1Level2Descendant3.id,
+        businessUnit2.id,
+      ]);
+    expect(businessUnitsOfDifferentLevels.length).toBe(7);
+    expect(businessUnitsOfDifferentLevels).toEqual(
+      expect.arrayContaining([
+        businessUnit1Level1Descendant1.id,
+        businessUnit1Level2Descendant1.id,
+        businessUnit1Level2Descendant2.id,
+        businessUnit1Level2Descendant3.id,
+        businessUnit2.id,
+        businessUnit2Level1Descendant1.id,
+        businessUnit2Level2Descendant1.id,
+      ]),
+    );
+  });
+});

--- a/api/test/integration/materials/materials-get-descendants.spec.ts
+++ b/api/test/integration/materials/materials-get-descendants.spec.ts
@@ -1,0 +1,135 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import { AppModule } from 'app.module';
+import { Material } from 'modules/materials/material.entity';
+import { MaterialsModule } from 'modules/materials/materials.module';
+import { MaterialRepository } from 'modules/materials/material.repository';
+import { createMaterial } from '../../entity-mocks';
+import { getApp } from '../../utils/getApp';
+import { MaterialsService } from 'modules/materials/materials.service';
+
+describe('materials - Get descendants by Material Ids', () => {
+  let app: INestApplication;
+  let materialRepository: MaterialRepository;
+  let materialsService: MaterialsService;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule, MaterialsModule],
+    }).compile();
+
+    materialRepository =
+      moduleFixture.get<MaterialRepository>(MaterialRepository);
+    materialsService = moduleFixture.get(MaterialsService);
+
+    app = getApp(moduleFixture);
+    await materialRepository.delete({});
+  });
+
+  afterEach(async () => {
+    await materialRepository.delete({});
+  });
+
+  test('Get Material descendants ids service should return ids of the requested Materials and the ids of their descendants', async () => {
+    const material1: Material = await createMaterial({
+      name: 'Material 1',
+    });
+    const material1Level1Descendant1: Material = await createMaterial({
+      name: 'Material 1 Level 1 Descendant 1',
+      parent: material1,
+    });
+    const material1Level1Descendant2: Material = await createMaterial({
+      name: 'Material 1 Level 1 Descendant 2',
+      parent: material1,
+    });
+
+    const material1Level2Descendant1: Material = await createMaterial({
+      name: 'Material 1 Level 2 Descendant 1',
+      parent: material1Level1Descendant1,
+    });
+    const material1Level2Descendant2: Material = await createMaterial({
+      name: 'Material 1 Level 2 Descendant 2',
+      parent: material1Level1Descendant1,
+    });
+
+    const material1Level2Descendant3: Material = await createMaterial({
+      name: 'Material 1 Level 2 Descendant 3',
+      parent: material1Level1Descendant2,
+    });
+    const material2: Material = await createMaterial({
+      name: 'Material 2',
+    });
+    const material2Level1Descendant1: Material = await createMaterial({
+      name: 'Material 2 Level 1 Descendant 1',
+      parent: material2,
+    });
+
+    const material2Level2Descendant1: Material = await createMaterial({
+      name: 'Material 2 GrandChild 1',
+      parent: material2Level1Descendant1,
+    });
+
+    const material1AllDescendants: string[] =
+      await materialsService.getMaterialsDescendants([material1.id]);
+
+    expect(material1AllDescendants.length).toBe(6);
+    expect(material1AllDescendants).toEqual(
+      expect.arrayContaining([
+        material1.id,
+        material1Level1Descendant1.id,
+        material1Level1Descendant2.id,
+        material1Level2Descendant1.id,
+        material1Level2Descendant2.id,
+        material1Level2Descendant3.id,
+      ]),
+    );
+
+    const materialsOfLevel2: string[] =
+      await materialsService.getMaterialsDescendants([
+        material1Level2Descendant2.id,
+        material1Level2Descendant3.id,
+      ]);
+    expect(materialsOfLevel2.length).toBe(2);
+    expect(material1AllDescendants).toEqual(
+      expect.arrayContaining([
+        material1Level2Descendant2.id,
+        material1Level2Descendant3.id,
+      ]),
+    );
+
+    const materialsOfLevel1: string[] =
+      await materialsService.getMaterialsDescendants([
+        material1Level1Descendant1.id,
+        material2Level1Descendant1.id,
+      ]);
+    expect(materialsOfLevel1.length).toBe(5);
+    expect(materialsOfLevel1).toEqual(
+      expect.arrayContaining([
+        material1Level1Descendant1.id,
+        material1Level2Descendant1.id,
+        material1Level2Descendant2.id,
+        material2Level1Descendant1.id,
+        material2Level2Descendant1.id,
+      ]),
+    );
+
+    const materialsOfDifferentLevels: string[] =
+      await materialsService.getMaterialsDescendants([
+        material1Level1Descendant1.id,
+        material1Level2Descendant3.id,
+        material2.id,
+      ]);
+    expect(materialsOfDifferentLevels.length).toBe(7);
+    expect(materialsOfDifferentLevels).toEqual(
+      expect.arrayContaining([
+        material1Level1Descendant1.id,
+        material1Level2Descendant1.id,
+        material1Level2Descendant2.id,
+        material1Level2Descendant3.id,
+        material2.id,
+        material2Level1Descendant1.id,
+        material2Level2Descendant1.id,
+      ]),
+    );
+  });
+});

--- a/api/test/integration/materials/materials-get-descendants.spec.ts
+++ b/api/test/integration/materials/materials-get-descendants.spec.ts
@@ -1,15 +1,12 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { INestApplication } from '@nestjs/common';
 import { AppModule } from 'app.module';
 import { Material } from 'modules/materials/material.entity';
 import { MaterialsModule } from 'modules/materials/materials.module';
 import { MaterialRepository } from 'modules/materials/material.repository';
 import { createMaterial } from '../../entity-mocks';
-import { getApp } from '../../utils/getApp';
 import { MaterialsService } from 'modules/materials/materials.service';
 
 describe('materials - Get descendants by Material Ids', () => {
-  let app: INestApplication;
   let materialRepository: MaterialRepository;
   let materialsService: MaterialsService;
 
@@ -22,7 +19,6 @@ describe('materials - Get descendants by Material Ids', () => {
       moduleFixture.get<MaterialRepository>(MaterialRepository);
     materialsService = moduleFixture.get(MaterialsService);
 
-    app = getApp(moduleFixture);
     await materialRepository.delete({});
   });
 

--- a/api/test/integration/suppliers/suppliers-get-descendants.spec.ts
+++ b/api/test/integration/suppliers/suppliers-get-descendants.spec.ts
@@ -1,15 +1,12 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { INestApplication } from '@nestjs/common';
 import { AppModule } from 'app.module';
 import { Supplier } from 'modules/suppliers/supplier.entity';
 import { SuppliersModule } from 'modules/suppliers/suppliers.module';
 import { SupplierRepository } from 'modules/suppliers/supplier.repository';
 import { createSupplier } from '../../entity-mocks';
-import { getApp } from '../../utils/getApp';
 import { SuppliersService } from 'modules/suppliers/suppliers.service';
 
 describe('suppliers - Get descendants by supplier Ids', () => {
-  let app: INestApplication;
   let supplierRepository: SupplierRepository;
   let suppliersService: SuppliersService;
 
@@ -22,7 +19,6 @@ describe('suppliers - Get descendants by supplier Ids', () => {
       moduleFixture.get<SupplierRepository>(SupplierRepository);
     suppliersService = moduleFixture.get(SuppliersService);
 
-    app = getApp(moduleFixture);
     await supplierRepository.delete({});
   });
 

--- a/api/test/integration/suppliers/suppliers-get-descendants.spec.ts
+++ b/api/test/integration/suppliers/suppliers-get-descendants.spec.ts
@@ -1,0 +1,135 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import { AppModule } from 'app.module';
+import { Supplier } from 'modules/suppliers/supplier.entity';
+import { SuppliersModule } from 'modules/suppliers/suppliers.module';
+import { SupplierRepository } from 'modules/suppliers/supplier.repository';
+import { createSupplier } from '../../entity-mocks';
+import { getApp } from '../../utils/getApp';
+import { SuppliersService } from 'modules/suppliers/suppliers.service';
+
+describe('suppliers - Get descendants by supplier Ids', () => {
+  let app: INestApplication;
+  let supplierRepository: SupplierRepository;
+  let suppliersService: SuppliersService;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule, SuppliersModule],
+    }).compile();
+
+    supplierRepository =
+      moduleFixture.get<SupplierRepository>(SupplierRepository);
+    suppliersService = moduleFixture.get(SuppliersService);
+
+    app = getApp(moduleFixture);
+    await supplierRepository.delete({});
+  });
+
+  afterEach(async () => {
+    await supplierRepository.delete({});
+  });
+
+  test('Get Supplier descendants ids service should return ids of the requested suppliers and the ids of their descendants', async () => {
+    const supplier1: Supplier = await createSupplier({
+      name: 'supplier 1',
+    });
+    const supplier1Level1Descendant1: Supplier = await createSupplier({
+      name: 'supplier 1 Level 1 Descendant 1',
+      parent: supplier1,
+    });
+    const supplier1Level1Descendant2: Supplier = await createSupplier({
+      name: 'supplier 1 Level 1 Descendant 2',
+      parent: supplier1,
+    });
+
+    const supplier1Level2Descendant1: Supplier = await createSupplier({
+      name: 'supplier 1 Level 2 Descendant 1',
+      parent: supplier1Level1Descendant1,
+    });
+    const supplier1Level2Descendant2: Supplier = await createSupplier({
+      name: 'supplier 1 Level 2 Descendant 2',
+      parent: supplier1Level1Descendant1,
+    });
+
+    const supplier1Level2Descendant3: Supplier = await createSupplier({
+      name: 'supplier 1 Level 2 Descendant 3',
+      parent: supplier1Level1Descendant2,
+    });
+    const supplier2: Supplier = await createSupplier({
+      name: 'supplier 2',
+    });
+    const supplier2Level1Descendant1: Supplier = await createSupplier({
+      name: 'supplier 2 Level 1 Descendant 1',
+      parent: supplier2,
+    });
+
+    const supplier2Level2Descendant1: Supplier = await createSupplier({
+      name: 'supplier 2 GrandChild 1',
+      parent: supplier2Level1Descendant1,
+    });
+
+    const supplier1AllDescendants: string[] =
+      await suppliersService.getSuppliersDescendants([supplier1.id]);
+
+    expect(supplier1AllDescendants.length).toBe(6);
+    expect(supplier1AllDescendants).toEqual(
+      expect.arrayContaining([
+        supplier1.id,
+        supplier1Level1Descendant1.id,
+        supplier1Level1Descendant2.id,
+        supplier1Level2Descendant1.id,
+        supplier1Level2Descendant2.id,
+        supplier1Level2Descendant3.id,
+      ]),
+    );
+
+    const suppliersOfLevel2: string[] =
+      await suppliersService.getSuppliersDescendants([
+        supplier1Level2Descendant2.id,
+        supplier1Level2Descendant3.id,
+      ]);
+    expect(suppliersOfLevel2.length).toBe(2);
+    expect(supplier1AllDescendants).toEqual(
+      expect.arrayContaining([
+        supplier1Level2Descendant2.id,
+        supplier1Level2Descendant3.id,
+      ]),
+    );
+
+    const suppliersOfLevel1: string[] =
+      await suppliersService.getSuppliersDescendants([
+        supplier1Level1Descendant1.id,
+        supplier2Level1Descendant1.id,
+      ]);
+    expect(suppliersOfLevel1.length).toBe(5);
+    expect(suppliersOfLevel1).toEqual(
+      expect.arrayContaining([
+        supplier1Level1Descendant1.id,
+        supplier1Level2Descendant1.id,
+        supplier1Level2Descendant2.id,
+        supplier2Level1Descendant1.id,
+        supplier2Level2Descendant1.id,
+      ]),
+    );
+
+    const suppliersOfDifferentLevels: string[] =
+      await suppliersService.getSuppliersDescendants([
+        supplier1Level1Descendant1.id,
+        supplier1Level2Descendant3.id,
+        supplier2.id,
+      ]);
+    expect(suppliersOfDifferentLevels.length).toBe(7);
+    expect(suppliersOfDifferentLevels).toEqual(
+      expect.arrayContaining([
+        supplier1Level1Descendant1.id,
+        supplier1Level2Descendant1.id,
+        supplier1Level2Descendant2.id,
+        supplier1Level2Descendant3.id,
+        supplier2.id,
+        supplier2Level1Descendant1.id,
+        supplier2Level2Descendant1.id,
+      ]),
+    );
+  });
+});

--- a/api/test/utils/scenario-interventions-preconditions.ts
+++ b/api/test/utils/scenario-interventions-preconditions.ts
@@ -20,11 +20,13 @@ export interface ScenarioInterventionPreconditions {
   material1: Material;
   material1Descendant: Material;
   supplier1: Supplier;
+  supplier1Descendant: Supplier;
   supplier2: Supplier;
   adminRegion1: AdminRegion;
   adminRegion1Descendant: AdminRegion;
   adminRegion2: AdminRegion;
   businessUnit1: BusinessUnit;
+  businessUnit1Descendant: BusinessUnit;
   businessUnit2: BusinessUnit;
   sourcingLocation1: SourcingLocation;
   sourcingLocation2: SourcingLocation;
@@ -39,12 +41,20 @@ export async function createInterventionPreconditions(): Promise<ScenarioInterve
     parent: material1,
   });
   const supplier1: Supplier = await createSupplier();
+  const supplier1Descendant: Supplier = await createSupplier({
+    name: 'Descendant Supplier',
+    parent: supplier1,
+  });
   const adminRegion1: AdminRegion = await createAdminRegion();
   const adminRegion1Descendant: AdminRegion = await createAdminRegion({
     name: 'Descendant region',
     parent: adminRegion1,
   });
   const businessUnit1: BusinessUnit = await createBusinessUnit();
+  const businessUnit1Descendant: BusinessUnit = await createBusinessUnit({
+    name: 'Descendant region',
+    parent: businessUnit1,
+  });
 
   const material2: Material = await createMaterial();
   const supplier2: Supplier = await createSupplier();
@@ -53,8 +63,8 @@ export async function createInterventionPreconditions(): Promise<ScenarioInterve
 
   const sourcingLocation1: SourcingLocation = await createSourcingLocation({
     materialId: material1Descendant.id,
-    t1SupplierId: supplier1.id,
-    businessUnitId: businessUnit1.id,
+    t1SupplierId: supplier1Descendant.id,
+    businessUnitId: businessUnit1Descendant.id,
     adminRegionId: adminRegion1Descendant.id,
   });
 
@@ -83,11 +93,13 @@ export async function createInterventionPreconditions(): Promise<ScenarioInterve
     material1Descendant,
     material2,
     supplier1,
+    supplier1Descendant,
     supplier2,
     adminRegion1,
     adminRegion1Descendant,
     adminRegion2,
     businessUnit1,
+    businessUnit1Descendant,
     businessUnit2,
     sourcingLocation1,
     sourcingLocation2,

--- a/api/test/utils/scenario-interventions-preconditions.ts
+++ b/api/test/utils/scenario-interventions-preconditions.ts
@@ -18,9 +18,11 @@ export interface ScenarioInterventionPreconditions {
   scenario: Scenario;
   material2: Material;
   material1: Material;
+  material1Descendant: Material;
   supplier1: Supplier;
   supplier2: Supplier;
   adminRegion1: AdminRegion;
+  adminRegion1Descendant: AdminRegion;
   adminRegion2: AdminRegion;
   businessUnit1: BusinessUnit;
   businessUnit2: BusinessUnit;
@@ -32,8 +34,16 @@ export async function createInterventionPreconditions(): Promise<ScenarioInterve
   const scenario: Scenario = await createScenario();
 
   const material1: Material = await createMaterial();
+  const material1Descendant = await createMaterial({
+    name: 'Descendant Material',
+    parent: material1,
+  });
   const supplier1: Supplier = await createSupplier();
   const adminRegion1: AdminRegion = await createAdminRegion();
+  const adminRegion1Descendant: AdminRegion = await createAdminRegion({
+    name: 'Descendant region',
+    parent: adminRegion1,
+  });
   const businessUnit1: BusinessUnit = await createBusinessUnit();
 
   const material2: Material = await createMaterial();
@@ -42,10 +52,10 @@ export async function createInterventionPreconditions(): Promise<ScenarioInterve
   const businessUnit2: BusinessUnit = await createBusinessUnit();
 
   const sourcingLocation1: SourcingLocation = await createSourcingLocation({
-    materialId: material1.id,
+    materialId: material1Descendant.id,
     t1SupplierId: supplier1.id,
     businessUnitId: businessUnit1.id,
-    adminRegionId: adminRegion1.id,
+    adminRegionId: adminRegion1Descendant.id,
   });
 
   await createSourcingRecord({
@@ -70,10 +80,12 @@ export async function createInterventionPreconditions(): Promise<ScenarioInterve
   return {
     scenario,
     material1,
+    material1Descendant,
     material2,
     supplier1,
     supplier2,
     adminRegion1,
+    adminRegion1Descendant,
     adminRegion2,
     businessUnit1,
     businessUnit2,


### PR DESCRIPTION
The method should be used in the Impact table endpoint to process Admin Region ids (received as filters) and add the Ids of their descendants (if they exists) to the query.

To be added once the update of the response of Impact table endpoint is merged.