### PR TITLE
Fix chart issues, a tragedy in two parts (part 1)

### DIFF
--- a/client/src/components/chart/area-stacked/component.tsx
+++ b/client/src/components/chart/area-stacked/component.tsx
@@ -59,7 +59,7 @@ const AreaStacked: React.FC<AreaStackedProps> = ({
     projection: true,
     target: false,
   },
-}: AreaStackedProps) => {
+}) => {
   const { showTooltip, hideTooltip, tooltipData, tooltipTop, tooltipLeft } = useTooltip();
 
   const lastCurrentIndex = useMemo(() => {
@@ -370,6 +370,7 @@ const AreaStacked: React.FC<AreaStackedProps> = ({
 
       {settings.tooltip && (
         <Tooltip
+          className="z-10"
           title={title}
           tooltipTop={tooltipTop}
           tooltipLeft={tooltipLeft + margin.left}

--- a/client/src/components/chart/area-stacked/tooltip/component.tsx
+++ b/client/src/components/chart/area-stacked/tooltip/component.tsx
@@ -4,6 +4,7 @@ import { ReactNode } from 'react';
 import { BIG_NUMBER_FORMAT } from 'utils/number-format';
 
 export type AreaStackedTooltipProps = {
+  className?: string;
   title: string | ReactNode;
   tooltipData:
     | {
@@ -32,11 +33,12 @@ const AreaStackedTooltip: React.FC<AreaStackedTooltipProps> = ({
   title,
   keys,
   colors,
+  className,
 }) => {
   if (!tooltipData) return null;
 
   return (
-    <TooltipWithBounds top={tooltipTop} left={tooltipLeft}>
+    <TooltipWithBounds className={className} top={tooltipTop} left={tooltipLeft}>
       <div className="flex flex-col p-2.5 space-y-2">
         <h3>{title}</h3>
 

--- a/client/src/components/chart/area-stacked/tooltip/component.tsx
+++ b/client/src/components/chart/area-stacked/tooltip/component.tsx
@@ -1,7 +1,7 @@
 import { TooltipWithBounds } from '@visx/tooltip';
 import { ReactNode } from 'react';
 
-import { PRECISE_NUMBER_FORMAT } from 'utils/number-format';
+import { BIG_NUMBER_FORMAT } from 'utils/number-format';
 
 export type AreaStackedTooltipProps = {
   title: string | ReactNode;
@@ -32,7 +32,7 @@ const AreaStackedTooltip: React.FC<AreaStackedTooltipProps> = ({
   title,
   keys,
   colors,
-}: AreaStackedTooltipProps) => {
+}) => {
   if (!tooltipData) return null;
 
   return (
@@ -42,10 +42,13 @@ const AreaStackedTooltip: React.FC<AreaStackedTooltipProps> = ({
 
         <ul className="space-y-1">
           {keys.map((k) => (
-            <li key={k} className="flex items-center space-x-1">
-              <div className="w-2.5 h-2.5 rounded-full" style={{ background: colors[k] }} />
+            <li key={k} className="flex gap-x-1 items-start">
+              <div
+                className="w-2.5 mt-[2px] h-2.5 aspect-square rounded-full "
+                style={{ background: colors[k] }}
+              />
               <div>{k}:</div>
-              <div>{PRECISE_NUMBER_FORMAT(tooltipData[k])}</div>
+              <div>{BIG_NUMBER_FORMAT(tooltipData[k])}</div>
             </li>
           ))}
         </ul>

--- a/client/src/components/widget/component.tsx
+++ b/client/src/components/widget/component.tsx
@@ -8,14 +8,8 @@ export type WidgetProps = {
   children: ReactChild | ReactChild[];
 };
 
-const Widget: React.FC<WidgetProps> = ({ title, className, height, children }: WidgetProps) => (
-  <div
-    className={cx({
-      'flex flex-col p-5 bg-white rounded shadow-sm': true,
-      [className]: !!className,
-    })}
-    style={{ height }}
-  >
+const Widget: React.FC<WidgetProps> = ({ title, className, height, children }) => (
+  <div className={cx('flex flex-col p-5 bg-white rounded shadow-sm', className)} style={{ height }}>
     <h2 className="flex-shrink-0">{title}</h2>
     <div className="relative flex-grow mt-2">{children}</div>
   </div>

--- a/client/src/containers/analysis-visualization/analysis-chart/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-chart/component.tsx
@@ -60,13 +60,8 @@ const AnalysisChart: React.FC = () => {
                   key={`${id}-${JSON.stringify(filters)}`}
                   initial={{ opacity: 0, y: -20 }}
                   animate={{ opacity: 1, y: 0 }}
-                  className="bg-white rounded shadow-sm p-5"
                 >
-                  <Widget
-                    title={indicator}
-                    height={chartData.length > 1 ? 325 : 500}
-                    className="bg-none rounded-none shadow-none"
-                  >
+                  <Widget title={indicator} height={chartData.length > 1 ? 325 : 500}>
                     <Chart>
                       <AreaStacked
                         title={indicator}
@@ -83,7 +78,7 @@ const AnalysisChart: React.FC = () => {
                       />
                     </Chart>
                   </Widget>
-                  <ul className="flex flex-row flex-wrap gap-x-3">
+                  <ul className="flex flex-row flex-wrap gap-x-3 mt-2">
                     {keys.map((key) => (
                       <li key={key} className="flex items-center space-x-1">
                         <div

--- a/client/src/containers/analysis-visualization/analysis-chart/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-chart/component.tsx
@@ -17,7 +17,7 @@ import { RANKING_LIMIT } from './constants';
 const AnalysisChart: React.FC = () => {
   const filters = useAppSelector(analysisFilters);
 
-  const { data: allChartData, legend: allLegendData, isFetching } = useAnalysisChart();
+  const { data: allChartData, isFetching } = useAnalysisChart();
 
   const chartData = useMemo(() => {
     const trimmed = allChartData.map((chart) => {
@@ -80,7 +80,7 @@ const AnalysisChart: React.FC = () => {
                   </Widget>
                   <ul className="flex flex-row flex-wrap gap-x-3 mt-2">
                     {keys.map((key) => (
-                      <li key={key} className="flex items-center space-x-1">
+                      <li key={key} className="flex items-center gap-x-1">
                         <div
                           className="w-3 h-3 rounded-full"
                           style={{ backgroundColor: d.colors[key] }}
@@ -93,23 +93,6 @@ const AnalysisChart: React.FC = () => {
               );
             })}
           </div>
-
-          {/* <motion.ul
-            key={`analysis-legend-${JSON.stringify(filters)}`}
-            className="flex mt-4 space-x-3"
-            initial={{ opacity: 0, y: -20 }}
-            animate={{ opacity: 1, y: 0 }}
-          >
-            {legendData.map((l) => (
-              <li
-                key={`${l.id}-${JSON.stringify(filters)}`}
-                className="flex items-center space-x-1"
-              >
-                <div className="w-3 h-3 rounded-full" style={{ backgroundColor: l.color }} />
-                <div>{l.name}</div>
-              </li>
-            ))}
-          </motion.ul> */}
         </AnimatePresence>
       )}
     </>

--- a/client/src/containers/analysis-visualization/analysis-chart/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-chart/component.tsx
@@ -21,15 +21,18 @@ const AnalysisChart: React.FC = () => {
 
   const chartData = useMemo(() => {
     const trimmed = allChartData.map((chart) => {
+      // Sort the first avaliable entry by value and get the keys of the top RANKING_LIMIT items
       const firstDateValues = chart.values[0];
-      const sortedByValue = Object.entries(firstDateValues)
+
+      const topValueKeys = Object.entries(firstDateValues)
         .filter(([key]) => !['id', 'date', 'current'].includes(key))
         .sort(([, valueA], [, valueB]) => (valueB as number) - (valueA as number))
-        .slice(0, RANKING_LIMIT);
+        .slice(0, RANKING_LIMIT)
+        .map(([key]) => key);
 
       return {
         ...chart,
-        keys: sortedByValue.map(([key]) => key),
+        keys: chart.keys.filter((key) => topValueKeys.includes(key)),
       };
     });
 

--- a/client/src/containers/analysis-visualization/analysis-chart/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-chart/component.tsx
@@ -17,7 +17,7 @@ import { RANKING_LIMIT } from './constants';
 const AnalysisChart: React.FC = () => {
   const filters = useAppSelector(analysisFilters);
 
-  const { data: allChartData, legend: legendData, isFetching } = useAnalysisChart();
+  const { data: allChartData, legend: allLegendData, isFetching } = useAnalysisChart();
 
   const chartData = useMemo(() => {
     const trimmed = allChartData.map((chart) => {
@@ -60,8 +60,13 @@ const AnalysisChart: React.FC = () => {
                   key={`${id}-${JSON.stringify(filters)}`}
                   initial={{ opacity: 0, y: -20 }}
                   animate={{ opacity: 1, y: 0 }}
+                  className="bg-white rounded shadow-sm p-5"
                 >
-                  <Widget title={indicator} height={chartData.length > 1 ? 325 : 500}>
+                  <Widget
+                    title={indicator}
+                    height={chartData.length > 1 ? 325 : 500}
+                    className="bg-none rounded-none shadow-none"
+                  >
                     <Chart>
                       <AreaStacked
                         title={indicator}
@@ -78,12 +83,23 @@ const AnalysisChart: React.FC = () => {
                       />
                     </Chart>
                   </Widget>
+                  <ul className="flex flex-row flex-wrap gap-x-3">
+                    {keys.map((key) => (
+                      <li key={key} className="flex items-center space-x-1">
+                        <div
+                          className="w-3 h-3 rounded-full"
+                          style={{ backgroundColor: d.colors[key] }}
+                        />
+                        <div>{key}</div>
+                      </li>
+                    ))}
+                  </ul>
                 </motion.div>
               );
             })}
           </div>
 
-          <motion.ul
+          {/* <motion.ul
             key={`analysis-legend-${JSON.stringify(filters)}`}
             className="flex mt-4 space-x-3"
             initial={{ opacity: 0, y: -20 }}
@@ -98,7 +114,7 @@ const AnalysisChart: React.FC = () => {
                 <div>{l.name}</div>
               </li>
             ))}
-          </motion.ul>
+          </motion.ul> */}
         </AnimatePresence>
       )}
     </>

--- a/client/src/containers/analysis-visualization/analysis-chart/constants.ts
+++ b/client/src/containers/analysis-visualization/analysis-chart/constants.ts
@@ -1,0 +1,3 @@
+const RANKING_LIMIT = 6;
+
+export { RANKING_LIMIT };

--- a/client/src/layouts/analysis/component.tsx
+++ b/client/src/layouts/analysis/component.tsx
@@ -17,10 +17,7 @@ const AnalysisVisualizationNoSSR = dynamic(() => import('containers/analysis-vis
   ssr: false,
 });
 
-const AnalysisLayout: React.FC<AnalysisLayoutProps> = ({
-  loading = false,
-  children,
-}: AnalysisLayoutProps) => {
+const AnalysisLayout: React.FC<AnalysisLayoutProps> = ({ loading = false, children }) => {
   const asideRef = useRef<HTMLDivElement>(null);
   const [position, setPosition] = useState<DOMRect>(null);
   const { visualizationMode, isSidebarCollapsed, isSubContentCollapsed } =


### PR DESCRIPTION
This PR fixes the charts page tooltip.
- Aligns the dot to the top of the paragraph instead of the middle
- Fixes the dot being noot round if the text spanned multiple lines
- Only show the top 6 values for each chart