### PR TITLE
Avoid multiple API calls in table view

### DIFF
--- a/client/src/containers/analysis-visualization/analysis-filters/years-range/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-filters/years-range/component.tsx
@@ -3,7 +3,7 @@ import { isFinite, toNumber } from 'lodash';
 
 import { useAppDispatch, useAppSelector } from 'store/hooks';
 import { analysisUI } from 'store/features/analysis/ui';
-import { analysisFilters, setFilter } from 'store/features/analysis/filters';
+import { analysisFilters, setFilters } from 'store/features/analysis/filters';
 
 import { useYears } from 'hooks/years';
 
@@ -32,8 +32,7 @@ const YearsFilter: React.FC = () => {
   }, [data]);
 
   useEffect(() => {
-    dispatch(setFilter({ id: 'startYear', value: startYear }));
-    dispatch(setFilter({ id: 'endYear', value: endYear }));
+    dispatch(setFilters({ startYear, endYear }));
   }, [startYear, endYear, dispatch]);
 
   const handleOnEndYearSearch = (searchedYear) => {

--- a/client/src/containers/analysis-visualization/analysis-filters/years/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-filters/years/component.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useMemo } from 'react';
 
 import { useAppDispatch, useAppSelector } from 'store/hooks';
-import { analysisFilters, setFilter } from 'store/features/analysis/filters';
+import { analysisFilters, setFilter, setFilters } from 'store/features/analysis/filters';
 
 import { useYears } from 'hooks/years';
 
@@ -25,15 +25,16 @@ const YearsFilter: React.FC = () => {
   );
 
   const handleChange: SelectProps['onChange'] = useCallback(
-    ({ value }) => dispatch(setFilter({ id: 'startYear', value: value })),
+    ({ value }) => {
+      dispatch(setFilter({ id: 'startYear', value: value }));
+    },
     [dispatch],
   );
 
   // Update filters when data changes
   useEffect(() => {
     if (years && !isLoading) {
-      dispatch(setFilter({ id: 'startYear', value: years[years.length - 1] }));
-      dispatch(setFilter({ id: 'endYear', value: null }));
+      dispatch(setFilters({ startYear: years[years.length - 1], endYear: null }));
     }
   }, [dispatch, isLoading, years]);
 

--- a/client/src/containers/filters/years-range/component.tsx
+++ b/client/src/containers/filters/years-range/component.tsx
@@ -20,7 +20,7 @@ export const YearsRangeFilter: React.FC<YearsRangeFilterProps> = ({
   onChange = () => null,
   onStartYearSearch = () => null,
   onEndYearSearch = () => null,
-}: YearsRangeFilterProps) => {
+}) => {
   const wrapperRef = useRef();
 
   const [isOpen, setIsOpen] = useState<boolean>(false);

--- a/client/src/hooks/impact/index.ts
+++ b/client/src/hooks/impact/index.ts
@@ -43,7 +43,11 @@ export function useImpactData(): ImpactDataResponse {
   const filters = filtersForTabularAPI(store.getState());
 
   const isEnable =
-    !!filters?.indicatorId && !!indicators?.length && !!filters.startYear && !!filters.endYear;
+    !!filters?.indicatorId &&
+    !!indicators?.length &&
+    !!filters.startYear &&
+    !!filters.endYear &&
+    filters.endYear !== filters.startYear;
 
   const indicatorIds = indicators.map(({ id }) => id);
 


### PR DESCRIPTION
The year range selector causes some intermediate values to be set
(2020,null) -> (2020, 2020) -> (2010, 2020). Ideally I'd like too avoid this instead of patchinng it up like I did on this commit