### PR TITLE
Bugfix: LANDGRIF - 622 add only effective elements to intervention

### DIFF
--- a/api/src/modules/scenario-interventions/dto/create.scenario-intervention.dto.ts
+++ b/api/src/modules/scenario-interventions/dto/create.scenario-intervention.dto.ts
@@ -170,7 +170,7 @@ export class CreateScenarioInterventionDto {
     enum: Object.values(LOCATION_TYPES),
     example: LOCATION_TYPES.POINT_OF_PRODUCTION,
   })
-  newLocationType?: LOCATION_TYPES;
+  newLocationType!: LOCATION_TYPES;
 
   @ValidateIf(
     (dto: CreateScenarioInterventionDto) =>

--- a/api/src/modules/scenario-interventions/dto/create.scenario-intervention.dto.ts
+++ b/api/src/modules/scenario-interventions/dto/create.scenario-intervention.dto.ts
@@ -103,8 +103,8 @@ export class CreateScenarioInterventionDto {
   businessUnitIds!: string[];
 
   @IsUUID(4, { each: true })
-  @IsNotEmpty()
-  @ApiProperty({
+  @IsOptional()
+  @ApiPropertyOptional({
     description:
       'Ids of Suppliers or Producers that will be affected by intervention',
     type: [String],

--- a/api/src/modules/scenario-interventions/dto/create.scenario-intervention.dto.ts
+++ b/api/src/modules/scenario-interventions/dto/create.scenario-intervention.dto.ts
@@ -45,7 +45,7 @@ export class CreateScenarioInterventionDto {
     enum: Object.values(SCENARIO_INTERVENTION_TYPE),
     example: SCENARIO_INTERVENTION_TYPE.NEW_MATERIAL,
   })
-  type!: string;
+  type!: SCENARIO_INTERVENTION_TYPE;
 
   @IsNumber()
   @IsNotEmpty()

--- a/api/src/modules/scenario-interventions/scenario-intervention.entity.ts
+++ b/api/src/modules/scenario-interventions/scenario-intervention.entity.ts
@@ -22,6 +22,9 @@ import {
 } from 'modules/sourcing-locations/sourcing-location.entity';
 import { TimestampedBaseEntity } from 'baseEntities/timestamped-base-entity';
 import { Scenario } from 'modules/scenarios/scenario.entity';
+// TODO: Making this import absolute creates some circular dependency. Fix it once we refactor the createScenatioIntervention process
+// eslint-disable-next-line no-restricted-imports
+import { CreateScenarioInterventionDto } from './dto/create.scenario-intervention.dto';
 
 export enum SCENARIO_INTERVENTION_STATUS {
   ACTIVE = 'active',
@@ -204,4 +207,25 @@ export class ScenarioIntervention extends TimestampedBaseEntity {
   @Column({ nullable: true })
   @ApiPropertyOptional()
   updatedById?: string;
+
+  static createInterventionInstance(
+    dto: CreateScenarioInterventionDto,
+  ): ScenarioIntervention {
+    const scenarioIntervention: ScenarioIntervention =
+      new ScenarioIntervention();
+    scenarioIntervention.title = dto.title;
+    scenarioIntervention.description = dto.description;
+    scenarioIntervention.scenarioId = dto.scenarioId;
+    scenarioIntervention.startYear = dto.startYear;
+    scenarioIntervention.percentage = dto.percentage;
+    scenarioIntervention.endYear = dto.endYear;
+    scenarioIntervention.type = dto.type;
+    scenarioIntervention.newIndicatorCoefficients =
+      dto.newIndicatorCoefficients as unknown as JSON;
+    scenarioIntervention.newLocationType = dto.newLocationType;
+    scenarioIntervention.newLocationCountryInput = dto.newLocationCountryInput;
+    scenarioIntervention.newLocationAddressInput = dto.newLocationAddressInput;
+
+    return scenarioIntervention;
+  }
 }

--- a/api/src/modules/scenario-interventions/scenario-intervention.entity.ts
+++ b/api/src/modules/scenario-interventions/scenario-intervention.entity.ts
@@ -93,7 +93,7 @@ export class ScenarioIntervention extends TimestampedBaseEntity {
 
   @Column({ type: 'jsonb', nullable: true })
   @ApiProperty()
-  newIndicatorCoefficients!: JSON;
+  newIndicatorCoefficients?: JSON;
 
   @ManyToOne(
     () => Scenario,
@@ -112,19 +112,19 @@ export class ScenarioIntervention extends TimestampedBaseEntity {
    */
   @ManyToMany(() => Material, { eager: true })
   @JoinTable()
-  replacedMaterials?: Material[];
+  replacedMaterials: Material[];
 
   @ManyToMany(() => BusinessUnit, { eager: true })
   @JoinTable()
-  replacedBusinessUnits?: BusinessUnit[];
+  replacedBusinessUnits: BusinessUnit[];
 
   @ManyToMany(() => Supplier, { eager: true })
   @JoinTable()
-  replacedSuppliers?: Supplier[];
+  replacedSuppliers: Supplier[];
 
   @ManyToMany(() => AdminRegion, { eager: true })
   @JoinTable()
-  replacedAdminRegions?: AdminRegion[];
+  replacedAdminRegions: AdminRegion[];
 
   @OneToMany(
     () => SourcingLocation,
@@ -135,27 +135,27 @@ export class ScenarioIntervention extends TimestampedBaseEntity {
   replacedSourcingLocations?: SourcingLocation[];
 
   /**
-   * Relationships with other entities - list of "new" relationships
+   * Relationships with other entities - list of "ne" relationships
    */
   @ManyToOne(() => Material, { eager: true })
   @ApiPropertyOptional({ type: () => Material })
-  newMaterial?: Material;
+  newMaterial: Material;
 
   @ManyToOne(() => BusinessUnit, { eager: true })
   @ApiPropertyOptional()
-  newBusinessUnit?: BusinessUnit;
+  newBusinessUnit: BusinessUnit;
 
   @ManyToOne(() => Supplier, { eager: true })
   @ApiPropertyOptional()
-  newT1Supplier?: Supplier;
+  newT1Supplier: Supplier;
 
   @ManyToOne(() => Supplier, { eager: true })
   @ApiPropertyOptional()
-  newProducer?: Supplier;
+  newProducer: Supplier;
 
   @ManyToOne(() => AdminRegion, { eager: true })
   @ApiPropertyOptional()
-  newAdminRegion?: AdminRegion;
+  newAdminRegion: AdminRegion;
 
   /**
    * New sourcing data, if intervention type involves supplier change:

--- a/api/src/modules/scenario-interventions/scenario-intervention.entity.ts
+++ b/api/src/modules/scenario-interventions/scenario-intervention.entity.ts
@@ -22,9 +22,6 @@ import {
 } from 'modules/sourcing-locations/sourcing-location.entity';
 import { TimestampedBaseEntity } from 'baseEntities/timestamped-base-entity';
 import { Scenario } from 'modules/scenarios/scenario.entity';
-// TODO: Making this import absolute creates some circular dependency. Fix it once we refactor the createScenatioIntervention process
-// eslint-disable-next-line no-restricted-imports
-import { CreateScenarioInterventionDto } from './dto/create.scenario-intervention.dto';
 
 export enum SCENARIO_INTERVENTION_STATUS {
   ACTIVE = 'active',
@@ -207,25 +204,4 @@ export class ScenarioIntervention extends TimestampedBaseEntity {
   @Column({ nullable: true })
   @ApiPropertyOptional()
   updatedById?: string;
-
-  static createInterventionInstance(
-    dto: CreateScenarioInterventionDto,
-  ): ScenarioIntervention {
-    const scenarioIntervention: ScenarioIntervention =
-      new ScenarioIntervention();
-    scenarioIntervention.title = dto.title;
-    scenarioIntervention.description = dto.description;
-    scenarioIntervention.scenarioId = dto.scenarioId;
-    scenarioIntervention.startYear = dto.startYear;
-    scenarioIntervention.percentage = dto.percentage;
-    scenarioIntervention.endYear = dto.endYear;
-    scenarioIntervention.type = dto.type;
-    scenarioIntervention.newIndicatorCoefficients =
-      dto.newIndicatorCoefficients as unknown as JSON;
-    scenarioIntervention.newLocationType = dto.newLocationType;
-    scenarioIntervention.newLocationCountryInput = dto.newLocationCountryInput;
-    scenarioIntervention.newLocationAddressInput = dto.newLocationAddressInput;
-
-    return scenarioIntervention;
-  }
 }

--- a/api/src/modules/scenario-interventions/scenario-interventions.module.ts
+++ b/api/src/modules/scenario-interventions/scenario-interventions.module.ts
@@ -11,6 +11,7 @@ import { MaterialsModule } from 'modules/materials/materials.module';
 import { BusinessUnitsModule } from 'modules/business-units/business-units.module';
 import { AdminRegionsModule } from 'modules/admin-regions/admin-regions.module';
 import { SuppliersModule } from 'modules/suppliers/suppliers.module';
+import { InterventionGeneratorService } from 'modules/scenario-interventions/services/intervention-generator.service';
 
 @Module({
   imports: [
@@ -24,7 +25,7 @@ import { SuppliersModule } from 'modules/suppliers/suppliers.module';
     SuppliersModule,
   ],
   controllers: [ScenarioInterventionsController],
-  providers: [ScenarioInterventionsService],
+  providers: [ScenarioInterventionsService, InterventionGeneratorService],
   exports: [ScenarioInterventionsService],
 })
 export class ScenarioInterventionsModule {}

--- a/api/src/modules/scenario-interventions/scenario-interventions.service.ts
+++ b/api/src/modules/scenario-interventions/scenario-interventions.service.ts
@@ -138,7 +138,9 @@ export class ScenarioInterventionsService extends AppBaseService<
      */
 
     const newScenarioIntervention: ScenarioIntervention =
-      ScenarioIntervention.createInterventionInstance(dtoWithDescendants);
+      ScenarioInterventionsService.createInterventionInstance(
+        dtoWithDescendants,
+      );
 
     // Add replaced Entities to new Scenario Intervention
 
@@ -422,5 +424,26 @@ export class ScenarioInterventionsService extends AppBaseService<
     }
 
     return newSourcingLocationData;
+  }
+
+  static createInterventionInstance(
+    dto: CreateScenarioInterventionDto,
+  ): ScenarioIntervention {
+    const scenarioIntervention: ScenarioIntervention =
+      new ScenarioIntervention();
+    scenarioIntervention.title = dto.title;
+    scenarioIntervention.description = dto.description;
+    scenarioIntervention.scenarioId = dto.scenarioId;
+    scenarioIntervention.startYear = dto.startYear;
+    scenarioIntervention.percentage = dto.percentage;
+    scenarioIntervention.endYear = dto.endYear;
+    scenarioIntervention.type = dto.type;
+    scenarioIntervention.newIndicatorCoefficients =
+      dto.newIndicatorCoefficients as unknown as JSON;
+    scenarioIntervention.newLocationType = dto.newLocationType;
+    scenarioIntervention.newLocationCountryInput = dto.newLocationCountryInput;
+    scenarioIntervention.newLocationAddressInput = dto.newLocationAddressInput;
+
+    return scenarioIntervention;
   }
 }

--- a/api/src/modules/scenario-interventions/scenario-interventions.service.ts
+++ b/api/src/modules/scenario-interventions/scenario-interventions.service.ts
@@ -156,6 +156,7 @@ export class ScenarioInterventionsService extends AppBaseService<
      */
 
     let newInterventionSourcingLocations: SourcingLocation[];
+    let newInterventionWithReplacingElements: ScenarioIntervention;
 
     switch (dto.type) {
       case SCENARIO_INTERVENTION_TYPE.NEW_MATERIAL:
@@ -168,6 +169,13 @@ export class ScenarioInterventionsService extends AppBaseService<
         newInterventionSourcingLocations =
           await this.sourcingLocationsService.save(
             newMaterialInterventionLocation,
+          );
+
+        newInterventionWithReplacingElements =
+          await this.interventionGenerator.addReplacingElementsToIntervention(
+            newInterventionWithReplacedElements,
+            newMaterialInterventionLocation,
+            SCENARIO_INTERVENTION_TYPE.NEW_MATERIAL,
           );
 
         for await (const sourcingLocation of newInterventionSourcingLocations) {
@@ -200,7 +208,14 @@ export class ScenarioInterventionsService extends AppBaseService<
             newSupplerInterventionLocations,
           );
 
-        newScenarioIntervention.newSourcingLocations =
+        newInterventionWithReplacingElements =
+          await this.interventionGenerator.addReplacingElementsToIntervention(
+            newInterventionWithReplacedElements,
+            newSupplerInterventionLocations,
+            SCENARIO_INTERVENTION_TYPE.NEW_SUPPLIER,
+          );
+
+        newInterventionWithReplacedElements.newSourcingLocations =
           newInterventionSourcingLocations;
         for await (const sourcingLocation of newInterventionSourcingLocations) {
           const [sourcingRecord] = sourcingLocation.sourcingRecords;
@@ -215,7 +230,7 @@ export class ScenarioInterventionsService extends AppBaseService<
           );
         }
 
-        newScenarioIntervention.newSourcingLocations =
+        newInterventionWithReplacedElements.newSourcingLocations =
           newInterventionSourcingLocations;
         break;
 
@@ -230,7 +245,7 @@ export class ScenarioInterventionsService extends AppBaseService<
           await this.sourcingLocationsService.save(
             newEfficiencyChangeInterventionLocations,
           );
-        newScenarioIntervention.newSourcingLocations =
+        newInterventionWithReplacedElements.newSourcingLocations =
           newInterventionSourcingLocations;
 
         for await (const sourcingLocation of newInterventionSourcingLocations) {
@@ -248,8 +263,6 @@ export class ScenarioInterventionsService extends AppBaseService<
 
         break;
     }
-
-    // Add new replaced Entities to new Scenario Intervention
 
     /**
      * After both sets of new Sourcing Locations with Sourcing Record (and Impact Records in the future) for the start year has been created

--- a/api/src/modules/scenario-interventions/scenario-interventions.service.ts
+++ b/api/src/modules/scenario-interventions/scenario-interventions.service.ts
@@ -138,9 +138,7 @@ export class ScenarioInterventionsService extends AppBaseService<
      */
 
     const newScenarioIntervention: ScenarioIntervention =
-      await this.interventionGenerator.createInterventionInstance(
-        dtoWithDescendants,
-      );
+      ScenarioIntervention.createInterventionInstance(dtoWithDescendants);
 
     // Add replaced Entities to new Scenario Intervention
 

--- a/api/src/modules/scenario-interventions/services/intervention-generator.service.ts
+++ b/api/src/modules/scenario-interventions/services/intervention-generator.service.ts
@@ -24,26 +24,6 @@ export class InterventionGeneratorService {
     protected readonly suppliersService: SuppliersService,
   ) {}
 
-  createInterventionInstance(
-    dto: CreateScenarioInterventionDto,
-  ): ScenarioIntervention {
-    const scenarioIntervention: ScenarioIntervention =
-      new ScenarioIntervention();
-    scenarioIntervention.title = dto.title;
-    scenarioIntervention.description = dto.description;
-    scenarioIntervention.scenarioId = dto.scenarioId;
-    scenarioIntervention.startYear = dto.startYear;
-    scenarioIntervention.percentage = dto.percentage;
-    scenarioIntervention.endYear = dto.endYear;
-    scenarioIntervention.type = dto.type;
-    scenarioIntervention.newIndicatorCoefficients =
-      dto.newIndicatorCoefficients as unknown as JSON;
-    scenarioIntervention.newLocationType = dto.newLocationType;
-    scenarioIntervention.newLocationCountryInput = dto.newLocationCountryInput;
-    scenarioIntervention.newLocationAddressInput = dto.newLocationAddressInput;
-
-    return scenarioIntervention;
-  }
   async addDescendantsEntitiesForFiltering(
     dto: CreateScenarioInterventionDto,
   ): Promise<CreateScenarioInterventionDto> {

--- a/api/src/modules/scenario-interventions/services/intervention-generator.service.ts
+++ b/api/src/modules/scenario-interventions/services/intervention-generator.service.ts
@@ -1,0 +1,126 @@
+import { Injectable } from '@nestjs/common';
+import { CreateScenarioInterventionDto } from 'modules/scenario-interventions/dto/create.scenario-intervention.dto';
+import { ScenarioIntervention } from 'modules/scenario-interventions/scenario-intervention.entity';
+import { MaterialsService } from 'modules/materials/materials.service';
+import { BusinessUnitsService } from 'modules/business-units/business-units.service';
+import { AdminRegionsService } from 'modules/admin-regions/admin-regions.service';
+import { SuppliersService } from 'modules/suppliers/suppliers.service';
+import { SourcingLocation } from 'modules/sourcing-locations/sourcing-location.entity';
+import { Material } from 'modules/materials/material.entity';
+import { AdminRegion } from 'modules/admin-regions/admin-region.entity';
+import { BusinessUnit } from 'modules/business-units/business-unit.entity';
+import { Supplier } from 'modules/suppliers/supplier.entity';
+
+/**
+ * @description: Utility wrapper to encapsulate some logics regarding new intervention generation
+ */
+
+@Injectable()
+export class InterventionGeneratorService {
+  constructor(
+    protected readonly materialService: MaterialsService,
+    protected readonly businessUnitService: BusinessUnitsService,
+    protected readonly adminRegionService: AdminRegionsService,
+    protected readonly suppliersService: SuppliersService,
+  ) {}
+
+  createInterventionInstance(
+    dto: CreateScenarioInterventionDto,
+  ): ScenarioIntervention {
+    const scenarioIntervention: ScenarioIntervention =
+      new ScenarioIntervention();
+    scenarioIntervention.title = dto.title;
+    scenarioIntervention.description = dto.description;
+    scenarioIntervention.scenarioId = dto.scenarioId;
+    scenarioIntervention.startYear = dto.startYear;
+    scenarioIntervention.percentage = dto.percentage;
+    scenarioIntervention.endYear = dto.endYear;
+    scenarioIntervention.type = dto.type;
+    scenarioIntervention.newIndicatorCoefficients =
+      dto.newIndicatorCoefficients as unknown as JSON;
+    scenarioIntervention.newLocationType = dto.newLocationType;
+    scenarioIntervention.newLocationCountryInput = dto.newLocationCountryInput;
+    scenarioIntervention.newLocationAddressInput = dto.newLocationAddressInput;
+
+    return scenarioIntervention;
+  }
+  async addDescendantsEntitiesForFiltering(
+    dto: CreateScenarioInterventionDto,
+  ): Promise<CreateScenarioInterventionDto> {
+    dto.materialIds = await this.materialService.getMaterialsDescendants(
+      dto.materialIds,
+    );
+
+    dto.adminRegionIds =
+      await this.adminRegionService.getAdminRegionDescendants(
+        dto.adminRegionIds,
+      );
+
+    dto.supplierIds = await this.suppliersService.getSuppliersDescendants(
+      dto.supplierIds,
+    );
+
+    dto.businessUnitIds =
+      await this.businessUnitService.getBusinessUnitsDescendants(
+        dto.businessUnitIds,
+      );
+
+    return dto;
+  }
+
+  async addReplacedElementsToIntervention(
+    newIntervention: ScenarioIntervention,
+    cancelledSourcingLocations: SourcingLocation[],
+  ): Promise<ScenarioIntervention> {
+    const materialIds: string[] = [];
+    const adminRegionsIds: string[] = [];
+    const businessUnitIds: string[] = [];
+    const supplierIds: string[] = [];
+    for await (const sourcingLocation of cancelledSourcingLocations) {
+      if (sourcingLocation.materialId) {
+        materialIds.push(sourcingLocation.materialId);
+      }
+      if (sourcingLocation.adminRegionId) {
+        adminRegionsIds.push(sourcingLocation.adminRegionId);
+      }
+      if (sourcingLocation.businessUnitId) {
+        businessUnitIds.push(sourcingLocation.businessUnitId);
+      }
+      if (sourcingLocation.producerId || sourcingLocation.t1SupplierId) {
+        supplierIds.push(
+          sourcingLocation.producerId
+            ? sourcingLocation.producerId
+            : sourcingLocation.t1SupplierId,
+        );
+      }
+    }
+
+    const replacedMaterials: Material[] =
+      await this.materialService.getMaterialsById(materialIds);
+
+    const replacedAdminRegions: AdminRegion[] =
+      await this.adminRegionService.getAdminRegionsById(adminRegionsIds);
+
+    const replacedBusinessUnits: BusinessUnit[] =
+      await this.businessUnitService.getBusinessUnitsById(businessUnitIds);
+
+    const replacedSuppliers: Supplier[] =
+      await this.suppliersService.getSuppliersById(supplierIds);
+
+    newIntervention.replacedMaterials = replacedMaterials;
+    newIntervention.replacedAdminRegions = replacedAdminRegions;
+    newIntervention.replacedBusinessUnits = replacedBusinessUnits;
+    newIntervention.replacedSuppliers = replacedSuppliers;
+
+    newIntervention.replacedSourcingLocations = cancelledSourcingLocations;
+
+    return newIntervention;
+  }
+
+  async addReplacingElementsToIntervention(
+    newIntervention: ScenarioIntervention,
+    replacingSourcingLocations: SourcingLocation[],
+  ): Promise<ScenarioIntervention> {
+    return newIntervention;
+  }
+}

--- a/api/src/modules/scenario-interventions/services/intervention-generator.service.ts
+++ b/api/src/modules/scenario-interventions/services/intervention-generator.service.ts
@@ -58,7 +58,7 @@ export class InterventionGeneratorService {
     const adminRegionsIds: string[] = [];
     const businessUnitIds: string[] = [];
     const supplierIds: string[] = [];
-    for await (const sourcingLocation of cancelledSourcingLocations) {
+    for (const sourcingLocation of cancelledSourcingLocations) {
       if (sourcingLocation.materialId) {
         materialIds.push(sourcingLocation.materialId);
       }

--- a/api/src/modules/scenario-interventions/services/intervention-generator.service.ts
+++ b/api/src/modules/scenario-interventions/services/intervention-generator.service.ts
@@ -9,10 +9,6 @@ import { BusinessUnitsService } from 'modules/business-units/business-units.serv
 import { AdminRegionsService } from 'modules/admin-regions/admin-regions.service';
 import { SuppliersService } from 'modules/suppliers/suppliers.service';
 import { SourcingLocation } from 'modules/sourcing-locations/sourcing-location.entity';
-import { Material } from 'modules/materials/material.entity';
-import { AdminRegion } from 'modules/admin-regions/admin-region.entity';
-import { BusinessUnit } from 'modules/business-units/business-unit.entity';
-import { Supplier } from 'modules/suppliers/supplier.entity';
 import { SourcingData } from 'modules/import-data/sourcing-data/dto-processor.service';
 
 /**
@@ -60,14 +56,16 @@ export class InterventionGeneratorService {
         dto.adminRegionIds,
       );
 
-    dto.supplierIds = await this.suppliersService.getSuppliersDescendants(
-      dto.supplierIds,
-    );
-
     dto.businessUnitIds =
       await this.businessUnitService.getBusinessUnitsDescendants(
         dto.businessUnitIds,
       );
+
+    if (dto.supplierIds) {
+      dto.supplierIds = await this.suppliersService.getSuppliersDescendants(
+        dto.supplierIds,
+      );
+    }
 
     return dto;
   }
@@ -99,22 +97,19 @@ export class InterventionGeneratorService {
       }
     }
 
-    const replacedMaterials: Material[] =
+    newIntervention.replacedMaterials =
       await this.materialService.getMaterialsById(materialIds);
 
-    const replacedAdminRegions: AdminRegion[] =
+    newIntervention.replacedAdminRegions =
       await this.adminRegionService.getAdminRegionsById(adminRegionsIds);
 
-    const replacedBusinessUnits: BusinessUnit[] =
+    newIntervention.replacedBusinessUnits =
       await this.businessUnitService.getBusinessUnitsById(businessUnitIds);
 
-    const replacedSuppliers: Supplier[] =
-      await this.suppliersService.getSuppliersById(supplierIds);
-
-    newIntervention.replacedMaterials = replacedMaterials;
-    newIntervention.replacedAdminRegions = replacedAdminRegions;
-    newIntervention.replacedBusinessUnits = replacedBusinessUnits;
-    newIntervention.replacedSuppliers = replacedSuppliers;
+    if (supplierIds.length) {
+      newIntervention.replacedSuppliers =
+        await this.suppliersService.getSuppliersById(supplierIds);
+    }
 
     newIntervention.replacedSourcingLocations = cancelledSourcingLocations;
 

--- a/api/src/modules/sourcing-locations/sourcing-location.entity.ts
+++ b/api/src/modules/sourcing-locations/sourcing-location.entity.ts
@@ -141,7 +141,7 @@ export class SourcingLocation extends TimestampedBaseEntity {
 
   @Column({ nullable: true })
   @ApiPropertyOptional()
-  adminRegionId?: string;
+  adminRegionId: string;
 
   @ManyToOne(() => BusinessUnit, (bu: BusinessUnit) => bu.sourcingLocations, {
     eager: false,

--- a/api/src/modules/sourcing-locations/sourcing-location.entity.ts
+++ b/api/src/modules/sourcing-locations/sourcing-location.entity.ts
@@ -20,11 +20,6 @@ import { SourcingRecord } from 'modules/sourcing-records/sourcing-record.entity'
 import { ScenarioIntervention } from 'modules/scenario-interventions/scenario-intervention.entity';
 
 export enum LOCATION_TYPES {
-  PRODUCTION_UNIT = 'production unit',
-  PROCESSING_FACILITY = 'processing facility',
-  TIER1_TRADE_FACILITY = 'tier 1 Trade facility',
-  TIER2_TRADE_FACILITY = 'tier 2 Trade facility',
-  ORIGIN_COUNTRY = 'origin Country',
   UNKNOWN = 'unknown',
   AGGREGATION_POINT = 'aggregation point',
   POINT_OF_PRODUCTION = 'point of production',

--- a/api/test/e2e/scenario-interventions/scenario-interventions.spec.ts
+++ b/api/test/e2e/scenario-interventions/scenario-interventions.spec.ts
@@ -486,6 +486,8 @@ describe('ScenarioInterventionsModule (e2e)', () => {
         'replacedBusinessUnits',
         'replacedAdminRegions',
         'replacedSuppliers',
+        'newAdminRegion',
+        'newMaterial',
       ]);
 
       const allSourcingLocations: [SourcingLocation[], number] =
@@ -1069,6 +1071,123 @@ describe('ScenarioInterventionsModule (e2e)', () => {
           childBusinessUnit.id,
         );
         expect(intervention?.replacedSuppliers[0].id).toEqual(childSupplier.id);
+      },
+    );
+
+    test(
+      'When I create a new Intervention to switch to a new Material' +
+        'Then said Intervention should retrieve the new Material and the new Admin Region',
+      async () => {
+        // ARRANGE
+
+        // Requirements for GeoCoding Mock
+        const geoRegion: GeoRegion = await createGeoRegion();
+        const newAdminRegion: AdminRegion = await createAdminRegion({
+          geoRegion,
+          name: 'new admin region',
+        });
+
+        // Not included in Sourcing Locations
+        const parentAdminRegion: AdminRegion = await createAdminRegion({
+          name: 'parent admin region',
+        });
+        // Included in Sourcing Locations
+        const childAdminRegion: AdminRegion = await createAdminRegion({
+          name: 'child admin region',
+          parent: parentAdminRegion,
+        });
+        // Included in Sourcing Locations
+        const grandChildAdminRegion: AdminRegion = await createAdminRegion({
+          name: 'grand child admin region',
+          parent: childAdminRegion,
+        });
+        // Not included in Sourcing Locations
+        const parentMaterial: Material = await createMaterial({
+          name: 'parent material',
+        });
+        // Included in Sourcing Locations
+        const childMaterial: Material = await createMaterial({
+          name: 'child material',
+          parent: parentMaterial,
+        });
+
+        // New Material that should be included in the intervention
+        const newMaterial: Material = await createMaterial({
+          name: 'new material',
+        });
+        // Included in Sourcing Locations
+        const grandChildMaterial: Material = await createMaterial({
+          name: 'grand child material',
+          parent: childMaterial,
+        });
+        // Not included in Sourcing Locations
+        const parentBusinessUnit: BusinessUnit = await createBusinessUnit({
+          name: 'parent business unit',
+        });
+        // Included in Sourcing Locations
+        const childBusinessUnit: BusinessUnit = await createBusinessUnit({
+          name: 'child business unit',
+          parent: parentBusinessUnit,
+        });
+        // Not included in Sourcing Locations
+        const parentSupplier: Supplier = await createSupplier({
+          name: 'parent supplier',
+        });
+
+        const childSupplier: Supplier = await createSupplier({
+          name: 'child supplier',
+          parent: parentSupplier,
+        });
+
+        const sourcingRecord1: SourcingRecord = await createSourcingRecord({
+          year: 2020,
+        });
+        const sourcingRecord2: SourcingRecord = await createSourcingRecord({
+          year: 2020,
+        });
+
+        await createSourcingLocation({
+          adminRegion: grandChildAdminRegion,
+          material: grandChildMaterial,
+          businessUnit: childBusinessUnit,
+          t1Supplier: childSupplier,
+          sourcingRecords: [sourcingRecord1],
+        });
+
+        await createSourcingLocation({
+          adminRegion: childAdminRegion,
+          material: childMaterial,
+          businessUnit: childBusinessUnit,
+          t1Supplier: childSupplier,
+          sourcingRecords: [sourcingRecord2],
+        });
+        const scenario: Scenario = await createScenario();
+
+        const response = await request(app.getHttpServer())
+          .post('/api/v1/scenario-interventions')
+          .set('Authorization', `Bearer ${jwtToken}`)
+          .send({
+            title: 'scenario intervention material',
+            startYear: 2020,
+            percentage: 50,
+            scenarioId: scenario.id,
+            materialIds: [parentMaterial.id],
+            supplierIds: [parentSupplier.id],
+            businessUnitIds: [parentBusinessUnit.id],
+            adminRegionIds: [parentAdminRegion.id],
+            type: SCENARIO_INTERVENTION_TYPE.NEW_MATERIAL,
+            newLocationType: LOCATION_TYPES.COUNTRY_OF_PRODUCTION,
+            newLocationCountryInput: 'Spain',
+            newMaterialId: newMaterial.id,
+          });
+
+        const intervention: ScenarioIntervention | undefined =
+          await scenarioInterventionRepository.findOne(response.body.data.id);
+
+        // ASSERT
+        expect(intervention).toBeTruthy();
+        expect(intervention!.newMaterial.id).toEqual(newMaterial.id);
+        expect(intervention!.newAdminRegion.id).toEqual(newAdminRegion.id);
       },
     );
   });

--- a/api/test/e2e/scenario-interventions/scenario-interventions.spec.ts
+++ b/api/test/e2e/scenario-interventions/scenario-interventions.spec.ts
@@ -207,7 +207,13 @@ describe('ScenarioInterventionsModule (e2e)', () => {
         'test scenario intervention',
       );
 
-      expect(response).toHaveJSONAPIAttributes([...expectedJSONAPIAttributes]);
+      expect(response).toHaveJSONAPIAttributes([
+        ...expectedJSONAPIAttributes,
+        'replacedMaterials',
+        'replacedBusinessUnits',
+        'replacedAdminRegions',
+        'replacedSuppliers',
+      ]);
 
       const allSourcingLocations: [SourcingLocation[], number] =
         await sourcingLocationRepository.findAndCount();
@@ -343,7 +349,13 @@ describe('ScenarioInterventionsModule (e2e)', () => {
         'scenario intervention supplier',
       );
 
-      expect(response).toHaveJSONAPIAttributes([...expectedJSONAPIAttributes]);
+      expect(response).toHaveJSONAPIAttributes([
+        ...expectedJSONAPIAttributes,
+        'replacedMaterials',
+        'replacedBusinessUnits',
+        'replacedAdminRegions',
+        'replacedSuppliers',
+      ]);
 
       const allSourcingLocations: [SourcingLocation[], number] =
         await sourcingLocationRepository.findAndCount();
@@ -468,7 +480,13 @@ describe('ScenarioInterventionsModule (e2e)', () => {
         'scenario intervention material',
       );
 
-      expect(response).toHaveJSONAPIAttributes([...expectedJSONAPIAttributes]);
+      expect(response).toHaveJSONAPIAttributes([
+        ...expectedJSONAPIAttributes,
+        'replacedMaterials',
+        'replacedBusinessUnits',
+        'replacedAdminRegions',
+        'replacedSuppliers',
+      ]);
 
       const allSourcingLocations: [SourcingLocation[], number] =
         await sourcingLocationRepository.findAndCount();


### PR DESCRIPTION
**UPDATE:** 

After a chat with FR, we realised Supplierd Ids should not be required for creating an Intervention. Even tho this should be a separate task / PR, since it was depending on this implementation (if this goes forward) and for avoiding further changes, I've decided to include it here.

Let me know if this is smelly


**This PR fixes:**

Add only elements that are actually replaceable as part of the intervention: AdminRegions, Materials, etc. that are present in sourcing locations.

We were adding a full tree of elements given a Parent Id 

I created a standalone service to handle the creation of a newIntervention, which will take care of:

1. creating a new instance, adding required properties from the DTO
2. Get all descendants Id's for filtering
3. Add replaced elements
4. Add replacing elements

I created some tests accordingly

**IMPORTANT NOTE:**
Please if you are aware of some use case that is not covered with automated tests, please highlight it, we need to have this covered as much as possible, I'll be very happy to add more cases if something is missing

However, I am still not happy with the overall flow, I think we should discuss a way to separate concerns and make it more readable

Up to your thoughts @yulia-bel @KevSanchez 
