### PR TITLE
feat(impactTable): Adds a /ranking endpoint to ImpactTable

### DIFF
--- a/api/src/modules/impact/dto/get-impact-table.dto.ts
+++ b/api/src/modules/impact/dto/get-impact-table.dto.ts
@@ -1,8 +1,10 @@
 import {
   IsEnum,
+  IsIn,
   IsNotEmpty,
   IsNumber,
   IsOptional,
+  IsPositive,
   IsString,
   IsUUID,
 } from 'class-validator';
@@ -57,4 +59,28 @@ export class GetImpactTableDto {
   @IsUUID(4, { each: true })
   @Type(() => String)
   supplierIds?: string[];
+}
+
+export class GetRankedImpactTableDto extends GetImpactTableDto {
+  @ApiProperty({
+    description:
+      'The maximum number of entities to show in the Impact Table. If the result includes more than that, they will be' +
+      'aggregated into the "other" field in the response',
+  })
+  @Type(() => Number)
+  @IsNumber()
+  @IsPositive()
+  @IsNotEmpty()
+  maxRankingEntities: number;
+
+  @ApiProperty({
+    description: `The sort order for the resulting entities. Can be 'ASC' (Ascendant) or 'DES' (Descendent), with the default being 'DES'`,
+  })
+  @Type(() => String)
+  @IsString()
+  @IsOptional()
+  @IsIn(['ASC', 'DES'], {
+    message: `sort property must be either 'ASC' (Ascendant) or 'DES' (Descendent)`,
+  })
+  sort?: string; // ASC or DESC, will be DESC by default
 }

--- a/api/src/modules/impact/dto/response-impact-table.dto.ts
+++ b/api/src/modules/impact/dto/response-impact-table.dto.ts
@@ -1,4 +1,4 @@
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { PaginationMeta } from 'utils/app-base.service';
 
 export class ImpactTable {
@@ -30,6 +30,16 @@ export class ImpactTableDataByIndicator {
   metadata: { unit: string };
   @ApiProperty({ type: () => ImpactTableRowsValues, isArray: true })
   values?: ImpactTableRowsValues[];
+
+  @ApiPropertyOptional({
+    description:
+      'Extra information used for Ranked ImpactTable requests. Missing on normal ImpactTable requests',
+  })
+  others?: {
+    aggregatedValue: number;
+    numberOfAggregatedEntities: number;
+    sort: string;
+  };
 }
 
 export class ImpactTablePurchasedTonnes {

--- a/api/src/modules/impact/impact.controller.ts
+++ b/api/src/modules/impact/impact.controller.ts
@@ -1,8 +1,14 @@
 import { Controller, Get, Query, ValidationPipe } from '@nestjs/common';
-import { GetImpactTableDto } from 'modules/impact/dto/get-impact-table.dto';
+import {
+  GetImpactTableDto,
+  GetRankedImpactTableDto,
+} from 'modules/impact/dto/get-impact-table.dto';
 import { ImpactService } from 'modules/impact/impact.service';
 import { ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
-import { PaginatedImpactTable } from 'modules/impact/dto/response-impact-table.dto';
+import {
+  ImpactTable,
+  PaginatedImpactTable,
+} from 'modules/impact/dto/response-impact-table.dto';
 import {
   FetchSpecification,
   ProcessFetchSpecification,
@@ -30,5 +36,20 @@ export class ImpactController {
       impactTableDto,
       fetchSpecification,
     );
+  }
+
+  @ApiOperation({
+    description:
+      'Get Ranked Impact Table, up to maxRankingEntities, aggregating the rest of entities, for each indicator ',
+  })
+  @ApiOkResponse({
+    type: ImpactTable,
+  })
+  @JSONAPIPaginationQueryParams()
+  @Get('ranking')
+  async getRankedImpactTable(
+    @Query(ValidationPipe) rankedImpactTableDto: GetRankedImpactTableDto,
+  ): Promise<ImpactTable> {
+    return await this.impactService.getRankedImpactTable(rankedImpactTableDto);
   }
 }

--- a/api/src/modules/sourcing-records/sourcing-records.service.ts
+++ b/api/src/modules/sourcing-records/sourcing-records.service.ts
@@ -9,7 +9,10 @@ import {
   sourcingRecordResource,
 } from 'modules/sourcing-records/sourcing-record.entity';
 import { AppInfoDTO } from 'dto/info.dto';
-import { SourcingRecordRepository } from 'modules/sourcing-records/sourcing-record.repository';
+import {
+  ImpactTableData,
+  SourcingRecordRepository,
+} from 'modules/sourcing-records/sourcing-record.repository';
 import { CreateSourcingRecordDto } from 'modules/sourcing-records/dto/create.sourcing-record.dto';
 import { UpdateSourcingRecordDto } from 'modules/sourcing-records/dto/update.sourcing-record.dto';
 import { GetImpactTableDto } from 'modules/impact/dto/get-impact-table.dto';
@@ -88,7 +91,7 @@ export class SourcingRecordsService extends AppBaseService<
 
   async getDataForImpactTable(
     getImpactTableDto: GetImpactTableDto,
-  ): Promise<any> {
+  ): Promise<ImpactTableData[]> {
     return this.sourcingRecordRepository.getDataForImpactTable(
       getImpactTableDto,
     );

--- a/api/test/entity-mocks.ts
+++ b/api/test/entity-mocks.ts
@@ -120,6 +120,21 @@ async function createIndicatorRecord(
   return indicatorRecord.save();
 }
 
+// Alternate version that doesn't crete a Matching Sourcing Record
+async function createIndicatorRecordV2(
+  additionalData: Partial<IndicatorRecord> = {},
+): Promise<IndicatorRecord> {
+  const indicatorRecord = IndicatorRecord.merge(
+    new IndicatorRecord(),
+    {
+      value: 2000,
+    },
+    additionalData,
+  );
+
+  return indicatorRecord.save();
+}
+
 async function createIndicatorSource(
   additionalData: Partial<IndicatorSource> = {},
 ): Promise<IndicatorSource> {
@@ -360,6 +375,7 @@ export {
   createIndicator,
   createIndicatorCoefficient,
   createIndicatorRecord,
+  createIndicatorRecordV2,
   createIndicatorSource,
   createMaterial,
   createMaterialToH3,


### PR DESCRIPTION
A new endpoint as well as a a bit of refactoring around the getImpactTable, so it's possible to either get a normal paginated ImpactTable with the original endpoint, or an ImpactTable with results ordered and aggregated depending on the arguments passed to the /ranking endpoint