### PR TITLE
params added to analysis smart filters

### DIFF
--- a/client/src/containers/analysis-visualization/analysis-filters/materials/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-filters/materials/component.tsx
@@ -19,19 +19,34 @@ type MaterialsFilterProps = {
   currentOptions?: TreeSelectProps['current'];
   ellipsis?: TreeSelectProps['ellipsis'];
   fitContent?: TreeSelectProps['fitContent'];
+  businessUnitIds?: MaterialsTreesParams['businessUnitIds'];
+  supplierIds?: MaterialsTreesParams['supplierIds'];
+  originIds?: MaterialsTreesParams['originIds'];
+  locationTypeIds?: MaterialsTreesParams['locationTypeIds'];
 };
 
 const MaterialsFilter: React.FC<MaterialsFilterProps> = ({
   multiple,
   current,
   depth = 1,
+  supplierIds,
+  businessUnitIds,
+  originIds,
+  locationTypeIds,
   withSourcingLocations, // Do not a default; backend will override depth if this is set at all
   onChange,
   theme,
   ellipsis,
   fitContent,
 }) => {
-  const { data, isFetching } = useMaterialsTrees({ depth, withSourcingLocations });
+  const { data, isFetching } = useMaterialsTrees({
+    depth,
+    supplierIds,
+    businessUnitIds,
+    originIds,
+    locationTypeIds,
+    withSourcingLocations,
+  });
 
   const treeOptions: TreeSelectProps['options'] = useMemo(
     () =>

--- a/client/src/containers/analysis-visualization/analysis-filters/more-filters/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-filters/more-filters/component.tsx
@@ -37,6 +37,14 @@ const MoreFilters: React.FC = () => {
     [materials, origins, suppliers, locationTypes],
   );
 
+  const materialIds: string[] = useMemo(() => materials.map(({ value }) => value), [materials]);
+  const originIds: string[] = useMemo(() => origins.map(({ value }) => value), [origins]);
+  const supplierIds: string[] = useMemo(() => suppliers.map(({ value }) => value), [suppliers]);
+  const locationTypesIds: string[] = useMemo(
+    () => locationTypes.map(({ value }) => value),
+    [locationTypes],
+  );
+
   // Initial state from redux
   const [selectedFilters, setSelectedFilters] = useState<MoreFiltersState>(moreFilters);
 
@@ -112,6 +120,9 @@ const MoreFilters: React.FC = () => {
                       <Materials
                         multiple
                         withSourcingLocations
+                        originIds={originIds}
+                        supplierIds={supplierIds}
+                        locationTypeIds={locationTypesIds}
                         current={selectedFilters.materials}
                         fitContent
                         onChange={(values) => handleChangeFilter('materials', values)}
@@ -122,6 +133,9 @@ const MoreFilters: React.FC = () => {
                       <OriginRegions
                         multiple
                         withSourcingLocations
+                        materialIds={materialIds}
+                        supplierIds={supplierIds}
+                        locationTypeIds={locationTypesIds}
                         current={selectedFilters.origins}
                         fitContent
                         onChange={(values) => handleChangeFilter('origins', values)}
@@ -132,6 +146,9 @@ const MoreFilters: React.FC = () => {
                       <Suppliers
                         multiple
                         withSourcingLocations
+                        materialIds={materialIds}
+                        originIds={originIds}
+                        locationTypeIds={locationTypesIds}
                         current={selectedFilters.suppliers}
                         fitContent
                         onChange={(values) => handleChangeFilter('suppliers', values)}

--- a/client/src/containers/analysis-visualization/analysis-filters/origin-regions/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-filters/origin-regions/component.tsx
@@ -16,6 +16,10 @@ type OriginRegionsFilterProps = {
   theme?: 'default' | 'inline-primary';
   ellipsis?: TreeSelectProps['ellipsis'];
   fitContent?: TreeSelectProps['fitContent'];
+  businessUnitIds?: AdminRegionsTreesParams['businessUnitIds'];
+  supplierIds?: AdminRegionsTreesParams['supplierIds'];
+  materialIds?: AdminRegionsTreesParams['materialIds'];
+  locationTypeIds?: AdminRegionsTreesParams['locationTypeIds'];
 };
 
 const OriginRegionsFilter: React.FC<OriginRegionsFilterProps> = ({
@@ -23,12 +27,23 @@ const OriginRegionsFilter: React.FC<OriginRegionsFilterProps> = ({
   current,
   depth = 1,
   withSourcingLocations, // Do not a default; backend will override depth if this is set at all
+  supplierIds,
+  businessUnitIds,
+  materialIds,
+  locationTypeIds,
   onChange,
   theme,
   ellipsis,
   fitContent,
 }) => {
-  const { data, isFetching } = useAdminRegionsTrees({ depth, withSourcingLocations });
+  const { data, isFetching } = useAdminRegionsTrees({
+    depth,
+    withSourcingLocations,
+    supplierIds,
+    businessUnitIds,
+    materialIds,
+    locationTypeIds,
+  });
 
   const treeOptions: TreeSelectProps['options'] = useMemo(
     () =>

--- a/client/src/containers/analysis-visualization/analysis-filters/suppliers/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-filters/suppliers/component.tsx
@@ -13,6 +13,10 @@ type SuppliersFilterProps = {
   depth?: SuppliersTreesParams['depth'];
   /** Only suppliers with sourcing locations. */
   withSourcingLocations?: SuppliersTreesParams['withSourcingLocations'];
+  originIds?: SuppliersTreesParams['originIds'];
+  businessUnitIds?: SuppliersTreesParams['businessUnitIds'];
+  materialIds?: SuppliersTreesParams['materialIds'];
+  locationTypeIds?: SuppliersTreesParams['locationTypeIds'];
   onChange?: TreeSelectProps['onChange'];
   theme?: 'default' | 'inline-primary';
   ellipsis?: TreeSelectProps['ellipsis'];
@@ -24,12 +28,23 @@ const SuppliersFilter: React.FC<SuppliersFilterProps> = ({
   current,
   depth = 1,
   withSourcingLocations, // Do not a default; backend will override depth if this is set at all
+  originIds,
+  businessUnitIds,
+  materialIds,
+  locationTypeIds,
   onChange,
   theme,
   ellipsis,
   fitContent,
 }) => {
-  const { data, isFetching } = useSuppliersTrees({ depth, withSourcingLocations });
+  const { data, isFetching } = useSuppliersTrees({
+    depth,
+    originIds,
+    businessUnitIds,
+    materialIds,
+    locationTypeIds,
+    withSourcingLocations,
+  });
 
   const treeOptions: TreeSelectProps['options'] = useMemo(
     () =>

--- a/client/src/containers/interventions/smart-filters/business-units/component.tsx
+++ b/client/src/containers/interventions/smart-filters/business-units/component.tsx
@@ -22,6 +22,7 @@ type BusinessUnitsFilterProps = {
   materialIds?: BusinessUnitsTreesParams['materialIds'];
   supplierIds?: BusinessUnitsTreesParams['supplierIds'];
   originIds?: BusinessUnitsTreesParams['originIds'];
+  locationTypeIds?: BusinessUnitsTreesParams['locationTypeIds'];
   onChange?: TreeSelectProps['onChange'];
 };
 
@@ -37,6 +38,7 @@ const BusinessUnitsFilter: React.FC<BusinessUnitsFilterProps> = ({
   supplierIds,
   materialIds,
   originIds,
+  locationTypeIds,
   onChange,
   ...props
 }) => {
@@ -46,6 +48,7 @@ const BusinessUnitsFilter: React.FC<BusinessUnitsFilterProps> = ({
     supplierIds,
     materialIds,
     originIds,
+    locationTypeIds,
   });
 
   const treeOptions: TreeSelectProps['options'] = useMemo(

--- a/client/src/containers/interventions/smart-filters/materials/component.tsx
+++ b/client/src/containers/interventions/smart-filters/materials/component.tsx
@@ -21,6 +21,7 @@ type MaterialsFilterProps = {
   businessUnitIds?: MaterialsTreesParams['businessUnitIds'];
   supplierIds?: MaterialsTreesParams['supplierIds'];
   originIds?: MaterialsTreesParams['originIds'];
+  locationTypeIds?: MaterialsTreesParams['locationTypeIds'];
   onChange?: TreeSelectProps['onChange'];
 };
 
@@ -36,6 +37,7 @@ const MaterialsFilter: React.FC<MaterialsFilterProps> = ({
   businessUnitIds,
   supplierIds,
   originIds,
+  locationTypeIds,
   onChange,
   ...props
 }) => {
@@ -45,6 +47,7 @@ const MaterialsFilter: React.FC<MaterialsFilterProps> = ({
     businessUnitIds,
     supplierIds,
     originIds,
+    locationTypeIds,
   });
 
   const treeOptions: TreeSelectProps['options'] = useMemo(

--- a/client/src/containers/interventions/smart-filters/suppliers/component.tsx
+++ b/client/src/containers/interventions/smart-filters/suppliers/component.tsx
@@ -16,6 +16,7 @@ type SuppliersFilterProps = {
   materialIds?: SuppliersTreesParams['materialIds'];
   businessUnitIds?: SuppliersTreesParams['businessUnitIds'];
   originIds?: SuppliersTreesParams['originIds'];
+  locationTypeIds?: SuppliersTreesParams['locationTypeIds'];
   onChange?: TreeSelectProps['onChange'];
   theme?: 'default' | 'inline-primary';
   ellipsis?: TreeSelectProps['ellipsis'];

--- a/client/src/hooks/admin-regions/index.ts
+++ b/client/src/hooks/admin-regions/index.ts
@@ -18,6 +18,7 @@ export type AdminRegionsTreesParams = {
   materialIds?: string[];
   supplierIds?: string[];
   businessUnitIds?: string[];
+  locationTypeIds?: string[];
 };
 
 export function useAdminRegions(): ResponseData {

--- a/client/src/hooks/business-units/index.ts
+++ b/client/src/hooks/business-units/index.ts
@@ -18,6 +18,7 @@ export type BusinessUnitsTreesParams = {
   materialIds?: string[];
   supplierIds?: string[];
   originIds?: string[];
+  locationTypeIds?: string[];
 };
 
 export function useBusinessUnits(): ResponseData {

--- a/client/src/hooks/materials/index.ts
+++ b/client/src/hooks/materials/index.ts
@@ -18,6 +18,7 @@ export type MaterialsTreesParams = {
   supplierIds?: string[];
   businessUnitIds?: string[];
   originIds?: string[];
+  locationTypeIds?: string[];
 };
 
 export function useMaterials(): ResponseData {

--- a/client/src/hooks/suppliers/index.ts
+++ b/client/src/hooks/suppliers/index.ts
@@ -18,6 +18,7 @@ export type SuppliersTreesParams = {
   materialIds?: string[];
   originIds?: string[];
   businessUnitIds?: string[];
+  locationTypeIds?: string[];
 };
 
 export function useSuppliers(params): ResponseData {


### PR DESCRIPTION
**DESCRIPTION**

Analysis filters as well as smart filters used in the creation of interventions should be smart filters. Material, suppliers, admin/origin regions, and business units should depend all on each other and depend as well on location type. Location type won't depend on anything yet as it's hardcoded

Note: the ids for location type should be reviewed with BE and changed accordingly

**JIRA**
https://vizzuality.atlassian.net/browse/LANDGRIF-569?atlOrigin=eyJpIjoiYTAyMzBiZDM4ZjVlNGVkM2JlYzEyNGM2NTU1MGFhYTkiLCJwIjoiaiJ9
