### PR TITLE
Legend UI tweaks

### DIFF
--- a/client/src/components/legend/item/component.tsx
+++ b/client/src/components/legend/item/component.tsx
@@ -53,13 +53,13 @@ export const LegendItem: React.FC<LegendItemProps> = ({
   const info = useMetadataLayerInfo();
 
   return (
-    <div className={classNames('p-4 space-y-4', { 'bg-gray-50': !main })}>
+    <div className={classNames('p-4 space-y-4 group', { 'bg-gray-50': !main })}>
       {isLoading && <Loading />}
       {!isLoading && name && (
         <div className="w-full flex">
           <div className="grow flex items-start justify-between">
             <div className="max-w-[210px] text-sm text-gray-500 flex flex-row justify-start gap-x-1">
-              <div>
+              <div className="invisible group-hover:visible">
                 <DragHandle />
               </div>
               <div>{name}</div>

--- a/client/src/components/legend/item/component.tsx
+++ b/client/src/components/legend/item/component.tsx
@@ -53,7 +53,7 @@ export const LegendItem: React.FC<LegendItemProps> = ({
   const info = useMetadataLayerInfo();
 
   return (
-    <div className={classNames('p-4 space-y-4 group', { 'bg-gray-50': !main })}>
+    <div className={classNames('pl-1 pr-4 py-4 space-y-4 group', { 'bg-gray-50': !main })}>
       {isLoading && <Loading />}
       {!isLoading && name && (
         <div className="w-full flex">
@@ -79,7 +79,7 @@ export const LegendItem: React.FC<LegendItemProps> = ({
         </div>
       )}
       {!isLoading && isActive && children && (
-        <div className="flex">
+        <div className="flex ml-2">
           <div className="flex-1">{children}</div>
           {unit && <div className="w-8 text-xs text-gray-500 -m-1">{unit}</div>}
         </div>

--- a/client/src/components/legend/item/component.tsx
+++ b/client/src/components/legend/item/component.tsx
@@ -7,6 +7,7 @@ import Loading from 'components/loading';
 import OpacityControl from './opacityControl';
 import DragHandle from './dragHandle';
 import InfoToolTip from 'containers/info-tooltip/component';
+import classNames from 'classnames';
 
 export type LegendItemProps = {
   name: string | JSX.Element;
@@ -20,6 +21,7 @@ export type LegendItemProps = {
   onActiveChange?: (active: boolean) => void;
   opacity: number;
   onChangeOpacity: (opacity: number) => void;
+  main?: boolean;
 };
 
 export const LegendItem: React.FC<LegendItemProps> = ({
@@ -33,6 +35,7 @@ export const LegendItem: React.FC<LegendItemProps> = ({
   onActiveChange,
   opacity,
   onChangeOpacity,
+  main = false,
 }) => {
   const [isActive, setActive] = useState<boolean>(active);
   const handleChange = useCallback(
@@ -50,7 +53,7 @@ export const LegendItem: React.FC<LegendItemProps> = ({
   const info = useMetadataLayerInfo();
 
   return (
-    <div className="p-4 space-y-4">
+    <div className={classNames('p-4 space-y-4', { 'bg-gray-50': !main })}>
       {isLoading && <Loading />}
       {!isLoading && name && (
         <div className="w-full flex">

--- a/client/src/components/legend/item/component.tsx
+++ b/client/src/components/legend/item/component.tsx
@@ -16,7 +16,6 @@ export type LegendItemProps = {
   active?: boolean;
   isLoading?: boolean;
   showToolbar?: boolean;
-  showToggle?: boolean;
   children?: React.ReactNode;
   onActiveChange?: (active: boolean) => void;
   opacity: number;
@@ -30,7 +29,6 @@ export const LegendItem: React.FC<LegendItemProps> = ({
   active = false,
   isLoading = false,
   showToolbar = true,
-  showToggle = true,
   children,
   onActiveChange,
   opacity,
@@ -73,7 +71,7 @@ export const LegendItem: React.FC<LegendItemProps> = ({
             )}
           </div>
           <div className="ml-1 w-8">
-            {showToggle && <Toggle defaultActive={isActive} onChange={handleChange} />}
+            <Toggle defaultActive={isActive} onChange={handleChange} />
           </div>
         </div>
       )}

--- a/client/src/components/legend/item/component.tsx
+++ b/client/src/components/legend/item/component.tsx
@@ -53,13 +53,13 @@ export const LegendItem: React.FC<LegendItemProps> = ({
   const info = useMetadataLayerInfo();
 
   return (
-    <div className={classNames('pl-1 pr-4 py-4 space-y-4 group', { 'bg-gray-50': !main })}>
+    <div className={classNames('pr-4 py-4 space-y-4 group', { 'bg-gray-50': !main })}>
       {isLoading && <Loading />}
       {!isLoading && name && (
         <div className="w-full flex">
           <div className="grow flex items-start justify-between">
             <div className="max-w-[210px] text-sm text-gray-500 flex flex-row justify-start gap-x-1">
-              <div className="invisible group-hover:visible">
+              <div className="invisible group-hover:visible pl-1 pr-0.5">
                 <DragHandle />
               </div>
               <div>{name}</div>

--- a/client/src/components/legend/item/dragHandle.tsx
+++ b/client/src/components/legend/item/dragHandle.tsx
@@ -21,7 +21,7 @@ const DragHandle: React.FC = () => {
       {Array(6)
         .fill(true)
         .map((_, i) => (
-          <div className="rounded-full bg-gray-400 w-[3px] h-[3px] m-auto" key={i} />
+          <div className="rounded-full bg-gray-300 w-[3px] h-[3px] m-auto" key={i} />
         ))}
     </div>
   );

--- a/client/src/components/toggle/component.tsx
+++ b/client/src/components/toggle/component.tsx
@@ -30,7 +30,7 @@ const Toggle: React.FC<ToggleProps> = ({ defaultActive = false, onChange }) => {
       <span className="sr-only">Use setting</span>
       <span
         aria-hidden="true"
-        className="pointer-events-none absolute bg-white w-full h-full rounded-md"
+        className="pointer-events-none absolute bg-none w-full h-full rounded-md"
       />
       <span
         aria-hidden="true"

--- a/client/src/containers/analysis-visualization/analysis-legend/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-legend/component.tsx
@@ -18,9 +18,11 @@ export const Legend: React.FC = () => {
   const layers = useAppSelector(analysisMap).layers;
 
   const orderedLayers = useMemo(() => {
-    return Object.values(layers)
-      .filter((legend) => legend.id !== 'h3-layer-impact')
-      .sort((a, b) => a.order - b.order);
+    return (
+      Object.values(layers)
+        // .filter((legend) => legend.id !== 'h3-layer-impact')
+        .sort((a, b) => a.order - b.order)
+    );
   }, [layers]);
 
   const handleShowLegend = useCallback(() => {
@@ -32,14 +34,18 @@ export const Legend: React.FC = () => {
   }, [showContextualLayers]);
 
   const legends = useMemo(
-    () => ({ 'h3-layer-material': <MaterialLegendItem />, 'h3-layer-risk': <RiskLegendItem /> }),
+    () => ({
+      'h3-layer-material': <MaterialLegendItem />,
+      'h3-layer-risk': <RiskLegendItem />,
+      'h3-layer-impact': <ImpactLegendItem />,
+    }),
     [],
   );
 
   return (
     <div className="relative">
       {showLegend && (
-        <div className="absolute z-10 bottom-0 right-12 flex flex-col flex-grow shadow-sm bg-white border border-gray-200 rounded w-80 max-w-xs">
+        <div className="absolute z-10 bottom-0 right-12 flex flex-col flex-grow shadow-sm bg-white border border-gray-200 rounded-lg w-80 max-w-xs">
           <div className="flex items-center justify-between px-4 py-2">
             <div className="font-semibold text-gray-900 text-sm">Legend</div>
             <button
@@ -57,7 +63,7 @@ export const Legend: React.FC = () => {
             <Sortable
               items={orderedLayers.map((layer) => layer.id)}
               onChangeOrder={(orderedIds) => {
-                dispatch(setLayerOrder([...orderedIds, 'h3-impact-layer']));
+                dispatch(setLayerOrder([...orderedIds]));
               }}
             >
               {orderedLayers.map(({ id }) => (

--- a/client/src/containers/analysis-visualization/analysis-legend/impact-legend-item/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-legend/impact-legend-item/component.tsx
@@ -30,6 +30,7 @@ const ImpactLayer = () => {
       active={impact.active}
       onChangeOpacity={handleOpacity}
       isLoading={impact.loading}
+      main
     >
       <LegendTypeChoropleth
         className="text-sm text-gray-500 flex-1"

--- a/client/src/containers/analysis-visualization/analysis-legend/impact-legend-item/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-legend/impact-legend-item/component.tsx
@@ -29,7 +29,6 @@ const ImpactLayer = () => {
       opacity={impact.opacity}
       active={impact.active}
       onChangeOpacity={handleOpacity}
-      showToggle={false}
       isLoading={impact.loading}
     >
       <LegendTypeChoropleth


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1385934/169862549-093fc64f-9f99-44e0-81db-84939770f7ce.png)

- All legends are sortable
- Non-impact legends have a gray background
- Non-impact layers hide when contextual layers are turned off
- Drag handle is only shown when hovering the legend
- Increased border radius
- Moved drag handle closer to the border