### PR TITLE
Client/landgrif 649 legend tweaks

### DIFF
--- a/client/src/components/legend/item/component.tsx
+++ b/client/src/components/legend/item/component.tsx
@@ -18,7 +18,7 @@ export type LegendItemProps = {
   isLoading?: boolean;
   showToolbar?: boolean;
   children?: React.ReactNode;
-  onActiveChange?: (active: boolean) => void;
+  onActiveChange: (active: boolean) => void;
   opacity: number;
   onChangeOpacity: (opacity: number) => void;
   main?: boolean;

--- a/client/src/components/tooltip/component.tsx
+++ b/client/src/components/tooltip/component.tsx
@@ -30,6 +30,7 @@ export const ToolTip: React.FC<TooltipProps> = ({
     middlewareData: { arrow: { x: arrowX, y: arrowY } = {} },
   } = useFloating({
     placement,
+    strategy: 'fixed',
     middleware: [
       offset({ mainAxis: arrow ? 15 : 10 }),
       shift({ padding: 4 }),

--- a/client/src/containers/analysis-visualization/analysis-legend/impact-legend-item/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-legend/impact-legend-item/component.tsx
@@ -20,6 +20,13 @@ const ImpactLayer = () => {
     [dispatch],
   );
 
+  const handleActive = useCallback(
+    (active) => {
+      dispatch(setLayer({ id: LAYER_ID, layer: { ...impact, active } }));
+    },
+    [dispatch, impact],
+  );
+
   // TO-DO: add Loading component
   return (
     <LegendItem
@@ -29,6 +36,7 @@ const ImpactLayer = () => {
       opacity={impact.opacity}
       active={impact.active}
       onChangeOpacity={handleOpacity}
+      onActiveChange={handleActive}
       isLoading={impact.loading}
       main
     >

--- a/client/src/hooks/layers/impact.ts
+++ b/client/src/hooks/layers/impact.ts
@@ -63,7 +63,7 @@ export const useImpactLayer: () => ReturnType<typeof useH3ImpactData> & { layer:
       coverage: 0.9,
       lineWidthMinPixels: 2,
       opacity: impactLayer.opacity,
-      visible: true, // always active
+      visible: impactLayer.active,
       getHexagon: (d) => d.h,
       getFillColor: (d) => d.c,
       getElevation: (d) => d.v,


### PR DESCRIPTION
This PR fixes:

- Impact layer being visible even when deactivated
- Info and opacity tooltips clipping
![image](https://user-images.githubusercontent.com/1385934/170078012-47777af4-b5d3-421b-9449-0303814ab759.png)
Notice in the image that the border doesn't overflow AND the tooltip is visible at the same time. My brain could only fix one issue at a time when working on this, sorryyy~