### PR TITLE
interactivity to legend area chart

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+- Interactivity added to chart legend to highlight areas in the graph [LANDGRIF-688](https://vizzuality.atlassian.net/browse/LANDGRIF-688)
 
 ### Added
 - [Storybook](https://storybook.js.org/) for documentation of UI components

--- a/client/src/components/chart/area-stacked/component.tsx
+++ b/client/src/components/chart/area-stacked/component.tsx
@@ -39,6 +39,7 @@ export type AreaStackedProps = {
   };
   keys?: string[];
   colors?: Record<string, string>;
+  activeArea: string;
   target?: number;
   projection?: number;
   settings?: {
@@ -59,6 +60,7 @@ const AreaStacked: React.FC<AreaStackedProps> = ({
   colors,
   target,
   projection,
+  activeArea,
   settings = {
     tooltip: true,
     projection: true,
@@ -66,7 +68,6 @@ const AreaStacked: React.FC<AreaStackedProps> = ({
   },
 }) => {
   const { showTooltip, hideTooltip, tooltipData, tooltipTop, tooltipLeft } = useTooltip();
-
   const lastCurrentIndex = useMemo(() => {
     const i = data.findIndex((d) => !d.current);
     if (i > -1 && i !== data.length - 1) return i;
@@ -184,6 +185,7 @@ const AreaStacked: React.FC<AreaStackedProps> = ({
                   strokeOpacity={0.25}
                   strokeWidth={0.5}
                   fill={colors[stack.key]}
+                  opacity={activeArea && `${stack.key}-${title}` === activeArea ? 1 : 0.3}
                 />
               ))
             }

--- a/client/src/components/chart/area-stacked/component.tsx
+++ b/client/src/components/chart/area-stacked/component.tsx
@@ -185,7 +185,7 @@ const AreaStacked: React.FC<AreaStackedProps> = ({
                   strokeOpacity={0.25}
                   strokeWidth={0.5}
                   fill={colors[stack.key]}
-                  opacity={activeArea && `${stack.key}-${title}` === activeArea ? 1 : 0.3}
+                  opacity={!activeArea || `${stack.key}-${title}` === activeArea ? 1 : 0.3}
                 />
               ))
             }

--- a/client/src/containers/analysis-visualization/analysis-chart/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-chart/component.tsx
@@ -1,3 +1,4 @@
+import { FC, useCallback, useState } from 'react';
 import cx from 'classnames';
 
 import { useAppSelector } from 'store/hooks';
@@ -12,13 +13,24 @@ import Chart from 'components/chart';
 import AreaStacked from 'components/chart/area-stacked';
 import Widget from 'components/widget';
 
-const AnalysisChart: React.FC = () => {
+const AnalysisChart: FC = () => {
   const filters = useAppSelector(analysisFilters);
+
+  const [activeArea, setActiveArea] = useState(null);
 
   const { data: chartData, isFetching } = useAnalysisChart({
     maxRankingEntities: 5,
     sort: 'DES',
   });
+
+  const handleActiveArea = useCallback(
+    (key, indicator) => {
+      if (!activeArea) {
+        setActiveArea(`${key}-${indicator}`);
+      } else setActiveArea(null);
+    },
+    [activeArea],
+  );
 
   return (
     <>
@@ -51,6 +63,7 @@ const AnalysisChart: React.FC = () => {
                         margin={{ top: 12, right: 8, bottom: 30, left: 60 }}
                         keys={keys}
                         colors={colors}
+                        activeArea={activeArea}
                         // target={120}
                         projection={projection}
                         settings={{
@@ -65,16 +78,23 @@ const AnalysisChart: React.FC = () => {
                   <ul className="flex flex-row flex-wrap gap-x-3 gap-y-1 mt-2">
                     {keys.map((key) => (
                       <li key={key} className="flex items-center gap-x-1">
-                        <div
-                          className="w-3 h-3 rounded-full"
-                          style={{ backgroundColor: d.colors[key] }}
-                        />
-                        <span
-                          title={key}
-                          className="text-xs text-gray-500 max-w-[74px] truncate text-ellipsis"
-                        >
-                          {key}
-                        </span>
+                        <button type="button" onClick={() => handleActiveArea(key, indicator)}>
+                          <span
+                            className="w-3 h-3 rounded-full"
+                            style={{ backgroundColor: d.colors[key] }}
+                          />
+                          <span
+                            title={key}
+                            className={cx('text-xs', {
+                              'truncate text-ellipsis text-gray-500 max-w-[74px]':
+                                activeArea !== `${key}-${indicator}`,
+                              'opacity-70 text-gray-900':
+                                activeArea && activeArea !== `${key}-${indicator}`,
+                            })}
+                          >
+                            {key}
+                          </span>
+                        </button>
                       </li>
                     ))}
                   </ul>

--- a/client/src/containers/analysis-visualization/analysis-chart/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-chart/component.tsx
@@ -78,9 +78,13 @@ const AnalysisChart: FC = () => {
                   <ul className="flex flex-row flex-wrap gap-x-3 gap-y-1 mt-2">
                     {keys.map((key) => (
                       <li key={key} className="flex items-center gap-x-1">
-                        <button type="button" onClick={() => handleActiveArea(key, indicator)}>
+                        <button
+                          type="button"
+                          className="flex items-center"
+                          onClick={() => handleActiveArea(key, indicator)}
+                        >
                           <span
-                            className="w-3 h-3 rounded-full"
+                            className="w-2.5 h-2.5 rounded-full mr-1"
                             style={{ backgroundColor: d.colors[key] }}
                           />
                           <span


### PR DESCRIPTION
### General description

_Areas in the chart should be highlighted when selecting items in the legend. To do so, every time the user clicks on the legend, the chart should have all areas with opacity but the one selected.
The legend item should change color, and opacity and should not be ellipsed._

### Designs

_[Design prototypes](https://www.figma.com/file/WxYMmJrUZAgV6f0Csmt8fK/LG-Tool---Work-in-progress?node-id=2240%3A31571)_

### Testing instructions

_Go to analysis, chart view, and interact with leged items. The text in the legend should expand and become bold. The area in the chart corresponding to that selection should get highlighted_

## Checklist before merging

- [x] Branch name / PR includes the related Jira ticket Id.
- [ ] Tests to check core implementation / bug fix added.
- [x] All checks in Continuous Integration workflow pass.
- [ ] Feature functionally tested by reviewer(s).
- [x] Code reviewed by reviewer(s).
- [x] Documentation updated (README, CHANGELOG...) (if required)

