### PR TITLE
Chore LANDGRIF-694 add gh pr template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+
+### General description
+
+_Please write a description. If the PR is hard to understand, provide a quick explanation of the code._
+
+### Designs
+
+_Link to the related design prototypes (if applicable)_
+
+### Testing instructions
+
+_Provide minimal instructions on how to test this PR._
+
+## Checklist before merging
+
+- [ ] Branch name / PR includes the related Jira ticket Id.
+- [ ] Tests to check core implementation / bug fix added.
+- [ ] All checks in Continuous Integration workflow pass.
+- [ ] Feature functionally tested by reviewer(s).
+- [ ] Code reviewed by reviewer(s).
+- [ ] Documentation updated (if required)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,6 +11,8 @@ _Link to the related design prototypes (if applicable)_
 
 _Provide minimal instructions on how to test this PR._
 
+- Apart from the added feature / bug fix, check overall performance, styling...
+
 ## Checklist before merging
 
 - [ ] Branch name / PR includes the related Jira ticket Id.
@@ -18,4 +20,4 @@ _Provide minimal instructions on how to test this PR._
 - [ ] All checks in Continuous Integration workflow pass.
 - [ ] Feature functionally tested by reviewer(s).
 - [ ] Code reviewed by reviewer(s).
-- [ ] Documentation updated (if required)
+- [ ] Documentation updated (README, CHANGELOG...) (if required)


### PR DESCRIPTION
This PR adds:

-GH PR template with some bullet points of actions that needs to be taken before merging the PR

These actions were agreed to take place as first steps to increase the quality of our work in LG, and to be measured over time for the next iteration

**NOTE:**

Apparently the template needs to exist on the base branch (in this repository's case _staging_ branch) in order to be shown for each PR 