### PR TITLE
Fix/landgrif 389 swagger array params

### DIFF
--- a/api/src/modules/h3-data/dto/get-impact-map.dto.ts
+++ b/api/src/modules/h3-data/dto/get-impact-map.dto.ts
@@ -42,19 +42,19 @@ export class GetImpactMapDto {
   @IsEnum(AvailableResolutions, { message: 'Available resolutions: 1 to 6' })
   resolution!: number;
 
-  @ApiPropertyOptional()
+  @ApiPropertyOptional({ name: 'materialIds[]' })
   @IsOptional()
   @IsString({ each: true })
   @Type(() => String)
   materialIds?: string[];
 
-  @ApiPropertyOptional()
+  @ApiPropertyOptional({ name: 'originIds[]' })
   @IsOptional()
   @IsString({ each: true })
   @Type(() => String)
   originIds?: string[];
 
-  @ApiPropertyOptional()
+  @ApiPropertyOptional({ name: 'supplierIds[]' })
   @IsOptional()
   @IsString({ each: true })
   @Type(() => String)
@@ -63,6 +63,7 @@ export class GetImpactMapDto {
   @ApiPropertyOptional({
     description: 'Types of Sourcing Locations, written with hyphens',
     enum: Object.values(LOCATION_TYPES_PARAMS),
+    name: 'locationTypes[]',
   })
   @IsOptional()
   @IsEnum(LOCATION_TYPES_PARAMS, {

--- a/api/src/modules/h3-data/dto/get-impact-map.dto.ts
+++ b/api/src/modules/h3-data/dto/get-impact-map.dto.ts
@@ -8,9 +8,13 @@ import {
   Min,
 } from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { Type } from 'class-transformer';
+import { Transform, Type } from 'class-transformer';
 import { AvailableResolutions } from 'modules/h3-data/dto/get-material-h3-by-resolution.dto';
-import { LOCATION_TYPES_PARAMS } from 'modules/sourcing-locations/sourcing-location.entity';
+import {
+  LOCATION_TYPES,
+  LOCATION_TYPES_PARAMS,
+} from 'modules/sourcing-locations/sourcing-location.entity';
+import { transformLocationType } from 'utils/transform-location-type.util';
 
 export enum GROUP_BY_VALUES {
   MATERIAL = 'material',
@@ -66,12 +70,13 @@ export class GetImpactMapDto {
     name: 'locationTypes[]',
   })
   @IsOptional()
-  @IsEnum(LOCATION_TYPES_PARAMS, {
+  @IsEnum(LOCATION_TYPES, {
     each: true,
     message:
       'Available options: ' +
       Object.values(LOCATION_TYPES_PARAMS).toString().toLowerCase(),
   })
+  @Transform(({ value }) => transformLocationType(value))
   @Type(() => String)
   locationTypes?: LOCATION_TYPES_PARAMS[];
 }

--- a/api/src/modules/h3-data/h3-data.repository.ts
+++ b/api/src/modules/h3-data/h3-data.repository.ts
@@ -183,69 +183,6 @@ export class H3DataRepository extends Repository<H3Data> {
     supplierIds?: string[],
     locationTypes?: LOCATION_TYPES_PARAMS[],
   ): Promise<{ impactMap: H3IndexValueData[]; quantiles: number[] }> {
-    // TODO: Feature toggle to switch between distributed / non-distributed impact map
-    //       delete when M.Views are set with proper performance
-    const distributed: boolean =
-      `${config.get('map.distributed')}`.toLowerCase() === 'true';
-
-    if (!distributed) {
-      const query: SelectQueryBuilder<any> = getManager()
-        .createQueryBuilder()
-        .select(
-          `h3_to_parent(unnest(gr."h3Flat"::h3index[]), ${resolution})`,
-          'h',
-        )
-        .addSelect('sum(ir.value/gr."h3FlatLength")', 'v')
-        .from(SourcingLocation, 'sl')
-        .innerJoin(SourcingRecord, 'sr', 'sl.id = sr.sourcingLocationId')
-        .innerJoin(IndicatorRecord, 'ir', 'sr.id = ir.sourcingRecordId')
-        .innerJoin(GeoRegion, 'gr', 'sl.geoRegionId = gr.id')
-        .where('sl.scenarioInterventionId IS NULL')
-        .andWhere('sl.interventionType IS NULL')
-        .andWhere('ir.indicatorId = :indicatorId', {
-          indicatorId: indicator.id,
-        })
-        .andWhere('sr.year = :year', { year })
-        .andWhere('gr."h3FlatLength" > 0')
-        .groupBy('h');
-
-      if (materialIds) {
-        query.andWhere('sl.material IN (:...materialIds)', { materialIds });
-      }
-
-      if (supplierIds) {
-        query.andWhere(
-          new Brackets((qb: WhereExpressionBuilder) => {
-            qb.where('sl.t1SupplierId IN (:...supplierIds)', {
-              supplierIds,
-            }).orWhere('sl.producerId IN (:...supplierIds)', { supplierIds });
-          }),
-        );
-      }
-      if (originIds) {
-        query.andWhere('sl.adminRegionId IN (:...originIds)', { originIds });
-      }
-
-      if (locationTypes) {
-        query.andWhere('sl.locationType IN (:...locationTypes)', {
-          locationTypes,
-        });
-      }
-      const tmpTableName: string = H3DataRepository.generateRandomTableName();
-      const [queryString, params] = query.getQueryAndParameters();
-      await getManager().query(
-        `CREATE TEMPORARY TABLE "${tmpTableName}" AS (${queryString});`,
-        params,
-      );
-      const impactMap: any = await getManager().query(
-        `SELECT *
-       FROM "${tmpTableName}";`,
-      );
-      this.logger.log('Impact Map generated');
-      const quantiles: number[] = await this.calculateQuantiles(tmpTableName);
-      await getManager().query(`DROP TABLE "${tmpTableName}";`);
-      return { impactMap, quantiles };
-    }
     const subqueryBuilder: SelectQueryBuilder<any> = getManager()
       .createQueryBuilder()
       .select('sl.geoRegionId', 'geoRegionId')

--- a/api/src/modules/h3-data/h3-data.repository.ts
+++ b/api/src/modules/h3-data/h3-data.repository.ts
@@ -183,6 +183,69 @@ export class H3DataRepository extends Repository<H3Data> {
     supplierIds?: string[],
     locationTypes?: LOCATION_TYPES_PARAMS[],
   ): Promise<{ impactMap: H3IndexValueData[]; quantiles: number[] }> {
+    // TODO: Feature toggle to switch between distributed / non-distributed impact map
+    //       delete when M.Views are set with proper performance
+    const distributed: boolean =
+      `${config.get('map.distributed')}`.toLowerCase() === 'true';
+
+    if (!distributed) {
+      const query: SelectQueryBuilder<any> = getManager()
+        .createQueryBuilder()
+        .select(
+          `h3_to_parent(unnest(gr."h3Flat"::h3index[]), ${resolution})`,
+          'h',
+        )
+        .addSelect('sum(ir.value/gr."h3FlatLength")', 'v')
+        .from(SourcingLocation, 'sl')
+        .innerJoin(SourcingRecord, 'sr', 'sl.id = sr.sourcingLocationId')
+        .innerJoin(IndicatorRecord, 'ir', 'sr.id = ir.sourcingRecordId')
+        .innerJoin(GeoRegion, 'gr', 'sl.geoRegionId = gr.id')
+        .where('sl.scenarioInterventionId IS NULL')
+        .andWhere('sl.interventionType IS NULL')
+        .andWhere('ir.indicatorId = :indicatorId', {
+          indicatorId: indicator.id,
+        })
+        .andWhere('sr.year = :year', { year })
+        .andWhere('gr."h3FlatLength" > 0')
+        .groupBy('h');
+
+      if (materialIds) {
+        query.andWhere('sl.material IN (:...materialIds)', { materialIds });
+      }
+
+      if (supplierIds) {
+        query.andWhere(
+          new Brackets((qb: WhereExpressionBuilder) => {
+            qb.where('sl.t1SupplierId IN (:...supplierIds)', {
+              supplierIds,
+            }).orWhere('sl.producerId IN (:...supplierIds)', { supplierIds });
+          }),
+        );
+      }
+      if (originIds) {
+        query.andWhere('sl.adminRegionId IN (:...originIds)', { originIds });
+      }
+
+      if (locationTypes) {
+        query.andWhere('sl.locationType IN (:...locationTypes)', {
+          locationTypes,
+        });
+      }
+      const tmpTableName: string = H3DataRepository.generateRandomTableName();
+      const [queryString, params] = query.getQueryAndParameters();
+      await getManager().query(
+        `CREATE TEMPORARY TABLE "${tmpTableName}" AS (${queryString});`,
+        params,
+      );
+      const impactMap: any = await getManager().query(
+        `SELECT *
+       FROM "${tmpTableName}";`,
+      );
+      this.logger.log('Impact Map generated');
+      const quantiles: number[] = await this.calculateQuantiles(tmpTableName);
+      await getManager().query(`DROP TABLE "${tmpTableName}";`);
+      return { impactMap, quantiles };
+    }
     const subqueryBuilder: SelectQueryBuilder<any> = getManager()
       .createQueryBuilder()
       .select('sl.geoRegionId', 'geoRegionId')

--- a/api/src/modules/impact/dto/get-impact-table.dto.ts
+++ b/api/src/modules/impact/dto/get-impact-table.dto.ts
@@ -9,10 +9,14 @@ import {
   IsUUID,
 } from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { Type } from 'class-transformer';
+import { Transform, Type } from 'class-transformer';
 
 import { GROUP_BY_VALUES } from 'modules/h3-data/dto/get-impact-map.dto';
-import { LOCATION_TYPES_PARAMS } from 'modules/sourcing-locations/sourcing-location.entity';
+import {
+  LOCATION_TYPES,
+  LOCATION_TYPES_PARAMS,
+} from 'modules/sourcing-locations/sourcing-location.entity';
+import { transformLocationType } from 'utils/transform-location-type.util';
 
 export class GetImpactTableDto {
   @ApiProperty({
@@ -71,12 +75,13 @@ export class GetImpactTableDto {
     name: 'locationTypes[]',
   })
   @IsOptional()
-  @IsEnum(LOCATION_TYPES_PARAMS, {
+  @IsEnum(LOCATION_TYPES, {
     each: true,
     message:
       'Available options: ' +
       Object.values(LOCATION_TYPES_PARAMS).toString().toLowerCase(),
   })
+  @Transform(({ value }) => transformLocationType(value))
   @Type(() => String)
   locationTypes?: LOCATION_TYPES_PARAMS[];
 

--- a/api/src/modules/impact/dto/get-impact-table.dto.ts
+++ b/api/src/modules/impact/dto/get-impact-table.dto.ts
@@ -15,7 +15,9 @@ import { GROUP_BY_VALUES } from 'modules/h3-data/dto/get-impact-map.dto';
 import { LOCATION_TYPES_PARAMS } from 'modules/sourcing-locations/sourcing-location.entity';
 
 export class GetImpactTableDto {
-  @ApiProperty()
+  @ApiProperty({
+    name: 'indicatorIds[]',
+  })
   @IsUUID(4, { each: true })
   @Type(() => String)
   indicatorIds!: string[];
@@ -45,19 +47,19 @@ export class GetImpactTableDto {
   })
   groupBy!: string;
 
-  @ApiPropertyOptional()
+  @ApiPropertyOptional({ name: 'materialIds[]' })
   @IsOptional()
   @IsUUID(4, { each: true })
   @Type(() => String)
   materialIds?: string[];
 
-  @ApiPropertyOptional()
+  @ApiPropertyOptional({ name: 'originIds[]' })
   @IsOptional()
   @IsUUID(4, { each: true })
   @Type(() => String)
   originIds?: string[];
 
-  @ApiPropertyOptional()
+  @ApiPropertyOptional({ name: 'supplierIds[]' })
   @IsOptional()
   @IsUUID(4, { each: true })
   @Type(() => String)
@@ -66,6 +68,7 @@ export class GetImpactTableDto {
   @ApiPropertyOptional({
     description: 'Types of Sourcing Locations, written with hyphens',
     enum: Object.values(LOCATION_TYPES_PARAMS),
+    name: 'locationTypes[]',
   })
   @IsOptional()
   @IsEnum(LOCATION_TYPES_PARAMS, {

--- a/api/src/modules/sourcing-records/sourcing-record.repository.ts
+++ b/api/src/modules/sourcing-records/sourcing-record.repository.ts
@@ -181,15 +181,10 @@ export class SourcingRecordRepository extends Repository<SourcingRecord> {
     }
 
     if (locationTypes) {
-      const sourcingLocationTypes: string[] = locationTypes.map(
-        (el: LOCATION_TYPES_PARAMS) => {
-          return el.replace(/-/g, ' ');
-        },
-      );
       impactDataQueryBuilder.andWhere(
-        'sourcingLocation.locationType IN (:...sourcingLocationTypes)',
+        'sourcingLocation.locationType IN (:...locationTypes)',
         {
-          sourcingLocationTypes,
+          locationTypes,
         },
       );
     }

--- a/api/src/utils/transform-location-type.util.ts
+++ b/api/src/utils/transform-location-type.util.ts
@@ -1,0 +1,12 @@
+import {
+  LOCATION_TYPES,
+  LOCATION_TYPES_PARAMS,
+} from 'modules/sourcing-locations/sourcing-location.entity';
+
+export function transformLocationType(
+  locationTypesParams: LOCATION_TYPES_PARAMS[],
+): LOCATION_TYPES[] {
+  return locationTypesParams.map((el: LOCATION_TYPES_PARAMS) => {
+    return el.replace(/-/g, ' ') as LOCATION_TYPES;
+  });
+}


### PR DESCRIPTION
### General description

- Minor fix of the Swagger UI serialization issue for the query params that come as array
- For GET Impact Map and GET Impact table, in particular for the filter 'LocationTypes' - the transformation from hyphen including URL-friendly location type options to format of the database (with spaces) is taken out of the TypeORM query in repository and is done with @Tranform decorator in the DTOs

### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

- Test 'Try Out' in the swagger UI for the following endpoints: GET Impact Map, GET Impact Table

- Apart from the added feature / bug fix, check overall performance, styling...

## Checklist before merging

- [ ] Branch name / PR includes the related Jira ticket Id.
- [ ] Tests to check core implementation / bug fix added.
- [ ] All checks in Continuous Integration workflow pass.
- [ ] Feature functionally tested by reviewer(s).
- [ ] Code reviewed by reviewer(s).
- [ ] Documentation updated (README, CHANGELOG...) (if required)
