### PR TITLE
location types standard and param added to impact endpoint

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -36,6 +36,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Arrow icon in the tables also toggle collapse the rows
 - Fixed issues related to duplicated keys in the table rendering [LANDGRIF-650](https://vizzuality.atlassian.net/browse/LANDGRIF-650)
 
+- Location types params standarized
+- Location types params added to "/h3/map/impact" endpoint
 
 ## 0.3.0 - 2021-09-01
 

--- a/client/src/containers/analysis-visualization/analysis-filters/location-types/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-filters/location-types/component.tsx
@@ -6,7 +6,6 @@ import TreeSelect from 'components/tree-select';
 // hooks
 import { useLocationTypes } from 'hooks/interventions';
 import type { TreeSelectProps } from 'components/tree-select/types';
-import { firstLetterUppercase } from 'utils/string';
 
 type LocationTypeFilterProps = {
   current: TreeSelectProps['current'];
@@ -29,9 +28,9 @@ const LocationTypesFilter: React.FC<LocationTypeFilterProps> = ({
   const options: TreeSelectProps['options'] = useMemo(
     () =>
       sortBy(
-        data?.map((d) => ({
-          label: firstLetterUppercase(d),
-          value: d,
+        data?.map(({ label, value }) => ({
+          label,
+          value,
         })),
         'label',
       ),

--- a/client/src/containers/interventions/new/step2/supplier/component.tsx
+++ b/client/src/containers/interventions/new/step2/supplier/component.tsx
@@ -17,7 +17,6 @@ import { useMetadataInterventionsInfo } from 'hooks/metadata-info';
 
 // types
 import type { SelectOption, SelectOptions } from 'components/select/types';
-import { firstLetterUppercase } from 'utils/string';
 
 const Supplier: FC = () => {
   const {
@@ -55,9 +54,9 @@ const Supplier: FC = () => {
   const locationTypes = useLocationTypes();
   const optionsLocationTypes: SelectOptions = useMemo(
     () =>
-      locationTypes.map((locationType) => ({
-        label: firstLetterUppercase(locationType),
-        value: locationType,
+      locationTypes.map(({ label, value }) => ({
+        label,
+        value,
       })),
     [locationTypes],
   );

--- a/client/src/hooks/h3-data/index.ts
+++ b/client/src/hooks/h3-data/index.ts
@@ -132,7 +132,7 @@ export function useH3ImpactData(
   options: Partial<UseQueryOptions> = {},
 ): H3DataResponse {
   const filters = useAppSelector(analysisFilters);
-  const { startYear, materials, indicator, suppliers, origins } = filters;
+  const { startYear, materials, indicator, suppliers, origins, locationTypes } = filters;
   const isEnable = !!(indicator && startYear);
 
   const colors = useColors('impact');
@@ -142,6 +142,7 @@ export function useH3ImpactData(
     ...(materials?.length ? { materialIds: materials?.map(({ value }) => value) } : {}),
     ...(suppliers?.length ? { supplierIds: suppliers?.map(({ value }) => value) } : {}),
     ...(origins?.length ? { originIds: origins?.map(({ value }) => value) } : {}),
+    ...(locationTypes?.length ? { locationTypes: locationTypes?.map(({ value }) => value) } : {}),
     ...params,
     resolution: origins?.length ? 6 : 4,
   };

--- a/client/src/hooks/interventions/index.ts
+++ b/client/src/hooks/interventions/index.ts
@@ -76,6 +76,17 @@ interface Indicator {
 
 type ResponseInterventionsData = UseQueryResult<Intervention[]>;
 type ResponseInterventionsIndicators = UseQueryResult<Indicator[]>;
+type LocationTypes =
+  | 'Point of production'
+  | 'Aggregation point'
+  | 'Country of production'
+  | 'Unknown';
+
+type LocationTypesValues =
+  | 'point-of-production'
+  | 'aggregation-point'
+  | 'country-of-production'
+  | 'unknown';
 
 export function useInterventions(queryParams = {}): ResponseInterventionsData {
   const response = useQuery(
@@ -152,8 +163,13 @@ export function useUpdateIntervention() {
 }
 
 export function useLocationTypes() {
-  return useMemo<string[]>(() => {
-    return ['point of production', 'aggregation point', 'country of production', 'unknown'];
+  return useMemo<{ label: LocationTypes; value: LocationTypesValues }[]>(() => {
+    return [
+      { label: 'Point of production', value: 'point-of-production' },
+      { label: 'Aggregation point', value: 'aggregation-point' },
+      { label: 'Country of production', value: 'country-of-production' },
+      { label: 'Unknown', value: 'unknown' },
+    ];
   }, []);
 }
 

--- a/client/src/hooks/materials/index.ts
+++ b/client/src/hooks/materials/index.ts
@@ -65,7 +65,6 @@ export function useMaterialsTrees(params: MaterialsTreesParams): ResponseData {
   );
 
   const { data, isError } = query;
-
   return useMemo<ResponseData>(
     () =>
       ({

--- a/client/src/utils/string.ts
+++ b/client/src/utils/string.ts
@@ -1,2 +1,0 @@
-export const firstLetterUppercase: (str: string) => string = (str) =>
-  str.charAt(0).toUpperCase() + str.slice(1);


### PR DESCRIPTION
### General description

_Standarization of values  for location types params. Location type params added to  "/h3/map/impact" endpoint_

### Testing instructions

_Go to analysis and open selector for location types. Apply different values for location types and make sure, all tree endpoints add the new params to their payload_

_NOTE: It won't work for the tree select endpoint as it's missing that part at API level_

### JIRA ticket

https://vizzuality.atlassian.net/browse/LANDGRIF-701

## Checklist before merging

- [x] Branch name / PR includes the related Jira ticket Id.
- [ ] Tests to check core implementation / bug fix added.
- [x] All checks in Continuous Integration workflow pass.
- [ ] Feature functionally tested by reviewer(s).
- [x] Code reviewed by reviewer(s).
- [x] Documentation updated (README, CHANGELOG...) (if required)
