### PR TITLE
table and chart view years range

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -66,6 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 - Migrated requests from containers to react hooks
 - By default analysis have the scenarios/interventions panel collapsed
+- Table and chart have are able to show a minimun of two years [LANDGRIF-699](https://vizzuality.atlassian.net/browse/LANDGRIF-699)
 
 ## 0.2.0 - 2021-08-01
 

--- a/client/src/containers/analysis-visualization/analysis-filters/years-range/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-filters/years-range/component.tsx
@@ -20,7 +20,6 @@ const YearsFilter: React.FC = () => {
 
   const { startYear, endYear, yearsGap, setYearsRange } = useYearsRange({
     years,
-    yearsGap: 5,
     // Map mode only makes use of the endYear and will display the Select,
     // not the YearsRangeFilter.
     validateRange: visualizationMode !== 'map',


### PR DESCRIPTION
### General description

_The year-selector in the table and chart view should show the full range of years and should allow the user to select a minimum of two years_

### Testing instructions

_Check the years range in the years-selector in table and chart view._

## Checklist before merging

- [x] Branch name / PR includes the related Jira ticket Id.
- [ ] Tests to check core implementation / bug fix added.
- [ ] All checks in Continuous Integration workflow pass.
- [ ] Feature functionally tested by reviewer(s).
- [x] Code reviewed by reviewer(s).
- [x] Documentation updated (README, CHANGELOG...) (if required)
