### PR TITLE
Bugfix: LANDGRIF-713 impact years filter by children material

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+##  2022-08-01
+### Added
+Fixed [LANDGRIF-713](https://vizzuality.atlassian.net/browse/LANDGRIF-713)
+Filter available years for a impact layer by the received Material Id's children
+
+
+
 ##  2022-06-01
 ### Added
 [LANDGRIF-683](https://vizzuality.atlassian.net/browse/LANDGRIF-683)

--- a/api/src/modules/h3-data/h3-data.service.ts
+++ b/api/src/modules/h3-data/h3-data.service.ts
@@ -311,6 +311,11 @@ export class H3DataService {
     materialIds?: string[],
     indicatorId?: string,
   ): Promise<number[]> {
+    if (materialIds) {
+      materialIds = await this.materialService.getMaterialsDescendants(
+        materialIds,
+      );
+    }
     return this.h3DataYearsService.getYearsByLayerType(
       layerType,
       materialIds,

--- a/api/src/modules/h3-data/services/h3-data-years.service.ts
+++ b/api/src/modules/h3-data/services/h3-data-years.service.ts
@@ -85,7 +85,7 @@ export class H3DataYearsService {
   }
 
   /**
-   * Return all available years in Sourcing-Locations, which represent available years for Impact Layer
+   * Return all available years in Sourcing-Records, which represent available years for Impact Layer
    */
   async getAvailableYearsForImpactLayer(
     materialIds?: string[],


### PR DESCRIPTION
### General description

Bugfix: When filtering available years for a Material in the Impact layer, a user can filter by a parent Material that is not actually present in sourcing locations. This is because in order to represent the entities in a tree and friendly format, we get the entities that are present in Sourcing Locations and build all the way up to the root.

There was a bug that we were not filtering by Materials that could be parent materials that are not present in Sourcing Locations, so they have no Sourcing Records, which represent the available years we have for generating Impact stuff, therefore sending back a empty array. We should filter also by ALL the children of the received Ids

So filtering by a Material, the API should return the available years for all the descendants that are present in Sourcing Locations, including itself (if it's present)

### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

Pretty much what is done in the automated tests. Create some Sourcing Locations and some materials, having a parent material that is not present in sourcing locations. 
Filter the API by said material, and you should receive the available years of it's children, which are actually present in sourcing locations and/so they have sourcing records

- Apart from the added feature / bug fix, check overall performance, styling...

## Checklist before merging

- [x] Branch name / PR includes the related Jira ticket Id.
- [x] Tests to check core implementation / bug fix added.
- [x] All checks in Continuous Integration workflow pass.
- [x] Feature functionally tested by reviewer(s).
- [x] Code reviewed by reviewer(s).
- [x] Documentation updated (README, CHANGELOG...) (if required)
