### PR TITLE
Fix smart filters using applied values

### DIFF
--- a/client/src/components/tree-select/component.tsx
+++ b/client/src/components/tree-select/component.tsx
@@ -403,25 +403,29 @@ const TreeSelect: React.FC<TreeSelectProps> = ({
               </div>
             )}
             {!loading && (
-              <Tree
-                autoExpandParent
-                checkStrictly={false}
-                checkable={multiple}
-                selectable={!multiple}
-                multiple={multiple}
-                selectedKeys={selectedKeys}
-                expandedKeys={expandedKeys}
-                checkedKeys={checkedKeys}
-                switcherIcon={customSwitcherIcon}
-                onExpand={handleExpand}
-                onSelect={handleSelect}
-                onCheck={handleCheck}
-              >
-                {renderTreeNodes(options)}
-              </Tree>
-            )}
-            {(options.length === 0 || (searchTerm && filteredKeys.length === 0)) && (
-              <div className="p-2 text-gray-700 text-sm opacity-60 w-fit mx-auto">No results</div>
+              <>
+                <Tree
+                  autoExpandParent
+                  checkStrictly={false}
+                  checkable={multiple}
+                  selectable={!multiple}
+                  multiple={multiple}
+                  selectedKeys={selectedKeys}
+                  expandedKeys={expandedKeys}
+                  checkedKeys={checkedKeys}
+                  switcherIcon={customSwitcherIcon}
+                  onExpand={handleExpand}
+                  onSelect={handleSelect}
+                  onCheck={handleCheck}
+                >
+                  {renderTreeNodes(options)}
+                </Tree>
+                {(options.length === 0 || (searchTerm && filteredKeys.length === 0)) && (
+                  <div className="p-2 text-gray-700 text-sm opacity-60 w-fit mx-auto">
+                    No results
+                  </div>
+                )}
+              </>
             )}
           </div>
         </div>

--- a/client/src/containers/analysis-visualization/analysis-filters/materials/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-filters/materials/component.tsx
@@ -39,14 +39,20 @@ const MaterialsFilter: React.FC<MaterialsFilterProps> = ({
   ellipsis,
   fitContent,
 }) => {
-  const { data, isFetching } = useMaterialsTrees({
-    depth,
-    supplierIds,
-    businessUnitIds,
-    originIds,
-    locationTypes,
-    withSourcingLocations,
-  });
+  const { data, isFetching } = useMaterialsTrees(
+    {
+      depth,
+      supplierIds,
+      businessUnitIds,
+      originIds,
+      locationTypes,
+      withSourcingLocations,
+    },
+    {
+      // 2 minutes stale time
+      staleTime: 2 * 60 * 1000,
+    },
+  );
 
   const treeOptions: TreeSelectProps['options'] = useMemo(
     () =>

--- a/client/src/containers/analysis-visualization/analysis-filters/more-filters/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-filters/more-filters/component.tsx
@@ -43,33 +43,25 @@ const MoreFilters: React.FC = () => {
     [materials, origins, suppliers, locationTypes],
   );
 
-  const materialIds: string[] = useMemo(() => materials.map(({ value }) => value), [materials]);
-  const originIds: string[] = useMemo(() => origins.map(({ value }) => value), [origins]);
-  const supplierIds: string[] = useMemo(() => suppliers.map(({ value }) => value), [suppliers]);
-  const locationTypesIds: string[] = useMemo(
-    () => locationTypes.map(({ value }) => value),
-    [locationTypes],
-  );
-
   // Initial state from redux
   const [selectedFilters, setSelectedFilters] = useState<MoreFiltersState>(moreFilters);
 
-  const selectedMaterialIds = useMemo(
+  const materialIds = useMemo(
     () => selectedFilters.materials.map(({ value }) => value),
     [selectedFilters.materials],
   );
 
-  const selectedOriginIds = useMemo(
+  const originIds = useMemo(
     () => selectedFilters.origins.map(({ value }) => value),
     [selectedFilters.origins],
   );
 
-  const selectedSuppliersIds = useMemo(
+  const supplierIds = useMemo(
     () => selectedFilters.suppliers.map(({ value }) => value),
     [selectedFilters.suppliers],
   );
 
-  const selectedLocationTypesIds = useMemo(
+  const locationTypesIds = useMemo(
     () => selectedFilters.locationTypes.map(({ value }) => value),
     [selectedFilters.locationTypes],
   );
@@ -173,9 +165,9 @@ const MoreFilters: React.FC = () => {
                   <Materials
                     multiple
                     withSourcingLocations
-                    originIds={selectedOriginIds}
-                    supplierIds={selectedSuppliersIds}
-                    locationTypes={selectedLocationTypesIds}
+                    originIds={originIds}
+                    supplierIds={supplierIds}
+                    locationTypes={locationTypesIds}
                     current={selectedFilters.materials}
                     fitContent
                     onChange={(values) => handleChangeFilter('materials', values)}
@@ -186,9 +178,9 @@ const MoreFilters: React.FC = () => {
                   <OriginRegions
                     multiple
                     withSourcingLocations
-                    materialIds={selectedMaterialIds}
-                    supplierIds={selectedSuppliersIds}
-                    locationTypes={selectedLocationTypesIds}
+                    materialIds={materialIds}
+                    supplierIds={supplierIds}
+                    locationTypes={locationTypesIds}
                     current={selectedFilters.origins}
                     fitContent
                     onChange={(values) => handleChangeFilter('origins', values)}
@@ -199,9 +191,9 @@ const MoreFilters: React.FC = () => {
                   <Suppliers
                     multiple
                     withSourcingLocations
-                    materialIds={selectedMaterialIds}
-                    originIds={selectedOriginIds}
-                    locationTypes={selectedLocationTypesIds}
+                    materialIds={materialIds}
+                    originIds={originIds}
+                    locationTypes={locationTypesIds}
                     current={selectedFilters.suppliers}
                     fitContent
                     onChange={(values) => handleChangeFilter('suppliers', values)}

--- a/client/src/containers/analysis-visualization/analysis-filters/more-filters/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-filters/more-filters/component.tsx
@@ -54,6 +54,26 @@ const MoreFilters: React.FC = () => {
   // Initial state from redux
   const [selectedFilters, setSelectedFilters] = useState<MoreFiltersState>(moreFilters);
 
+  const selectedMaterialIds = useMemo(
+    () => selectedFilters.materials.map(({ value }) => value),
+    [selectedFilters.materials],
+  );
+
+  const selectedOriginIds = useMemo(
+    () => selectedFilters.origins.map(({ value }) => value),
+    [selectedFilters.origins],
+  );
+
+  const selectedSuppliersIds = useMemo(
+    () => selectedFilters.suppliers.map(({ value }) => value),
+    [selectedFilters.suppliers],
+  );
+
+  const selectedLocationTypesIds = useMemo(
+    () => selectedFilters.locationTypes.map(({ value }) => value),
+    [selectedFilters.locationTypes],
+  );
+
   const [counter, setCounter] = useState<number>(0);
 
   // Restoring state from initial state from redux
@@ -153,9 +173,9 @@ const MoreFilters: React.FC = () => {
                   <Materials
                     multiple
                     withSourcingLocations
-                    originIds={originIds}
-                    supplierIds={supplierIds}
-                    locationTypes={locationTypesIds}
+                    originIds={selectedOriginIds}
+                    supplierIds={selectedSuppliersIds}
+                    locationTypes={selectedLocationTypesIds}
                     current={selectedFilters.materials}
                     fitContent
                     onChange={(values) => handleChangeFilter('materials', values)}
@@ -166,9 +186,9 @@ const MoreFilters: React.FC = () => {
                   <OriginRegions
                     multiple
                     withSourcingLocations
-                    materialIds={materialIds}
-                    supplierIds={supplierIds}
-                    locationTypes={locationTypesIds}
+                    materialIds={selectedMaterialIds}
+                    supplierIds={selectedSuppliersIds}
+                    locationTypes={selectedLocationTypesIds}
                     current={selectedFilters.origins}
                     fitContent
                     onChange={(values) => handleChangeFilter('origins', values)}
@@ -179,9 +199,9 @@ const MoreFilters: React.FC = () => {
                   <Suppliers
                     multiple
                     withSourcingLocations
-                    materialIds={materialIds}
-                    originIds={originIds}
-                    locationTypes={locationTypesIds}
+                    materialIds={selectedMaterialIds}
+                    originIds={selectedOriginIds}
+                    locationTypes={selectedLocationTypesIds}
                     current={selectedFilters.suppliers}
                     fitContent
                     onChange={(values) => handleChangeFilter('suppliers', values)}

--- a/client/src/containers/analysis-visualization/analysis-filters/more-filters/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-filters/more-filters/component.tsx
@@ -67,12 +67,13 @@ const MoreFilters: React.FC = () => {
   );
 
   const [counter, setCounter] = useState<number>(0);
+  const [isOpen, setIsOpen] = useState(false);
 
   // Restoring state from initial state from redux
-  const handleClose = useCallback(() => {
+  useEffect(() => {
+    if (isOpen) return;
     setSelectedFilters(moreFilters);
-    setIsOpen(false);
-  }, [moreFilters]);
+  }, [isOpen, moreFilters]);
 
   // Only the changes are applied when the user clicks on Apply
   const handleApply = useCallback(() => {
@@ -102,8 +103,6 @@ const MoreFilters: React.FC = () => {
     () => JSON.stringify(selectedFilters) !== JSON.stringify(moreFilters),
     [selectedFilters, moreFilters],
   );
-
-  const [isOpen, setIsOpen] = useState(false);
 
   const { reference, floating, strategy, x, y, context } = useFloating({
     open: isOpen,
@@ -210,7 +209,7 @@ const MoreFilters: React.FC = () => {
               </div>
 
               <div className="flex gap-2 mt-6">
-                <Button theme="secondary" className="px-9" onClick={handleClose}>
+                <Button theme="secondary" className="px-9">
                   Cancel
                 </Button>
                 <Button

--- a/client/src/containers/analysis-visualization/analysis-filters/origin-regions/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-filters/origin-regions/component.tsx
@@ -36,14 +36,20 @@ const OriginRegionsFilter: React.FC<OriginRegionsFilterProps> = ({
   ellipsis,
   fitContent,
 }) => {
-  const { data, isFetching } = useAdminRegionsTrees({
-    depth,
-    withSourcingLocations,
-    supplierIds,
-    businessUnitIds,
-    materialIds,
-    locationTypes,
-  });
+  const { data, isFetching } = useAdminRegionsTrees(
+    {
+      depth,
+      withSourcingLocations,
+      supplierIds,
+      businessUnitIds,
+      materialIds,
+      locationTypes,
+    },
+    {
+      // 2 minutes stale time
+      staleTime: 2 * 60 * 1000,
+    },
+  );
 
   const treeOptions: TreeSelectProps['options'] = useMemo(
     () =>

--- a/client/src/containers/analysis-visualization/analysis-filters/suppliers/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-filters/suppliers/component.tsx
@@ -37,14 +37,20 @@ const SuppliersFilter: React.FC<SuppliersFilterProps> = ({
   ellipsis,
   fitContent,
 }) => {
-  const { data, isFetching } = useSuppliersTrees({
-    depth,
-    originIds,
-    businessUnitIds,
-    materialIds,
-    locationTypes,
-    withSourcingLocations,
-  });
+  const { data, isFetching } = useSuppliersTrees(
+    {
+      depth,
+      originIds,
+      businessUnitIds,
+      materialIds,
+      locationTypes,
+      withSourcingLocations,
+    },
+    {
+      // 2 minutes stale time
+      staleTime: 2 * 60 * 1000,
+    },
+  );
 
   const treeOptions: TreeSelectProps['options'] = useMemo(
     () =>

--- a/client/src/hooks/admin-regions/index.ts
+++ b/client/src/hooks/admin-regions/index.ts
@@ -48,7 +48,10 @@ export function useAdminRegions(): ResponseData {
   );
 }
 
-export function useAdminRegionsTrees(params: AdminRegionsTreesParams): ResponseData {
+export function useAdminRegionsTrees(
+  params: AdminRegionsTreesParams,
+  options: UseQueryOptions = {},
+): ResponseData {
   const query = useQuery(
     ['admin-regions-trees', JSON.stringify(params)],
     async () =>
@@ -61,6 +64,7 @@ export function useAdminRegionsTrees(params: AdminRegionsTreesParams): ResponseD
         .then(({ data: responseData }) => responseData.data),
     {
       ...DEFAULT_QUERY_OPTIONS,
+      ...options,
     },
   );
 

--- a/client/src/hooks/materials/index.ts
+++ b/client/src/hooks/materials/index.ts
@@ -8,6 +8,7 @@ const DEFAULT_QUERY_OPTIONS: UseQueryOptions = {
   retry: false,
   keepPreviousData: true,
   refetchOnWindowFocus: false,
+  staleTime: 2 * 60 * 1000, // 2 minutes max stale time
 };
 
 type ResponseData = UseQueryResult<Material[]>;
@@ -48,7 +49,10 @@ export function useMaterials(): ResponseData {
   );
 }
 
-export function useMaterialsTrees(params: MaterialsTreesParams): ResponseData {
+export function useMaterialsTrees(
+  params: MaterialsTreesParams,
+  options: UseQueryOptions = {},
+): ResponseData {
   const query = useQuery(
     ['materials-trees', JSON.stringify(params)],
     async () =>
@@ -61,6 +65,7 @@ export function useMaterialsTrees(params: MaterialsTreesParams): ResponseData {
         .then(({ data: responseData }) => responseData.data),
     {
       ...DEFAULT_QUERY_OPTIONS,
+      ...options,
     },
   );
 

--- a/client/src/hooks/suppliers/index.ts
+++ b/client/src/hooks/suppliers/index.ts
@@ -49,7 +49,10 @@ export function useSuppliers(params): ResponseData {
   );
 }
 
-export function useSuppliersTrees(params: SuppliersTreesParams): ResponseData {
+export function useSuppliersTrees(
+  params: SuppliersTreesParams,
+  options: UseQueryOptions = {},
+): ResponseData {
   const query = useQuery(
     ['suppliers-trees', JSON.stringify(params)],
     async () =>
@@ -60,7 +63,7 @@ export function useSuppliersTrees(params: SuppliersTreesParams): ResponseData {
           params,
         })
         .then(({ data: responseData }) => responseData.data),
-    DEFAULT_QUERY_OPTIONS,
+    { ...DEFAULT_QUERY_OPTIONS, ...options },
   );
 
   const { data, isError } = query;


### PR DESCRIPTION
### General description

This PR fixes the smart filters inside the "More filters" menu so they filter the data shown using their current selected values instead of the applied ones.

The `useQuery` options for this data fetching were also tweaked, adding them a 2 minute stale time. This way, we prevent refetching all data again every time the menu opens. This will probably happen in other places too, specially in dynamically  shown menus, but `useQuery` will automatically refetch everything stale (all queries by default) on window focus for example. We should look into this.

### Testing instructions

- Select Origin: Sri Lanka. The rest of the filters should be filtered. For example, the only available material should be silk.
- Remove the Origin filter. The filters should restore to their original state

## Checklist before merging

- [x] Branch name / PR includes the related Jira ticket Id.
- [ ] Tests to check core implementation / bug fix added.
- [x] All checks in Continuous Integration workflow pass.
- [x] Feature functionally tested by reviewer(s).
- [ ] Code reviewed by reviewer(s).
- [ ] Documentation updated (README, CHANGELOG...) (if required)
