### PR TITLE
Fix empty values in impact table (filtering)

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -37,3 +37,9 @@ contextual layers. Related N to 1 to H3Data (H3 Master table)
 [LANDGRIF-705](https://vizzuality.atlassian.net/browse/LANDGRIF-705)
 Add endpoint for location types with smart filters. Add location types options to
 other smart filter endpoints.
+
+## 2022-06-29
+### Fixed
+
+Fixed 
+Impact table - fix filters when retrieving 'group by' entities for table skeleton

--- a/api/src/modules/impact/impact.service.ts
+++ b/api/src/modules/impact/impact.service.ts
@@ -250,33 +250,29 @@ export class ImpactService {
   private async getEntityTree(
     impactTableDto: GetImpactTableDto,
   ): Promise<ImpactTableEntityType[]> {
+    const treeOptions: GetMaterialTreeWithOptionsDto = {
+      ...(impactTableDto.materialIds && {
+        materialIds: impactTableDto.materialIds,
+      }),
+      ...(impactTableDto.originIds && {
+        originIds: impactTableDto.originIds,
+      }),
+      ...(impactTableDto.supplierIds && {
+        supplierIds: impactTableDto.supplierIds,
+      }),
+    };
     switch (impactTableDto.groupBy) {
       case GROUP_BY_VALUES.MATERIAL: {
-        const treeOptions: GetMaterialTreeWithOptionsDto =
-          impactTableDto.materialIds
-            ? { materialIds: impactTableDto.materialIds }
-            : {};
-
         return this.materialsService.getMaterialsTreeWithSourcingLocations(
           treeOptions,
         );
       }
       case GROUP_BY_VALUES.REGION: {
-        const treeOptions: GetAdminRegionTreeWithOptionsDto =
-          impactTableDto.originIds
-            ? { originIds: impactTableDto.originIds }
-            : {};
-
         return this.adminRegionsService.getAdminRegionTreeWithSourcingLocations(
           treeOptions,
         );
       }
       case GROUP_BY_VALUES.SUPPLIER: {
-        const treeOptions: GetSupplierTreeWithOptions =
-          impactTableDto.supplierIds
-            ? { supplierIds: impactTableDto.supplierIds }
-            : {};
-
         return this.suppliersService.getSuppliersWithSourcingLocations(
           treeOptions,
         );

--- a/api/test/e2e/impact/impact.spec.ts
+++ b/api/test/e2e/impact/impact.spec.ts
@@ -725,7 +725,7 @@ describe('Impact Table and Charts test suite (e2e)', () => {
   });
 
   describe('Group By tests', () => {
-    test('When I query the API for a Impact table grouped by material Then I should get the correct data', async () => {
+    test('When I query the API for a Impact table grouped by material with filters Then I should get the correct data', async () => {
       const adminRegion: AdminRegion = await createAdminRegion({
         name: 'Fake AdminRegion',
       });
@@ -743,12 +743,25 @@ describe('Impact Table and Charts test suite (e2e)', () => {
         name: 'Fake Material 2',
       });
 
+      const material3: Material = await createMaterial({
+        name: 'Fake Material 3',
+      });
+
+      const material4: Material = await createMaterial({
+        name: 'Fake Material 4',
+        parent: material3,
+      });
+
       const businessUnit: BusinessUnit = await createBusinessUnit({
         name: 'Fake Business Unit',
       });
 
       const supplier: Supplier = await createSupplier({
         name: 'Fake Supplier',
+      });
+
+      const supplier2: Supplier = await createSupplier({
+        name: 'Fake Supplier 2',
       });
 
       const sourcingLocation1: SourcingLocation = await createSourcingLocation({
@@ -762,6 +775,13 @@ describe('Impact Table and Charts test suite (e2e)', () => {
         material: material2,
         businessUnit,
         t1Supplier: supplier,
+        adminRegion,
+      });
+
+      await createSourcingLocation({
+        material: material4,
+        businessUnit,
+        t1Supplier: supplier2,
         adminRegion,
       });
 
@@ -798,6 +818,7 @@ describe('Impact Table and Charts test suite (e2e)', () => {
         .set('Authorization', `Bearer ${jwtToken}`)
         .query({
           'indicatorIds[]': [indicator.id],
+          'supplierIds[]': [supplier.id],
           endYear: 2013,
           startYear: 2010,
           groupBy: 'material',


### PR DESCRIPTION
### General description

Big fix - when building an impact table and retrieving entities according to selected  groupBy, not all user filters were applied. 

### Designs

### Testing instructions

Test in client - Impact table. When grouping by material and selecting Sri Lanka as origin filter, only Silk with values must be retrieved (no other materials with 0 values)

- Apart from the added feature / bug fix, check overall performance, styling...

## Checklist before merging

- [x] Branch name / PR includes the related Jira ticket Id.
- [x] Tests to check core implementation / bug fix added.
- [x] All checks in Continuous Integration workflow pass.
- [x] Feature functionally tested by reviewer(s).
- [x] Code reviewed by reviewer(s).
- [x] Documentation updated (README, CHANGELOG...) (if required)
