### PR TITLE
dashed line in table to difference projected data

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
+- Dashed line added to analysis table to difference between real and projected data [LANDGRIF-736](https://vizzuality.atlassian.net/browse/LANDGRIF-736)
 
 ### Changed
 

--- a/client/src/components/table/component.tsx
+++ b/client/src/components/table/component.tsx
@@ -17,7 +17,7 @@ import { DEFAULT_CLASSNAMES, SHADOW_CLASSNAMES } from './constants';
 import { SortingMode, ApiSortingDirection } from './enums';
 
 import type { TableProps, ColumnProps, ApiSortingType } from './types';
-import type { ChildComponents } from 'ka-table/models';
+import type { CustomChildComponents } from './types';
 
 const defaultProps: TableProps = {
   columns: [],
@@ -151,11 +151,10 @@ const Table: React.FC<TableProps> = ({
             }),
           }))
         : props.columns;
-
     setTableProps((tableProps) => ({ ...tableProps, columns }));
   }, [props.columns, apiSorting, sortingMode, isLoading]);
 
-  const childComponents: ChildComponents = {
+  const childComponents: CustomChildComponents = {
     tableWrapper: {
       elementAttributes: () => ({
         className: DEFAULT_CLASSNAMES.tableWrapper,
@@ -173,6 +172,7 @@ const Table: React.FC<TableProps> = ({
         const isFirstColumn = props.column.key === firstColumnKey;
         const isSticky = isFirstColumnSticky && props.column.key === stickyColumnKey;
         const classNames = DEFAULT_CLASSNAMES.headCell;
+        const isProjected = props.column.isFirstYearProjected;
 
         return {
           className: cx(classNames, {
@@ -180,6 +180,7 @@ const Table: React.FC<TableProps> = ({
             'sticky left-0 z-10 w-80': isSticky,
             'w-48': !isSticky,
             [SHADOW_CLASSNAMES]: isSticky,
+            'border-l border-dashed border-gray-200': isProjected,
           }),
         };
       },
@@ -233,7 +234,6 @@ const Table: React.FC<TableProps> = ({
       elementAttributes: () => ({
         className: DEFAULT_CLASSNAMES.summaryCell,
       }),
-      ...props.childComponents?.summaryCell,
     };
   }
 

--- a/client/src/components/table/data-row/component.tsx
+++ b/client/src/components/table/data-row/component.tsx
@@ -61,12 +61,12 @@ const DataRow: React.FC<DataRowProps> = ({
         const editorValue = editableCell && editableCell.editorValue;
         const value = hasEditorValue ? editorValue : getValueByColumn(rowData, column);
         const cellDeep = treeDeep != null && index === 0 ? treeDeep : undefined;
-
         return (
           <Cell
             className={cx({
               'cursor-pointer': isTreeGroup,
               'font-semibold': isTreeExpanded && treeDeep === 0 && index === 0,
+              'border-l border-dashed border-gray-200': column.isFirstYearProjected,
             })}
             treeArrowElement={arrow?.pop()}
             childComponents={childComponents}

--- a/client/src/components/table/data-row/types.d.ts
+++ b/client/src/components/table/data-row/types.d.ts
@@ -1,10 +1,20 @@
 import { IRowProps } from 'ka-table/props';
 
-export type DataRowProps = Partial<IRowProps> & {
+import { Column } from 'ka-table/models';
+
+interface CustomColumn extends Column {
+  isFirstYearProjected?: boolean;
+}
+
+interface CustomIRowProps extends IRowProps {
+  columns: CustomColumn[];
+}
+
+export type DataRowProps = Partial<Omit<IRowProps, 'columns'>> & {
   /** Key of the first column */
   firstColumnKey: string;
   /** Whether the first column should be sticky (when scrolling horizontally) */
   isFirstColumnSticky: boolean;
-
   stickyColumnKey: string;
+  columns: CustomColumn[];
 };

--- a/client/src/components/table/head-cell-content/component.tsx
+++ b/client/src/components/table/head-cell-content/component.tsx
@@ -4,7 +4,20 @@ import { SortDirection } from 'ka-table/enums';
 import { IHeadCellProps } from 'ka-table/props';
 import { isSortingEnabled } from 'ka-table/Utils/SortUtils';
 
-const HeadCellContent: React.FC<IHeadCellProps> = ({ column, sortingMode }: IHeadCellProps) => {
+import type { Column } from 'ka-table/models';
+
+interface CustomColumn extends Column {
+  isFirstYearProjected?: boolean;
+}
+
+interface CustomIHeadCellProps extends IHeadCellProps {
+  column: CustomColumn;
+}
+
+const HeadCellContent: React.FC<CustomIHeadCellProps> = ({
+  column,
+  sortingMode,
+}: CustomIHeadCellProps) => {
   const sortingEnabled = isSortingEnabled(sortingMode);
 
   return (

--- a/client/src/components/table/summary-row/component.tsx
+++ b/client/src/components/table/summary-row/component.tsx
@@ -11,10 +11,11 @@ const DEFAULT_CLASSNAMES =
 const SummaryRow: React.FC<SummaryRowProps> = ({
   rowData,
   isFirstColumnSticky = true,
+  firstProjectedYear,
   ...props
 }: SummaryRowProps) => {
   const firstColumnKey = props.columns[0].key;
-
+  console.log(firstProjectedYear, 'firstProjectedYear');
   return (
     <>
       {times(props.groupColumnsCount, (idx) => (
@@ -30,7 +31,6 @@ const SummaryRow: React.FC<SummaryRowProps> = ({
         if (!rowData[key]) {
           return <td key={key} className={classNames('ka-empty-cell', DEFAULT_CLASSNAMES)}></td>;
         }
-
         return (
           <td
             key={key}
@@ -41,6 +41,7 @@ const SummaryRow: React.FC<SummaryRowProps> = ({
                 uppercase: isFirstColumn,
                 'text-center': !isFirstColumn,
                 'sticky z-10 left-0': isFirstColumn && isFirstColumnSticky,
+                'border-l border-dashed color-gray-200': firstProjectedYear === Number(key),
                 'after:absolute after:opacity-100 after:-right-3 after:w-3 after:top-0 after:bottom-0 after:border-l after:border-gray-50 after:shadow-[12px_0_10px_-15px_inset_#c2c5c9]':
                   isFirstColumn && isFirstColumnSticky,
               },

--- a/client/src/components/table/summary-row/types.d.ts
+++ b/client/src/components/table/summary-row/types.d.ts
@@ -3,4 +3,6 @@ import { IRowProps } from 'ka-table/props';
 export type SummaryRowProps = IRowProps & {
   /** Whether the first column should be sticky */
   isFirstColumnSticky: boolean;
+  /** First year for projected data */
+  firstProjectedYear: number;
 };

--- a/client/src/components/table/types.d.ts
+++ b/client/src/components/table/types.d.ts
@@ -1,4 +1,5 @@
-import { ITableProps, ICellProps, ChildComponents } from 'ka-table';
+import { ITableProps, ICellProps } from 'ka-table';
+import { ChildComponents } from 'ka-table/models';
 
 import { SortingMode } from './enums';
 
@@ -8,6 +9,21 @@ export type ColumnProps = ICellProps & {
   /** Whether the column is sortable */
   isSortable: boolean;
 };
+
+import type { Column } from 'ka-table/models';
+import type { IHeadCellProps } from 'ka-table/props';
+
+interface CustomColumn extends Column {
+  isFirstYearProjected?: boolean;
+}
+
+export interface CustomHeadCell extends Omit<IHeadCellProps, 'column'> {
+  column: CustomColumn;
+}
+
+export interface CustomChildComponents extends ChildComponents {
+  headCell: ChildComponent<CustomHeadCell>;
+}
 
 export interface TableProps extends ITableProps {
   /** classNames to apply to the table */
@@ -20,7 +36,7 @@ export interface TableProps extends ITableProps {
   /** Whether to make the first column sticky. Defaults to `true` */
   stickyFirstColumn?: boolean;
   /** ka-table childComponents */
-  childComponents?: ChildComponents;
+  childComponents?: CustomChildComponents;
   /** ka-table sorting modes + a custom one: `Api` */
   sortingMode?: SortingMode;
   /** Default sorting time */

--- a/client/src/containers/analysis-visualization/analysis-table/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-table/component.tsx
@@ -184,12 +184,26 @@ const AnalysisTable: React.FC = () => {
     return uniq(result);
   }, [impactTable]);
 
+  const projectedYears = useMemo<number[]>(
+    () =>
+      Object.values(impactTable)[0]
+        ?.rows[0].values.filter(({ isProjected }) => !!isProjected)
+        .map(({ year }) => year) as number[],
+    [impactTable],
+  );
+
+  const firstProjectedYear = useMemo(
+    () => projectedYears && Math.min(...projectedYears),
+    [projectedYears],
+  );
+
   // Totals for summary
   const yearsSum = useMemo(() => {
     const resultByYear = [];
 
     years.forEach((year) => {
-      const result = impactTable.map(({ yearSum }) => {
+      const result = impactTable.map((props) => {
+        const yearSum = props.yearSum;
         const yearValue = yearSum.find((sum) => sum.year === year);
         if (yearValue) return yearValue;
         return { year, value: null };
@@ -227,6 +241,8 @@ const AnalysisTable: React.FC = () => {
           key: year.toString(),
           title: year.toString(),
           dataType: DataType.Number,
+          isFirstYearProjected: firstProjectedYear === year,
+          isProjected: projectedYears.includes(year),
           width: 110,
         })),
       ],
@@ -243,12 +259,16 @@ const AnalysisTable: React.FC = () => {
       childComponents: {
         summaryRow: {
           content: (props) => (
-            <SummaryRow rowData={{ name: 'Total impact', ...yearsSum }} {...props} />
+            <SummaryRow
+              firstProjectedYear={firstProjectedYear}
+              rowData={{ name: 'Total impact', ...yearsSum }}
+              {...props}
+            />
           ),
         },
       },
     };
-  }, [tableData, years, yearsSum, totalIndicators]);
+  }, [tableData, years, yearsSum, projectedYears, totalIndicators, firstProjectedYear]);
 
   const handleIndicatorRows = useCallback((total) => {
     setTotalRows(total);

--- a/client/src/containers/analysis-visualization/analysis-table/types.d.ts
+++ b/client/src/containers/analysis-visualization/analysis-table/types.d.ts
@@ -9,6 +9,8 @@ export type ITableData = ITableProps & {
 export type CustomColumn = ICellProps & {
   type: 'analysis-chart';
   width: number;
+  isProjected: boolean;
+  isFirstYearProjected?: number;
 };
 
 export type CustomChartCell = ICellProps & {
@@ -31,6 +33,6 @@ export type ColumnHeadings = Readonly<{
 }>;
 
 export type CustomChartCell = ICellProps & {
-  column: { chart: boolean; width: number };
+  column: { chart: boolean; width: number; isProjected: boolean; isFirstYearProjected: boolean };
   rowData: GroupRowData;
 };


### PR DESCRIPTION
### General description

_Missing a line to make a difference between projected and actual data in the table view_

### Designs

_[Link to the related design prototypes ](https://www.figma.com/file/tDHyfnWfMsydWmKcXaX8dV/LandGriffon-tool?node-id=1426%3A5786)_

### Testing instructions

_Go to analysis, table view. In years select, select a non-existent year in the "To" input to get projected years. A dashed line should appear in the table to make the difference between the projected and none projected data_


## Checklist before merging

- [x] Branch name / PR includes the related Jira ticket Id.
- [ ] Tests to check core implementation / bug fix added.
- [x] All checks in Continuous Integration workflow pass.
- [ ] Feature functionally tested by reviewer(s).
- [x] Code reviewed by reviewer(s).
- [x] Documentation updated (README, CHANGELOG...) (if required)
