### PR TITLE
Update of creating new Scenario Intervention

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -51,8 +51,8 @@ Impact table - fix filters when retrieving 'group by' entities for table skeleto
 
 ## 2022-06-30
 
-### Fixed
+### Updated (change of requirements)
 
-Fixed
+Updated
 Creating Scenario Intervention can cover only 1 material, business units and admin regions filters are not obligatory
 

--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -48,3 +48,11 @@ other smart filter endpoints.
 
 Fixed 
 Impact table - fix filters when retrieving 'group by' entities for table skeleton
+
+## 2022-06-30
+
+### Fixed
+
+Fixed
+Creating Scenario Intervention can cover only 1 material, business units and admin regions filters are not obligatory
+

--- a/api/src/modules/scenario-interventions/dto/create.scenario-intervention.dto.ts
+++ b/api/src/modules/scenario-interventions/dto/create.scenario-intervention.dto.ts
@@ -8,17 +8,19 @@ import {
   IsOptional,
   IsString,
   IsUUID,
-  maxLength,
   MaxLength,
   MinLength,
   ValidateIf,
   ValidateNested,
 } from 'class-validator';
 import { SCENARIO_INTERVENTION_TYPE } from 'modules/scenario-interventions/scenario-intervention.entity';
-import { LOCATION_TYPES } from 'modules/sourcing-locations/sourcing-location.entity';
+import {
+  LOCATION_TYPES,
+  LOCATION_TYPES_PARAMS,
+} from 'modules/sourcing-locations/sourcing-location.entity';
 import { IndicatorCoefficientsDto } from 'modules/indicator-coefficients/dto/indicator-coefficients.dto';
-import { Type } from 'class-transformer';
-import { Optional } from '@nestjs/common';
+import { Transform, Type } from 'class-transformer';
+import { transformSingleLocationType } from 'utils/transform-location-type.util';
 
 export class CreateScenarioInterventionDto {
   @IsString()
@@ -167,16 +169,21 @@ export class CreateScenarioInterventionDto {
     message:
       'New location type input is required for the selected intervention type',
   })
-  @IsEnum(Object.values(LOCATION_TYPES), {
-    message: `Available columns for new location type: ${Object.values(
-      LOCATION_TYPES,
-    ).join(', ')}`,
-  })
   @ApiPropertyOptional({
     description: `Type of new Supplier Location, is required for Intervention types: ${SCENARIO_INTERVENTION_TYPE.NEW_MATERIAL} and ${SCENARIO_INTERVENTION_TYPE.NEW_SUPPLIER}`,
     enum: Object.values(LOCATION_TYPES),
     example: LOCATION_TYPES.POINT_OF_PRODUCTION,
   })
+  @IsEnum(LOCATION_TYPES, {
+    each: true,
+    message:
+      'Available location types options: ' +
+      Object.values(LOCATION_TYPES_PARAMS).toString().toLowerCase(),
+  })
+  @Transform(({ value }: { value: LOCATION_TYPES_PARAMS }) =>
+    transformSingleLocationType(value),
+  )
+  @Type(() => String)
   newLocationType!: LOCATION_TYPES;
 
   @ValidateIf(

--- a/api/src/modules/scenario-interventions/dto/create.scenario-intervention.dto.ts
+++ b/api/src/modules/scenario-interventions/dto/create.scenario-intervention.dto.ts
@@ -1,11 +1,14 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import {
+  ArrayMaxSize,
+  ArrayNotEmpty,
   IsEnum,
   IsNotEmpty,
   IsNumber,
   IsOptional,
   IsString,
   IsUUID,
+  maxLength,
   MaxLength,
   MinLength,
   ValidateIf,
@@ -15,6 +18,7 @@ import { SCENARIO_INTERVENTION_TYPE } from 'modules/scenario-interventions/scena
 import { LOCATION_TYPES } from 'modules/sourcing-locations/sourcing-location.entity';
 import { IndicatorCoefficientsDto } from 'modules/indicator-coefficients/dto/indicator-coefficients.dto';
 import { Type } from 'class-transformer';
+import { Optional } from '@nestjs/common';
 
 export class CreateScenarioInterventionDto {
   @IsString()
@@ -85,7 +89,10 @@ export class CreateScenarioInterventionDto {
   scenarioId!: string;
 
   @IsUUID(4, { each: true })
-  @IsNotEmpty()
+  @ArrayNotEmpty()
+  @ArrayMaxSize(1, {
+    message: 'Intervention must cover 1 existing material',
+  })
   @ApiProperty({
     description: 'Ids of Materials that will be affected by intervention',
     type: [String],
@@ -94,13 +101,13 @@ export class CreateScenarioInterventionDto {
   materialIds!: string[];
 
   @IsUUID(4, { each: true })
-  @IsNotEmpty()
+  @IsOptional()
   @ApiPropertyOptional({
     description: 'Ids of Business Units that will be affected by intervention',
     type: [String],
     example: 'bc5e4933-cd9a-4afc-bd53-56941b812345',
   })
-  businessUnitIds!: string[];
+  businessUnitIds?: string[];
 
   @IsUUID(4, { each: true })
   @IsOptional()
@@ -110,16 +117,16 @@ export class CreateScenarioInterventionDto {
     type: [String],
     example: 'bc5e4933-cd9a-4afc-bd53-56941b865432',
   })
-  supplierIds!: string[];
+  supplierIds?: string[];
 
   @IsUUID(4, { each: true })
-  @IsNotEmpty()
+  @IsOptional()
   @ApiProperty({
     description: 'Ids of Admin Regions that will be affected by intervention',
     type: [String],
     example: 'bc5e4933-cd9a-4afc-bd53-56941b8adca3',
   })
-  adminRegionIds!: string[];
+  adminRegionIds?: string[];
 
   @IsOptional()
   @ApiPropertyOptional({

--- a/api/src/modules/scenario-interventions/scenario-interventions.service.ts
+++ b/api/src/modules/scenario-interventions/scenario-interventions.service.ts
@@ -111,6 +111,7 @@ export class ScenarioInterventionsService extends AppBaseService<
     /**
      * Getting Sourcing Locations and Sourcing Records for start year of all Materials of the intervention with applied filters
      */
+
     const actualSourcingDataWithTonnage: SourcingLocation[] =
       await this.sourcingLocationsService.findFilteredSourcingLocationsForIntervention(
         dtoWithDescendants,

--- a/api/src/modules/scenario-interventions/services/intervention-generator.service.ts
+++ b/api/src/modules/scenario-interventions/services/intervention-generator.service.ts
@@ -27,28 +27,28 @@ export class InterventionGeneratorService {
   async addDescendantsEntitiesForFiltering(
     dto: CreateScenarioInterventionDto,
   ): Promise<CreateScenarioInterventionDto> {
-    dto.materialIds = await this.materialService.getMaterialsDescendants(
-      dto.materialIds,
-    );
+    let dtoWithDescendants: CreateScenarioInterventionDto = { ...dto };
+
+    dtoWithDescendants.materialIds =
+      await this.materialService.getMaterialsDescendants(dto.materialIds);
 
     if (dto.adminRegionIds)
-      dto.adminRegionIds =
+      dtoWithDescendants.adminRegionIds =
         await this.adminRegionService.getAdminRegionDescendants(
           dto.adminRegionIds,
         );
 
     if (dto.businessUnitIds)
-      dto.businessUnitIds =
+      dtoWithDescendants.businessUnitIds =
         await this.businessUnitService.getBusinessUnitsDescendants(
           dto.businessUnitIds,
         );
 
     if (dto.supplierIds)
-      dto.supplierIds = await this.suppliersService.getSuppliersDescendants(
-        dto.supplierIds,
-      );
+      dtoWithDescendants.supplierIds =
+        await this.suppliersService.getSuppliersDescendants(dto.supplierIds);
 
-    return dto;
+    return dtoWithDescendants;
   }
 
   async addReplacedElementsToIntervention(

--- a/api/src/modules/scenario-interventions/services/intervention-generator.service.ts
+++ b/api/src/modules/scenario-interventions/services/intervention-generator.service.ts
@@ -31,21 +31,22 @@ export class InterventionGeneratorService {
       dto.materialIds,
     );
 
-    dto.adminRegionIds =
-      await this.adminRegionService.getAdminRegionDescendants(
-        dto.adminRegionIds,
-      );
+    if (dto.adminRegionIds)
+      dto.adminRegionIds =
+        await this.adminRegionService.getAdminRegionDescendants(
+          dto.adminRegionIds,
+        );
 
-    dto.businessUnitIds =
-      await this.businessUnitService.getBusinessUnitsDescendants(
-        dto.businessUnitIds,
-      );
+    if (dto.businessUnitIds)
+      dto.businessUnitIds =
+        await this.businessUnitService.getBusinessUnitsDescendants(
+          dto.businessUnitIds,
+        );
 
-    if (dto.supplierIds) {
+    if (dto.supplierIds)
       dto.supplierIds = await this.suppliersService.getSuppliersDescendants(
         dto.supplierIds,
       );
-    }
 
     return dto;
   }

--- a/api/src/modules/sourcing-locations/sourcing-locations.service.ts
+++ b/api/src/modules/sourcing-locations/sourcing-locations.service.ts
@@ -135,18 +135,22 @@ export class SourcingLocationsService extends AppBaseService<
         .where('sl."materialId" IN (:...materialIds)', {
           materialIds: createInterventionDto.materialIds,
         })
-        .andWhere('sl."businessUnitId" IN (:...businessUnits)', {
-          businessUnits: createInterventionDto.businessUnitIds,
-        })
         .andWhere('sr.year >= :startYear', {
           startYear: createInterventionDto.startYear,
         })
-        .andWhere('sl.adminRegionId IN (:...adminRegion)', {
-          adminRegion: createInterventionDto.adminRegionIds,
-        })
+
         .andWhere('sl.interventionType IS NULL');
 
-    // Filter by suppliers if are provided. A user might not know from which provider gets some material
+    // Optional filters:
+
+    if (createInterventionDto.businessUnitIds)
+      queryBuilder.andWhere('sl."businessUnitId" IN (:...businessUnits)', {
+        businessUnits: createInterventionDto.businessUnitIds,
+      });
+    if (createInterventionDto.adminRegionIds)
+      queryBuilder.andWhere('sl.adminRegionId IN (:...adminRegion)', {
+        adminRegion: createInterventionDto.adminRegionIds,
+      });
     if (createInterventionDto.supplierIds) {
       queryBuilder.andWhere(
         new Brackets((qb: WhereExpressionBuilder) => {

--- a/api/src/utils/transform-location-type.util.ts
+++ b/api/src/utils/transform-location-type.util.ts
@@ -10,3 +10,9 @@ export function transformLocationType(
     return el.replace(/-/g, ' ') as LOCATION_TYPES;
   });
 }
+
+export function transformSingleLocationType(
+  locationTypesParam: LOCATION_TYPES_PARAMS,
+): LOCATION_TYPES {
+  return locationTypesParam.replace(/-/g, ' ') as LOCATION_TYPES;
+}

--- a/api/test/e2e/scenario-interventions/scenario-interventions.spec.ts
+++ b/api/test/e2e/scenario-interventions/scenario-interventions.spec.ts
@@ -203,7 +203,7 @@ describe('ScenarioInterventionsModule (e2e)', () => {
           },
         });
 
-      expect(HttpStatus.CREATED);
+      expect(response.status).toBe(HttpStatus.CREATED);
 
       const createdScenarioIntervention =
         await scenarioInterventionRepository.findOne(response.body.data.id);
@@ -345,7 +345,7 @@ describe('ScenarioInterventionsModule (e2e)', () => {
           },
         });
 
-      expect(HttpStatus.CREATED);
+      expect(response.status).toBe(HttpStatus.CREATED);
 
       const createdScenarioIntervention =
         await scenarioInterventionRepository.findOne(response.body.data.id);
@@ -465,7 +465,7 @@ describe('ScenarioInterventionsModule (e2e)', () => {
           },
         });
 
-      expect(HttpStatus.CREATED);
+      expect(response.status).toBe(HttpStatus.CREATED);
 
       const createdScenarioIntervention =
         await scenarioInterventionRepository.findOne(response.body.data.id);
@@ -849,7 +849,7 @@ describe('ScenarioInterventionsModule (e2e)', () => {
           },
         });
 
-      expect(HttpStatus.BAD_REQUEST);
+      expect(response.status).toBe(HttpStatus.BAD_REQUEST);
       expect(response.body.errors[0].title).toEqual(
         'No actual data for requested filters',
       );
@@ -875,7 +875,7 @@ describe('ScenarioInterventionsModule (e2e)', () => {
           type: SCENARIO_INTERVENTION_TYPE.CHANGE_PRODUCTION_EFFICIENCY,
         });
 
-      expect(HttpStatus.BAD_REQUEST);
+      expect(response.status).toBe(HttpStatus.BAD_REQUEST);
       expect(response.body.errors[0].title).toEqual(
         'No actual data for requested filters',
       );
@@ -977,7 +977,7 @@ describe('ScenarioInterventionsModule (e2e)', () => {
           newLocationType: LOCATION_TYPES_PARAMS.COUNTRY_OF_PRODUCTION,
         });
 
-      expect(HttpStatus.BAD_REQUEST);
+      expect(response.status).toBe(HttpStatus.BAD_REQUEST);
       expect(response).toHaveErrorMessage(
         HttpStatus.BAD_REQUEST,
         'Bad Request Exception',
@@ -1059,7 +1059,7 @@ describe('ScenarioInterventionsModule (e2e)', () => {
           newLocationCountryInput: 'TestCountry',
         });
 
-      expect(HttpStatus.BAD_REQUEST);
+      expect(response.status).toBe(HttpStatus.BAD_REQUEST);
       expect(response2).toHaveErrorMessage(
         HttpStatus.BAD_REQUEST,
         'Bad Request Exception',
@@ -1092,7 +1092,7 @@ describe('ScenarioInterventionsModule (e2e)', () => {
           newLocationCountryInput: 'TestCountry',
         });
 
-      expect(HttpStatus.BAD_REQUEST);
+      expect(response.status).toBe(HttpStatus.BAD_REQUEST);
       expect(response).toHaveErrorMessage(
         HttpStatus.BAD_REQUEST,
         'Bad Request Exception',
@@ -1130,7 +1130,7 @@ describe('ScenarioInterventionsModule (e2e)', () => {
           newMaterialId: material.id,
         });
 
-      expect(HttpStatus.BAD_REQUEST);
+      expect(response.status).toBe(HttpStatus.BAD_REQUEST);
       expect(response).toHaveErrorMessage(
         HttpStatus.BAD_REQUEST,
         'Bad Request Exception',


### PR DESCRIPTION
### General description

Changes:

1. Scenario Intervention can affect only one existing  material (materialIds). However if the received material has descendant materials present in Sourcing Locations - those descendants will be added to filters when retrieving Sourcing Locations to be replaced. 
- 'materialIds' property of the dto remains an array for easier filter management, however it is validated that only 1 element is received 
2. businessUnitIds property for filters is not required. If no businessUnitIds are received, the filter won't be added to the query and sourcing locations of all business units (matching other filters)
3. 'adminRegionIds' property for filters is not required. If no businessUnitIds are received, the filter won't be added to the query and sourcing locations of all business units (matching other filters)
4. Location types format changed according to latest Location types endpoint: location types with dashes are received and transformed to database format
5. Update of test to cover changes

### Designs


### Testing instructions

Expected endpoint behavior:

- Sending more than material to create intervention should return error message
- Intervention can be created without sending business unit ids and admin region ids
- Location types should be sent and validated in format with dashes

## Checklist before merging

- [ ] Branch name / PR includes the related Jira ticket Id.
- [x] Tests to check core implementation / bug fix added.
- [x] All checks in Continuous Integration workflow pass.
- [ ] Feature functionally tested by reviewer(s).
- [x] Code reviewed by reviewer(s).
- [x] Documentation updated (README, CHANGELOG...) (if required)
