### PR TITLE
Landgrif 737 limit from input dropdown to existed data in years select for analysis

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Prevent collapse button to break his position [LANDGRIF-729](https://vizzuality.atlassian.net/browse/LANDGRIF-729)
 - [LANDGRIF-716](https://vizzuality.atlassian.net/browse/LANDGRIF-716) fixed extra bad requests in analysis.
 - Scenario description not updating properly [LANDGRIF-740](https://vizzuality.atlassian.net/browse/LANDGRIF-740)
+- Limit options for start year in analysis to years with available data [LANDGRIF-737](https://vizzuality.atlassian.net/browse/LANDGRIF-737)
 
 ## 2022.06.27
 

--- a/client/src/containers/filters/years-range/component.tsx
+++ b/client/src/containers/filters/years-range/component.tsx
@@ -40,8 +40,9 @@ export const YearsRangeFilter: React.FC<YearsRangeFilterProps> = ({
 
   useEffect(() => {
     if (!years.length) return;
+    const filteredYears = years.filter((y) => y <= lastYearWithData);
     setStartYearOptions(
-      years?.map((year) => ({
+      filteredYears?.map((year) => ({
         label: year.toString(),
         value: year,
         disabled: endYear <= year + (yearsGap - 1),
@@ -57,7 +58,7 @@ export const YearsRangeFilter: React.FC<YearsRangeFilterProps> = ({
     );
 
     setIsLoaded(true);
-  }, [endYear, isLoaded, startYear, years, yearsGap]);
+  }, [endYear, isLoaded, startYear, years, yearsGap, lastYearWithData]);
 
   useEffect(() => {
     if (!startYearOptions || !endYearOptions) return;

--- a/client/src/containers/scenarios/item/component.tsx
+++ b/client/src/containers/scenarios/item/component.tsx
@@ -95,7 +95,10 @@ const ScenariosList: React.FC<ScenariosItemProps> = (props: ScenariosItemProps) 
                   >
                     <span className="rounded-full bg-white w-1.5 h-1.5" />
                   </span>
+<<<<<<< HEAD
                   )
+=======
+>>>>>>> 97b27526 (limit start year options in analysis)
                 </div>
                 <div className="flex-1 py-4 pr-4 truncate">
                   <h2 className="text-sm font-medium text-gray-900 truncate">{data.title}</h2>


### PR DESCRIPTION
### General description

_Options for start year in year selector for analysis should be limited to years with existing data (avoid showing the projected years in the dropdown options)_

### Testing instructions

_Go to analysis, get projected years and make sure those years don't appear in the start year select dropdown._

## Checklist before merging

- [x] Branch name / PR includes the related Jira ticket Id.
- [ ] Tests to check core implementation / bug fix added.
- [x] All checks in Continuous Integration workflow pass.
- [ ] Feature functionally tested by reviewer(s).
- [x] Code reviewed by reviewer(s).
- [x] Documentation updated (README, CHANGELOG...) (if required)
