### PR TITLE
category other in chart changed to gray

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Scenario description not updating properly [LANDGRIF-740](https://vizzuality.atlassian.net/browse/LANDGRIF-740)
 - Limit options for start year in analysis to years with available data [LANDGRIF-737](https://vizzuality.atlassian.net/browse/LANDGRIF-737)
 - Make loader more visible when chart data is fetching [LANDGRIF-759](https://vizzuality.atlassian.net/browse/LANDGRIF-759)
+- Aggregated values in chart ('other/others' category) should always be '#E4E4E4' [LANDGRIF-771](https://vizzuality.atlassian.net/browse/LANDGRIF-771)
 
 ## 2022.06.27
 

--- a/client/src/hooks/analysis/index.ts
+++ b/client/src/hooks/analysis/index.ts
@@ -14,15 +14,15 @@ import type { AnalysisChart } from './types';
 import type { Intervention } from './types';
 
 const COLOR_SCALE = chroma.scale([
-  '#E1E1E1',
-  '#AAD463',
-  '#FDB462',
-  '#9CBB97',
-  '#80B1D3',
-  '#FB968A',
-  '#BEBADA',
-  '#FFFFB3',
   '#8DD3C7',
+  '#FFFFB3',
+  '#BEBADA',
+  '#FB968A',
+  '#80B1D3',
+  '#9CBB97',
+  '#FDB462',
+  '#AAD463',
+  '#E1E1E1',
 ]);
 
 export function useColors(): RGBColor[] {
@@ -129,7 +129,7 @@ export function useAnalysisChart(params): AnalysisChart {
         {
           id: k,
           name: k,
-          color: colorScale[i],
+          color: k === 'Other' || k === 'Others' ? '#E4E4E4' : colorScale[i],
         },
       ],
       [],
@@ -138,7 +138,7 @@ export function useAnalysisChart(params): AnalysisChart {
     const colors = allKeys.reduce(
       (acc, k, i) => ({
         ...acc,
-        [k]: colorScale[i],
+        [k]: k === 'Other' || k === 'Others' ? '#E4E4E4' : colorScale[i],
       }),
       {},
     );


### PR DESCRIPTION
### General description

_Aggregated values in the analysis chart should be represented in gray color ('#E4E4E4')_

### Testing instructions

_In analysis chart view check the color for the category other/others._

- Apart from the added feature / bug fix, check overall performance, styling...

## Checklist before merging

- [x] Branch name / PR includes the related Jira ticket Id.
- [ ] Tests to check core implementation / bug fix added.
- [x] All checks in Continuous Integration workflow pass.
- [ ] Feature functionally tested by reviewer(s).
- [x] Code reviewed by reviewer(s).
- [x] Documentation updated (README, CHANGELOG...) (if required)
