### PR TITLE
Feature/landgrif 722 serve contextual layers

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ##  2022-06-12
 ### Added
+Added [LANDGRIF-722](https://vizzuality.atlassian.net/browse/LANDGRIF-722)
+Added support for Contextual Layer data with 2 endpoints to serve contextual layers and their H3 Data
+
+##  2022-06-12
+### Added
 Added [LANDGRIF-697](https://vizzuality.atlassian.net/browse/LANDGRIF-697)
 Added class with custom chunk save method for large inserts to avoid blocking
 event loop

--- a/api/src/modules/contextual-layers/contextual-layer.entity.ts
+++ b/api/src/modules/contextual-layers/contextual-layer.entity.ts
@@ -41,9 +41,9 @@ export class ContextualLayer extends BaseEntity {
 
   @Column({
     type: 'jsonb',
-    nullable: false,
+    nullable: true,
   })
-  metadata: JSON;
+  metadata?: JSON;
 
   @Column({
     type: 'enum',

--- a/api/src/modules/contextual-layers/contextual-layer.entity.ts
+++ b/api/src/modules/contextual-layers/contextual-layer.entity.ts
@@ -56,3 +56,9 @@ export class ContextualLayer extends BaseEntity {
   @OneToMany(() => H3Data, (h3Data: H3Data) => h3Data.contextualLayer)
   h3Data: H3Data[];
 }
+
+export class ContextualLayerByCategory {
+  category: CONTEXTUAL_LAYER_CATEGORY;
+
+  layer: ContextualLayer;
+}

--- a/api/src/modules/contextual-layers/contextual-layers.controller.ts
+++ b/api/src/modules/contextual-layers/contextual-layers.controller.ts
@@ -1,0 +1,25 @@
+import { Controller, Get } from '@nestjs/common';
+import {
+  ApiForbiddenResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger';
+import { ContextualLayer } from 'modules/contextual-layers/contextual-layer.entity';
+
+@Controller('api/v1/contextual-layers')
+export class ContextualLayersController {
+  @ApiOperation({
+    description: 'Get all Contextual Layer info ordered by Category',
+  })
+  @ApiOkResponse({
+    type: ContextualLayer,
+    isArray: true,
+  })
+  @ApiUnauthorizedResponse()
+  @ApiForbiddenResponse()
+  @Get('/categories')
+  async getContextualLayerByCategory(): Promise<any> {
+    return;
+  }
+}

--- a/api/src/modules/contextual-layers/contextual-layers.controller.ts
+++ b/api/src/modules/contextual-layers/contextual-layers.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, Param, Query, ValidationPipe } from '@nestjs/common';
 import {
   ApiForbiddenResponse,
   ApiOkResponse,
@@ -7,6 +7,9 @@ import {
 } from '@nestjs/swagger';
 import { ContextualLayerByCategory } from 'modules/contextual-layers/contextual-layer.entity';
 import { ContextualLayersService } from 'modules/contextual-layers/contextual-layers.service';
+import { H3IndexValueData } from 'modules/h3-data/h3-data.entity';
+import { GetContextualLayerH3Dto } from 'modules/contextual-layers//dto/get-contextual-layer-h3.dto';
+import { GetContextualLayerH3ResponseDto } from 'modules/contextual-layers//dto/get-contextual-layer-h3-response.dto';
 
 @Controller('api/v1/contextual-layers')
 export class ContextualLayersController {
@@ -30,5 +33,29 @@ export class ContextualLayersController {
       await this.contextualLayerService.getContextualLayersByCategory();
 
     return { data: contextualLayersByCategory };
+  }
+
+  @ApiOperation({
+    description:
+      'Returns all the H3 index data for this given contextual layer, resolution and optionally year',
+  })
+  @ApiOkResponse({
+    type: GetContextualLayerH3ResponseDto,
+  })
+  @ApiUnauthorizedResponse()
+  @ApiForbiddenResponse()
+  @Get('/:id/h3data')
+  async getContextualLayerH3(
+    @Param('id') contextualLayerId: string,
+    @Query(ValidationPipe) queryParams: GetContextualLayerH3Dto,
+  ): Promise<{ data: H3IndexValueData[] }> {
+    const h3Data: H3IndexValueData[] =
+      await this.contextualLayerService.getContextualLayerH3(
+        contextualLayerId,
+        queryParams.resolution,
+        queryParams.year,
+      );
+
+    return { data: h3Data };
   }
 }

--- a/api/src/modules/contextual-layers/contextual-layers.controller.ts
+++ b/api/src/modules/contextual-layers/contextual-layers.controller.ts
@@ -5,21 +5,30 @@ import {
   ApiOperation,
   ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
-import { ContextualLayer } from 'modules/contextual-layers/contextual-layer.entity';
+import { ContextualLayerByCategory } from 'modules/contextual-layers/contextual-layer.entity';
+import { ContextualLayersService } from 'modules/contextual-layers/contextual-layers.service';
 
 @Controller('api/v1/contextual-layers')
 export class ContextualLayersController {
+  constructor(
+    private readonly contextualLayerService: ContextualLayersService,
+  ) {}
   @ApiOperation({
-    description: 'Get all Contextual Layer info ordered by Category',
+    description: 'Get all Contextual Layer info grouped by Category',
   })
   @ApiOkResponse({
-    type: ContextualLayer,
+    type: ContextualLayerByCategory,
     isArray: true,
   })
   @ApiUnauthorizedResponse()
   @ApiForbiddenResponse()
   @Get('/categories')
-  async getContextualLayerByCategory(): Promise<any> {
-    return;
+  async getContextualLayersByCategory(): Promise<{
+    data: ContextualLayerByCategory[];
+  }> {
+    const contextualLayersByCategory: ContextualLayerByCategory[] =
+      await this.contextualLayerService.getContextualLayersByCategory();
+
+    return { data: contextualLayersByCategory };
   }
 }

--- a/api/src/modules/contextual-layers/contextual-layers.module.ts
+++ b/api/src/modules/contextual-layers/contextual-layers.module.ts
@@ -3,9 +3,13 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { ContextualLayerRepository } from 'modules/contextual-layers/contextual-layer.repository';
 import { ContextualLayersController } from 'modules/contextual-layers/contextual-layers.controller';
 import { ContextualLayersService } from 'modules/contextual-layers/contextual-layers.service';
+import { H3DataModule } from 'modules/h3-data/h3-data.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([ContextualLayerRepository])],
+  imports: [
+    TypeOrmModule.forFeature([ContextualLayerRepository]),
+    H3DataModule,
+  ],
   controllers: [ContextualLayersController],
   providers: [ContextualLayersService],
 })

--- a/api/src/modules/contextual-layers/contextual-layers.module.ts
+++ b/api/src/modules/contextual-layers/contextual-layers.module.ts
@@ -1,8 +1,12 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ContextualLayerRepository } from 'modules/contextual-layers/contextual-layer.repository';
+import { ContextualLayersController } from 'modules/contextual-layers/contextual-layers.controller';
+import { ContextualLayersService } from 'modules/contextual-layers/contextual-layers.service';
 
 @Module({
   imports: [TypeOrmModule.forFeature([ContextualLayerRepository])],
+  controllers: [ContextualLayersController],
+  providers: [ContextualLayersService],
 })
 export class ContextualLayersModule {}

--- a/api/src/modules/contextual-layers/contextual-layers.service.ts
+++ b/api/src/modules/contextual-layers/contextual-layers.service.ts
@@ -2,6 +2,8 @@ import { Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { ContextualLayerRepository } from 'modules/contextual-layers/contextual-layer.repository';
 import { ContextualLayer } from 'modules/contextual-layers/contextual-layer.entity';
 import { groupBy } from 'lodash';
+import { H3Data, H3IndexValueData } from 'modules/h3-data/h3-data.entity';
+import { H3DataService } from 'modules/h3-data/h3-data.service';
 
 @Injectable()
 export class ContextualLayersService {
@@ -9,6 +11,7 @@ export class ContextualLayersService {
 
   constructor(
     private readonly contextualLayerRepository: ContextualLayerRepository,
+    private readonly h3dataService: H3DataService,
   ) {}
 
   async getContextualLayersByCategory(): Promise<any[]> {
@@ -25,5 +28,29 @@ export class ContextualLayersService {
       category: category[0],
       layers: category[1],
     }));
+  }
+
+  async getContextualLayerH3(
+    contextualLayerId: string,
+    resolution?: number,
+    year?: number,
+  ): Promise<H3IndexValueData[]> {
+    const h3Data: H3Data | undefined =
+      await this.h3dataService.getContextualLayerH3DataByClosestYear(
+        contextualLayerId,
+        year,
+      );
+
+    if (!h3Data) {
+      throw new NotFoundException(
+        `No H3 Data could be found for contextual Layer with id ${contextualLayerId}`,
+      );
+    }
+
+    return this.h3dataService.getSumH3ByNameAndResolution(
+      h3Data.h3tableName,
+      h3Data.h3columnName,
+      resolution,
+    );
   }
 }

--- a/api/src/modules/contextual-layers/contextual-layers.service.ts
+++ b/api/src/modules/contextual-layers/contextual-layers.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class ContextualLayersService {}

--- a/api/src/modules/contextual-layers/contextual-layers.service.ts
+++ b/api/src/modules/contextual-layers/contextual-layers.service.ts
@@ -1,4 +1,29 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { ContextualLayerRepository } from 'modules/contextual-layers/contextual-layer.repository';
+import { ContextualLayer } from 'modules/contextual-layers/contextual-layer.entity';
+import { groupBy } from 'lodash';
 
 @Injectable()
-export class ContextualLayersService {}
+export class ContextualLayersService {
+  logger: Logger = new Logger();
+
+  constructor(
+    private readonly contextualLayerRepository: ContextualLayerRepository,
+  ) {}
+
+  async getContextualLayersByCategory(): Promise<any[]> {
+    const contextualLayers: ContextualLayer[] =
+      await this.contextualLayerRepository.find();
+
+    if (!contextualLayers.length) {
+      throw new NotFoundException('No contextual layers were found');
+    }
+
+    return Object.entries(
+      groupBy(contextualLayers, (layer: ContextualLayer) => layer.category),
+    ).map((category: any) => ({
+      category: category[0],
+      layers: category[1],
+    }));
+  }
+}

--- a/api/src/modules/contextual-layers/dto/get-contextual-layer-h3-response.dto.ts
+++ b/api/src/modules/contextual-layers/dto/get-contextual-layer-h3-response.dto.ts
@@ -1,0 +1,20 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { H3IndexValueData } from 'modules/h3-data/h3-data.entity';
+
+export class GetContextualLayerH3ResponseDto {
+  @ApiProperty({
+    type: 'array',
+    items: {
+      type: 'object',
+      properties: {
+        h: {
+          type: 'string',
+        },
+        v: {
+          type: 'number',
+        },
+      },
+    },
+  })
+  data: H3IndexValueData[];
+}

--- a/api/src/modules/contextual-layers/dto/get-contextual-layer-h3.dto.ts
+++ b/api/src/modules/contextual-layers/dto/get-contextual-layer-h3.dto.ts
@@ -1,0 +1,22 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEnum, IsNumber, IsOptional, Max, Min } from 'class-validator';
+import { Type } from 'class-transformer';
+import { AvailableResolutions } from 'modules/h3-data/dto/get-material-h3-by-resolution.dto';
+
+export class GetContextualLayerH3Dto {
+  @ApiProperty()
+  @IsNumber()
+  @IsOptional()
+  @Type(() => Number)
+  @Min(1)
+  @Max(6)
+  @IsEnum(AvailableResolutions, { message: 'Available resolutions: 1 to 6' })
+  resolution?: number;
+
+  @ApiProperty()
+  @IsNumber()
+  @IsOptional()
+  @Type(() => Number)
+  @Min(0)
+  year?: number;
+}

--- a/api/src/modules/h3-data/h3-data.controller.ts
+++ b/api/src/modules/h3-data/h3-data.controller.ts
@@ -30,11 +30,11 @@ export class H3DataController {
     description: 'Bad Request. Incorrect or missing parameters',
   })
   @Get('data/:h3TableName/:h3ColumnName')
-  async findOneByName(
+  async getH3ByName(
     @Param('h3TableName') h3TableName: string,
     @Param('h3ColumnName') h3ColumnName: string,
   ): Promise<{ data: H3IndexValueData[] }> {
-    const h3Data: H3IndexValueData[] = await this.h3DataService.findH3ByName(
+    const h3Data: H3IndexValueData[] = await this.h3DataService.getH3ByName(
       h3TableName,
       h3ColumnName,
     );

--- a/api/src/modules/h3-data/h3-data.service.ts
+++ b/api/src/modules/h3-data/h3-data.service.ts
@@ -1,9 +1,4 @@
-import {
-  Injectable,
-  Logger,
-  NotFoundException,
-  ServiceUnavailableException,
-} from '@nestjs/common';
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { H3DataRepository } from 'modules/h3-data/h3-data.repository';
 import { H3Data, H3IndexValueData } from 'modules/h3-data/h3-data.entity';
@@ -53,11 +48,27 @@ export class H3DataService {
   /**
    * Find one H3 full data by its name
    */
-  async findH3ByName(
+  getH3ByName(
     h3TableName: string,
     h3ColumnName: string,
   ): Promise<H3IndexValueData[]> {
-    return await this.h3DataRepository.findH3ByName(h3TableName, h3ColumnName);
+    return this.h3DataRepository.getH3ByName(h3TableName, h3ColumnName);
+  }
+
+  /**
+   * Find one H3 full data by its name, for the given optional resolution
+   * if no resolution is provided, the  data will have the same resolution as it stored in the DB
+   */
+  getSumH3ByNameAndResolution(
+    h3TableName: string,
+    h3ColumnName: string,
+    resolution?: number,
+  ): Promise<H3IndexValueData[]> {
+    return this.h3DataRepository.getSumH3ByNameAndResolution(
+      h3TableName,
+      h3ColumnName,
+      resolution,
+    );
   }
 
   async getById(id: string): Promise<H3Data | undefined> {
@@ -66,6 +77,22 @@ export class H3DataService {
 
   async findH3ByIndicatorId(indicatorId: string): Promise<H3Data | undefined> {
     return await this.h3DataRepository.findOne({ indicatorId });
+  }
+
+  findH3ByContextualLayerId(
+    contextualLayerId: string,
+  ): Promise<H3Data | undefined> {
+    return this.h3DataRepository.findOne({ contextualLayerId });
+  }
+
+  getContextualLayerH3DataByClosestYear(
+    contextualLayerId: string,
+    year?: number,
+  ): Promise<H3Data | undefined> {
+    return this.h3DataRepository.getContextualLayerH3DataByClosestYear(
+      contextualLayerId,
+      year,
+    );
   }
 
   async getMaterialMapByResolution(

--- a/api/test/e2e/contextual-layers/contextual-layers.spec.ts
+++ b/api/test/e2e/contextual-layers/contextual-layers.spec.ts
@@ -1,0 +1,81 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { HttpStatus, INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { AppModule } from 'app.module';
+import { saveUserAndGetToken } from '../../utils/userAuth';
+import { getApp } from '../../utils/getApp';
+import { ContextualLayersModule } from 'modules/contextual-layers/contextual-layers.module';
+import { clearEntityTables } from '../../utils/database-test-helper';
+import {
+  CONTEXTUAL_LAYER_CATEGORY,
+  ContextualLayer,
+  ContextualLayerByCategory,
+} from 'modules/contextual-layers/contextual-layer.entity';
+import { createContextualLayer } from '../../entity-mocks';
+
+/**
+ * Tests for the GeoRegionsModule.
+ */
+
+describe('ContextualLayersModule (e2e)', () => {
+  let app: INestApplication;
+  let jwtToken: string;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule, ContextualLayersModule],
+    }).compile();
+
+    app = getApp(moduleFixture);
+    await app.init();
+    jwtToken = await saveUserAndGetToken(moduleFixture, app);
+  });
+
+  afterEach(async () => {
+    await clearEntityTables([ContextualLayer]);
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  describe('Contextual Layers - Get all contextual layers by category', () => {
+    test('When I query the API to get all the contextual layer info, Then I should get all available layers grouped by category', async () => {
+      for (const num of [1, 2]) {
+        await Promise.all(
+          Object.values(CONTEXTUAL_LAYER_CATEGORY).map(
+            async (category: string) => {
+              return createContextualLayer({
+                category: category as CONTEXTUAL_LAYER_CATEGORY,
+              });
+            },
+          ),
+        );
+      }
+
+      await createContextualLayer({
+        category: CONTEXTUAL_LAYER_CATEGORY.DEFAULT,
+      });
+      const response = await request(app.getHttpServer())
+        .get('/api/v1/contextual-layers/categories')
+        .set('Authorization', `Bearer ${jwtToken}`);
+
+      expect(HttpStatus.OK);
+
+      Object.values(CONTEXTUAL_LAYER_CATEGORY).forEach((value: string) =>
+        expect(
+          response.body.data.find(
+            (layer: ContextualLayerByCategory) => layer.category === value,
+          ),
+        ),
+      );
+
+      expect(
+        response.body.data.filter(
+          (category: ContextualLayerByCategory) =>
+            category.category === CONTEXTUAL_LAYER_CATEGORY.DEFAULT,
+        )[0].layers,
+      ).toHaveLength(3);
+    });
+  });
+});

--- a/api/test/e2e/h3-data/mocks/h3-data.mock.ts
+++ b/api/test/e2e/h3-data/mocks/h3-data.mock.ts
@@ -8,6 +8,7 @@ export const h3DataMock = async (h3DataMockParams: {
   additionalH3Data?: Record<string, any> | null;
   indicatorId?: string | null;
   year: number;
+  contextualLayerId?: string | null;
 }): Promise<H3Data> => {
   const formattedTableName: string = snakeCase(h3DataMockParams.h3TableName);
   const formattedColumnName: string = camelCase(h3DataMockParams.h3ColumnName);
@@ -36,7 +37,9 @@ export const h3DataMock = async (h3DataMockParams: {
   if (h3DataMockParams.indicatorId) {
     h3data.indicatorId = h3DataMockParams.indicatorId;
   }
-
+  if (h3DataMockParams.contextualLayerId) {
+    h3data.contextualLayerId = h3DataMockParams.contextualLayerId;
+  }
   return h3data.save();
 };
 

--- a/api/test/e2e/h3-data/mocks/h3-fixtures.ts
+++ b/api/test/e2e/h3-data/mocks/h3-fixtures.ts
@@ -182,3 +182,14 @@ export const h3DeforestationExampleDataFixture = {
   '868c36d97ffffff': 0,
   '868c36d9fffffff': null,
 };
+
+export const h3ContextualLayerExampleDataFixture = {
+  // parent resolution 1 - 8110bffffffffff
+
+  // parent resolution 3 - 821087fffffffff
+  '861080007ffffff': 0.2,
+  '86108002fffffff': 0.04,
+  // parent resolution 3 - 8210b7fffffffff
+  '8610b6d97ffffff': 0.1,
+  '8610b6db7ffffff': null,
+};

--- a/api/test/entity-mocks.ts
+++ b/api/test/entity-mocks.ts
@@ -28,6 +28,10 @@ import { BusinessUnit } from 'modules/business-units/business-unit.entity';
 import { Task, TASK_STATUS, TASK_TYPE } from 'modules/tasks/task.entity';
 import { Target } from 'modules/targets/target.entity';
 import { H3DataRepository } from '../src/modules/h3-data/h3-data.repository';
+import {
+  CONTEXTUAL_LAYER_CATEGORY,
+  ContextualLayer,
+} from '../src/modules/contextual-layers/contextual-layer.entity';
 
 async function createAdminRegion(
   additionalData: Partial<AdminRegion> = {},
@@ -55,6 +59,22 @@ async function createBusinessUnit(
   );
   return businessUnit.save();
 }
+
+async function createContextualLayer(
+  additionalData: Partial<ContextualLayer> = {},
+): Promise<ContextualLayer> {
+  const businessUnit = ContextualLayer.merge(
+    new ContextualLayer(),
+    {
+      name: 'A fake Contextual Layer',
+      description: 'Description of the fake Contextual Layer',
+      category: CONTEXTUAL_LAYER_CATEGORY.ENVIRONMENTAL_DATASETS,
+    },
+    additionalData,
+  );
+  return businessUnit.save();
+}
+
 async function createH3Data(
   additionalData: Partial<H3Data> = {},
 ): Promise<H3Data> {
@@ -389,6 +409,7 @@ async function createUnitConversion(
 export {
   createAdminRegion,
   createBusinessUnit,
+  createContextualLayer,
   createH3Data,
   createIndicator,
   createIndicatorCoefficient,

--- a/api/test/entity-mocks.ts
+++ b/api/test/entity-mocks.ts
@@ -67,7 +67,6 @@ async function createContextualLayer(
     new ContextualLayer(),
     {
       name: 'A fake Contextual Layer',
-      description: 'Description of the fake Contextual Layer',
       category: CONTEXTUAL_LAYER_CATEGORY.ENVIRONMENTAL_DATASETS,
     },
     additionalData,


### PR DESCRIPTION
### General description

Adds support for Contextual Layers and related H3 data, that is served over 2 endpoints (one to retrieve the contextual layer itself, and another for aggregated H3 data by resolution of a contextual layer)

### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

e2e area included in the test suites.

- Apart from the added feature / bug fix, check overall performance, styling...

## Checklist before merging

- [x] Branch name / PR includes the related Jira ticket Id.
- [x] Tests to check core implementation / bug fix added.
- [x] All checks in Continuous Integration workflow pass.
- [x] Feature functionally tested by reviewer(s).
- [x] Code reviewed by reviewer(s).
- [x] Documentation updated (README, CHANGELOG...) (if required)
