### PR TITLE
limit aggregated values in chart

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Limit options for start year in analysis to years with available data [LANDGRIF-737](https://vizzuality.atlassian.net/browse/LANDGRIF-737)
 - Make loader more visible when chart data is fetching [LANDGRIF-759](https://vizzuality.atlassian.net/browse/LANDGRIF-759)
 - Aggregated values in chart ('other/others' category) should always be '#E4E4E4' [LANDGRIF-771](https://vizzuality.atlassian.net/browse/LANDGRIF-771)
+- Show aggregated values in chart just if there are more than 5 elements in total [LANDGRIF-773](https://vizzuality.atlassian.net/browse/LANDGRIF-773)
 
 ## 2022.06.27
 

--- a/client/src/containers/analysis-visualization/analysis-chart/analysis-chart-legend/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-chart/analysis-chart-legend/component.tsx
@@ -24,7 +24,9 @@ const Legend: FC<LegendChartTypes> = ({ activeArea, onClick, indicatorData }: Le
             <span
               title={key}
               className={cx('text-xs', {
-                'truncate text-ellipsis text-gray-500 max-w-[74px]': activeArea !== `${key}-${id}`,
+                'truncate text-ellipsis max-w-[74px]':
+                  keys.length > 4 && activeArea !== `${key}-${id}`,
+                'text-gray-500': activeArea !== `${key}-${id}`,
                 'opacity-70 text-gray-900': activeArea && activeArea !== `${key}-${id}`,
               })}
             >

--- a/client/src/hooks/analysis/index.ts
+++ b/client/src/hooks/analysis/index.ts
@@ -22,7 +22,6 @@ const COLOR_SCALE = chroma.scale([
   '#9CBB97',
   '#FDB462',
   '#AAD463',
-  '#E1E1E1',
 ]);
 
 export function useColors(): RGBColor[] {
@@ -51,27 +50,30 @@ export function useAnalysisChart(params): AnalysisChart {
     ) as number[];
 
     const projection = !!projectedYears.length && Math.min(...projectedYears);
+
     return {
       id: data.indicatorId,
       indicator: data.indicatorShortName,
       unit: data.metadata.unit,
       values: data.yearSum,
       projection,
-      children: flatten([
-        data.rows.map((row) => ({
-          id: row.name,
-          name: row.name,
-          values: row.values,
-        })),
-        {
-          id: data.others.numberOfAggregatedEntities === 1 ? 'Other' : 'Others',
-          name: data.others.numberOfAggregatedEntities === 1 ? 'Other' : 'Others',
-          values: data.others.aggregatedValues.map((aggregated) => ({
-            ...aggregated,
-            isProjected: projectedYears.includes(aggregated.year),
+      children: flatten(
+        [
+          data.rows.map((row) => ({
+            id: row.name,
+            name: row.name,
+            values: row.values,
           })),
-        },
-      ]),
+          data.others.numberOfAggregatedEntities > 0 && {
+            id: data.others.numberOfAggregatedEntities === 1 ? 'Other' : 'Others',
+            name: data.others.numberOfAggregatedEntities === 1 ? 'Other' : 'Others',
+            values: data.others.aggregatedValues.map((aggregated) => ({
+              ...aggregated,
+              isProjected: projectedYears.includes(aggregated.year),
+            })),
+          },
+        ].filter(Boolean),
+      ),
     };
   });
   return useMemo(() => {


### PR DESCRIPTION
### General description

_Analysis chart should show a maximun of 6 elements. If there are 6 in total, the chart should show 5 elements and "other" representing the 6th value. If there are more than 6, the chart should show 5 values and "others" representing the aggregation of the rest of the values. If there are less than 4 elements in legend, this shouldn't appear with ellipsis _

### Testing instructions

_Check the analysis chart and change the filters to see all possibilities._

## Checklist before merging

- [x] Branch name / PR includes the related Jira ticket Id.
- [ ] Tests to check core implementation / bug fix added.
- [x] All checks in Continuous Integration workflow pass.
- [ ] Feature functionally tested by reviewer(s).
- [x] Code reviewed by reviewer(s).
- [x] Documentation updated (README, CHANGELOG...) (if required)
