### PR TITLE
Scenario Intervention creation and impact table bug fixes

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -71,4 +71,11 @@ Impact years endpoint - returns years for which sourcing record volumes are not 
 Fixed
 Update entity methods that build trees - filters descendants search moved to calling functions
 
+## 2022-07-12
+
+### Fixed
+
+Fixed
+Scenario Interventions - when creating new intervention of type new supplier location, replacing SLs with identical entities relations 
+are grouped into one with tonnage accumulated
 

--- a/api/src/modules/admin-regions/admin-region.repository.ts
+++ b/api/src/modules/admin-regions/admin-region.repository.ts
@@ -10,6 +10,8 @@ import { CreateAdminRegionDto } from 'modules/admin-regions/dto/create.admin-reg
 import { BadRequestException, Logger, NotFoundException } from '@nestjs/common';
 import { SourcingLocation } from 'modules/sourcing-locations/sourcing-location.entity';
 import { GetAdminRegionTreeWithOptionsDto } from 'modules/admin-regions/dto/get-admin-region-tree-with-options.dto';
+import { ScenarioIntervention } from 'modules/scenario-interventions/scenario-intervention.entity';
+import { Scenario } from 'modules/scenarios/scenario.entity';
 
 @EntityRepository(AdminRegion)
 export class AdminRegionRepository extends ExtendedTreeRepository<
@@ -183,6 +185,25 @@ export class AdminRegionRepository extends ExtendedTreeRepository<
       queryBuilder.andWhere('sl.locationType IN (:...locationTypes)', {
         locationTypes: adminRegionTreeOptions.locationTypes,
       });
+    }
+
+    if (adminRegionTreeOptions.scenarioId) {
+      queryBuilder
+        .innerJoin(
+          ScenarioIntervention,
+          'scenarioIntervention',
+          'sl.scenarioInterventionId = scenarioIntervention.id',
+        )
+        .innerJoin(
+          Scenario,
+          'scenario',
+          'scenarioIntervention.scenarioId = scenario.id',
+        )
+        .andWhere('scenario.id = :scenarioId', {
+          scenarioId: adminRegionTreeOptions.scenarioId,
+        });
+    } else {
+      queryBuilder.andWhere('sl.scenarioInterventionId is null');
     }
 
     const [subQuery, subQueryParams]: [string, any[]] =

--- a/api/src/modules/admin-regions/dto/get-admin-region-tree-with-options.dto.ts
+++ b/api/src/modules/admin-regions/dto/get-admin-region-tree-with-options.dto.ts
@@ -70,4 +70,9 @@ export class GetAdminRegionTreeWithOptionsDto {
   )
   @Type(() => String)
   locationTypes?: LOCATION_TYPES_PARAMS[];
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsUUID(4)
+  scenarioId?: string;
 }

--- a/api/src/modules/h3-data/strategies/risk-map.strategies.ts
+++ b/api/src/modules/h3-data/strategies/risk-map.strategies.ts
@@ -1,6 +1,9 @@
-import { Indicator, INDICATOR_TYPES } from '../../indicators/indicator.entity';
-import { H3Data } from '../h3-data.entity';
-import { MATERIAL_TO_H3_TYPE } from '../../materials/material-to-h3.entity';
+import {
+  Indicator,
+  INDICATOR_TYPES,
+} from 'modules/indicators/indicator.entity';
+import { H3Data } from 'modules/h3-data/h3-data.entity';
+import { MATERIAL_TO_H3_TYPE } from 'modules/materials/material-to-h3.entity';
 import { getManager, SelectQueryBuilder } from 'typeorm';
 import { NotFoundException } from '@nestjs/common';
 

--- a/api/src/modules/impact/impact.service.ts
+++ b/api/src/modules/impact/impact.service.ts
@@ -258,6 +258,9 @@ export class ImpactService {
       ...(impactTableDto.supplierIds && {
         supplierIds: impactTableDto.supplierIds,
       }),
+      ...(impactTableDto.scenarioId && {
+        scenarioId: impactTableDto.scenarioId,
+      }),
     };
     switch (impactTableDto.groupBy) {
       case GROUP_BY_VALUES.MATERIAL: {

--- a/api/src/modules/indicator-records/indicator-record.repository.ts
+++ b/api/src/modules/indicator-records/indicator-record.repository.ts
@@ -12,10 +12,13 @@ import {
 } from '@nestjs/common';
 import { SourcingRecordsWithIndicatorRawDataDto } from 'modules/sourcing-records/dto/sourcing-records-with-indicator-raw-data.dto';
 import { MissingH3DataError } from 'modules/indicator-records/errors/missing-h3-data.error';
-import { H3Data } from '../h3-data/h3-data.entity';
-import { Indicator, INDICATOR_TYPES } from '../indicators/indicator.entity';
-import { MATERIAL_TO_H3_TYPE } from '../materials/material-to-h3.entity';
-import { IndicatorRecordValueSQLStrategies } from './strategies/indicator-record-value.strategies';
+import { H3Data } from 'modules/h3-data/h3-data.entity';
+import {
+  Indicator,
+  INDICATOR_TYPES,
+} from 'modules/indicators/indicator.entity';
+import { MATERIAL_TO_H3_TYPE } from 'modules/materials/material-to-h3.entity';
+import { IndicatorRecordValueSQLStrategies } from 'modules/indicator-records/strategies/indicator-record-value.strategies';
 import { AppBaseRepository } from 'utils/app-base.repository';
 
 @EntityRepository(IndicatorRecord)

--- a/api/src/modules/indicator-records/strategies/indicator-record-value.strategies.ts
+++ b/api/src/modules/indicator-records/strategies/indicator-record-value.strategies.ts
@@ -1,6 +1,9 @@
-import { Indicator, INDICATOR_TYPES } from '../../indicators/indicator.entity';
-import { H3Data } from '../../h3-data/h3-data.entity';
-import { MATERIAL_TO_H3_TYPE } from '../../materials/material-to-h3.entity';
+import {
+  Indicator,
+  INDICATOR_TYPES,
+} from 'modules/indicators/indicator.entity';
+import { H3Data } from 'modules/h3-data/h3-data.entity';
+import { MATERIAL_TO_H3_TYPE } from 'modules/materials/material-to-h3.entity';
 import { getManager, SelectQueryBuilder } from 'typeorm';
 import { NotFoundException } from '@nestjs/common';
 

--- a/api/src/modules/indicators/dto/indicator-computed-raw-data.dto.ts
+++ b/api/src/modules/indicators/dto/indicator-computed-raw-data.dto.ts
@@ -2,7 +2,7 @@
  * @description Raw indicator data computed in DB using stored functions of migration: XXXXXX
  * used to calculate impact for a Intervention
  */
-import { INDICATOR_TYPES } from '../indicator.entity';
+import { INDICATOR_TYPES } from 'modules/indicators/indicator.entity';
 
 export class IndicatorComputedRawDataDto {
   production: number;

--- a/api/src/modules/materials/dto/get-material-tree-with-options.dto.ts
+++ b/api/src/modules/materials/dto/get-material-tree-with-options.dto.ts
@@ -70,4 +70,9 @@ export class GetMaterialTreeWithOptionsDto {
   )
   @Type(() => String)
   locationTypes?: LOCATION_TYPES_PARAMS[];
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsUUID(4)
+  scenarioId?: string;
 }

--- a/api/src/modules/materials/material.repository.ts
+++ b/api/src/modules/materials/material.repository.ts
@@ -10,6 +10,8 @@ import { CreateMaterialDto } from 'modules/materials/dto/create.material.dto';
 import { Logger, NotFoundException } from '@nestjs/common';
 import { SourcingLocation } from 'modules/sourcing-locations/sourcing-location.entity';
 import { GetMaterialTreeWithOptionsDto } from 'modules/materials/dto/get-material-tree-with-options.dto';
+import { ScenarioIntervention } from 'modules/scenario-interventions/scenario-intervention.entity';
+import { Scenario } from 'modules/scenarios/scenario.entity';
 
 @EntityRepository(Material)
 export class MaterialRepository extends ExtendedTreeRepository<
@@ -64,6 +66,24 @@ export class MaterialRepository extends ExtendedTreeRepository<
       queryBuilder.andWhere('sl.locationType IN (:...locationTypes)', {
         locationTypes: materialTreeOptions.locationTypes,
       });
+    }
+    if (materialTreeOptions.scenarioId) {
+      queryBuilder
+        .innerJoin(
+          ScenarioIntervention,
+          'scenarioIntervention',
+          'sl.scenarioInterventionId = scenarioIntervention.id',
+        )
+        .innerJoin(
+          Scenario,
+          'scenario',
+          'scenarioIntervention.scenarioId = scenario.id',
+        )
+        .andWhere('scenario.id = :scenarioId', {
+          scenarioId: materialTreeOptions.scenarioId,
+        });
+    } else {
+      queryBuilder.andWhere('sl.scenarioInterventionId is null');
     }
 
     const [subQuery, subQueryParams]: [string, any[]] =

--- a/api/src/modules/scenario-interventions/scenario-interventions.service.ts
+++ b/api/src/modules/scenario-interventions/scenario-interventions.service.ts
@@ -542,20 +542,19 @@ export class ScenarioInterventionsService extends AppBaseService<
         newSourcingRecords,
       );
 
-    const mergedRecords: { year: number; tonnage: number }[] =
-      joinedRecords.reduce(
-        (acc: any, sourcingRecords: { year: number; tonnage: number }) => {
-          acc[sourcingRecords.year] = {
-            year: sourcingRecords.year,
-            tonnage:
-              (acc[sourcingRecords.year]
-                ? Number(acc[sourcingRecords.year].tonnage)
-                : 0) + Number(sourcingRecords.tonnage),
-          };
-          return acc;
-        },
-        {},
-      );
+    const mergedRecords: { year: SourcingRecord } = joinedRecords.reduce(
+      (acc: any, sourcingRecords: { year: number; tonnage: number }) => {
+        acc[sourcingRecords.year] = {
+          year: sourcingRecords.year,
+          tonnage:
+            (acc[sourcingRecords.year]
+              ? Number(acc[sourcingRecords.year].tonnage)
+              : 0) + Number(sourcingRecords.tonnage),
+        };
+        return acc;
+      },
+      {},
+    );
 
     return Object.values(mergedRecords);
   }

--- a/api/src/modules/scenario-interventions/scenario-interventions.service.ts
+++ b/api/src/modules/scenario-interventions/scenario-interventions.service.ts
@@ -141,6 +141,23 @@ export class ScenarioInterventionsService extends AppBaseService<
         newCancelledByInterventionLocationsData,
       );
 
+    // Saving Indicator records for newly created Sourcing Locations of type canceled:
+
+    for (const sourcingLocation of cancelledInterventionSourcingLocations) {
+      for await (const sourcingRecord of sourcingLocation.sourcingRecords) {
+        await this.indicatorRecordsService.createIndicatorRecordsBySourcingRecords(
+          {
+            sourcingRecordId: sourcingRecord.id,
+            tonnage: sourcingRecord.tonnage,
+            geoRegionId: sourcingLocation.geoRegionId,
+            materialId: sourcingLocation.materialId,
+            year: sourcingRecord.year,
+          },
+          dto.newIndicatorCoefficients,
+        );
+      }
+    }
+
     /**
      *  Creating New Intervention to be saved in scenario_interventions table
      */
@@ -346,27 +363,58 @@ export class ScenarioInterventionsService extends AppBaseService<
 
     const newSourcingLocationData: SourcingData[] = [];
     for (const location of sourcingData) {
-      const newInterventionLocation: SourcingData = {
-        materialId: location.materialId,
-        locationType: dto.newLocationType,
-        locationAddressInput: dto.newLocationAddressInput,
-        locationCountryInput: dto.newLocationCountryInput,
-        locationLatitude: dto.newLocationLatitude,
-        locationLongitude: dto.newLocationLongitude,
-        t1SupplierId: dto.newT1SupplierId,
-        producerId: dto.newProducerId,
-        businessUnitId: location.businessUnitId,
-        geoRegionId: geoCodedLocationSample[0].geoRegionId,
-        adminRegionId: geoCodedLocationSample[0].adminRegionId,
-        locationWarning: geoCodedLocationSample[0].locationWarning,
-        sourcingRecords: location.sourcingRecords.map((elem: any) => {
-          return { year: elem.year, tonnage: elem.tonnage };
-        }),
-        interventionType: SOURCING_LOCATION_TYPE_BY_INTERVENTION.REPLACING,
-      };
+      const identicalSourcingLocationDataIndex: number | undefined =
+        newSourcingLocationData.findIndex(
+          (el: SourcingData) =>
+            location.materialId === el.materialId &&
+            location.businessUnitId === el.businessUnitId,
+        );
 
-      newSourcingLocationData.push(newInterventionLocation);
+      if (identicalSourcingLocationDataIndex >= 0) {
+        const joinedRecords: any = newSourcingLocationData[
+          identicalSourcingLocationDataIndex
+        ].sourcingRecords.concat(location.sourcingRecords);
+
+        const mergedRecords = joinedRecords.reduce(
+          (acc: any, sourcingRecords: { year: number; tonnage: number }) => {
+            acc[sourcingRecords.year] = {
+              year: sourcingRecords.year,
+              tonnage:
+                (acc[sourcingRecords.year]
+                  ? Number(acc[sourcingRecords.year].tonnage)
+                  : 0) + Number(sourcingRecords.tonnage),
+            };
+            return acc;
+          },
+          {},
+        );
+        newSourcingLocationData[
+          identicalSourcingLocationDataIndex
+        ].sourcingRecords = Object.values(mergedRecords);
+      } else {
+        const newInterventionLocation: SourcingData = {
+          materialId: location.materialId,
+          locationType: dto.newLocationType,
+          locationAddressInput: dto.newLocationAddressInput,
+          locationCountryInput: dto.newLocationCountryInput,
+          locationLatitude: dto.newLocationLatitude,
+          locationLongitude: dto.newLocationLongitude,
+          t1SupplierId: dto.newT1SupplierId,
+          producerId: dto.newProducerId,
+          businessUnitId: location.businessUnitId,
+          geoRegionId: geoCodedLocationSample[0].geoRegionId,
+          adminRegionId: geoCodedLocationSample[0].adminRegionId,
+          locationWarning: geoCodedLocationSample[0].locationWarning,
+          sourcingRecords: location.sourcingRecords.map((elem: any) => {
+            return { year: elem.year, tonnage: elem.tonnage };
+          }),
+          interventionType: SOURCING_LOCATION_TYPE_BY_INTERVENTION.REPLACING,
+        };
+
+        newSourcingLocationData.push(newInterventionLocation);
+      }
     }
+
     return newSourcingLocationData;
   }
 

--- a/api/src/modules/scenario-interventions/scenario-interventions.service.ts
+++ b/api/src/modules/scenario-interventions/scenario-interventions.service.ts
@@ -371,26 +371,15 @@ export class ScenarioInterventionsService extends AppBaseService<
         );
 
       if (identicalSourcingLocationDataIndex >= 0) {
-        const joinedRecords: any = newSourcingLocationData[
-          identicalSourcingLocationDataIndex
-        ].sourcingRecords.concat(location.sourcingRecords);
-
-        const mergedRecords = joinedRecords.reduce(
-          (acc: any, sourcingRecords: { year: number; tonnage: number }) => {
-            acc[sourcingRecords.year] = {
-              year: sourcingRecords.year,
-              tonnage:
-                (acc[sourcingRecords.year]
-                  ? Number(acc[sourcingRecords.year].tonnage)
-                  : 0) + Number(sourcingRecords.tonnage),
-            };
-            return acc;
-          },
-          {},
-        );
+        const updatedSourcingRecords: SourcingRecord[] =
+          this.updateNewSupplierLocationTonnage(
+            newSourcingLocationData,
+            identicalSourcingLocationDataIndex,
+            location.sourcingRecords,
+          );
         newSourcingLocationData[
           identicalSourcingLocationDataIndex
-        ].sourcingRecords = Object.values(mergedRecords);
+        ].sourcingRecords = updatedSourcingRecords;
       } else {
         const newInterventionLocation: SourcingData = {
           materialId: location.materialId,
@@ -541,5 +530,33 @@ export class ScenarioInterventionsService extends AppBaseService<
     newScenarioIntervention.updatedById = dto.updatedById;
     await this.repository.save(newScenarioIntervention);
     return newScenarioIntervention;
+  }
+
+  updateNewSupplierLocationTonnage(
+    existingSourcingLocations: SourcingData[],
+    index: number,
+    newSourcingRecords: SourcingRecord[],
+  ): SourcingRecord[] {
+    const joinedRecords: { year: number; tonnage: number }[] =
+      existingSourcingLocations[index].sourcingRecords.concat(
+        newSourcingRecords,
+      );
+
+    const mergedRecords: { year: number; tonnage: number }[] =
+      joinedRecords.reduce(
+        (acc: any, sourcingRecords: { year: number; tonnage: number }) => {
+          acc[sourcingRecords.year] = {
+            year: sourcingRecords.year,
+            tonnage:
+              (acc[sourcingRecords.year]
+                ? Number(acc[sourcingRecords.year].tonnage)
+                : 0) + Number(sourcingRecords.tonnage),
+          };
+          return acc;
+        },
+        {},
+      );
+
+    return Object.values(mergedRecords);
   }
 }

--- a/api/src/modules/scenario-interventions/services/intervention-generator.service.ts
+++ b/api/src/modules/scenario-interventions/services/intervention-generator.service.ts
@@ -27,7 +27,7 @@ export class InterventionGeneratorService {
   async addDescendantsEntitiesForFiltering(
     dto: CreateScenarioInterventionDto,
   ): Promise<CreateScenarioInterventionDto> {
-    let dtoWithDescendants: CreateScenarioInterventionDto = { ...dto };
+    const dtoWithDescendants: CreateScenarioInterventionDto = { ...dto };
 
     dtoWithDescendants.materialIds =
       await this.materialService.getMaterialsDescendants(dto.materialIds);

--- a/api/src/modules/suppliers/dto/get-supplier-tree-with-options.dto.ts
+++ b/api/src/modules/suppliers/dto/get-supplier-tree-with-options.dto.ts
@@ -70,4 +70,9 @@ export class GetSupplierTreeWithOptions {
   )
   @Type(() => String)
   locationTypes?: LOCATION_TYPES_PARAMS[];
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsUUID(4)
+  scenarioId?: string;
 }

--- a/api/src/modules/suppliers/supplier.repository.ts
+++ b/api/src/modules/suppliers/supplier.repository.ts
@@ -5,6 +5,8 @@ import { CreateSupplierDto } from 'modules/suppliers/dto/create.supplier.dto';
 import { Logger, NotFoundException } from '@nestjs/common';
 import { SourcingLocation } from 'modules/sourcing-locations/sourcing-location.entity';
 import { GetSupplierTreeWithOptions } from 'modules/suppliers/dto/get-supplier-tree-with-options.dto';
+import { ScenarioIntervention } from 'modules/scenario-interventions/scenario-intervention.entity';
+import { Scenario } from 'modules/scenarios/scenario.entity';
 
 @EntityRepository(Supplier)
 export class SupplierRepository extends ExtendedTreeRepository<
@@ -57,6 +59,25 @@ export class SupplierRepository extends ExtendedTreeRepository<
       queryBuilder.andWhere('sl.locationType IN (:...locationTypes)', {
         locationTypes: supplierTreeOptions.locationTypes,
       });
+    }
+
+    if (supplierTreeOptions.scenarioId) {
+      queryBuilder
+        .innerJoin(
+          ScenarioIntervention,
+          'scenarioIntervention',
+          'sl.scenarioInterventionId = scenarioIntervention.id',
+        )
+        .innerJoin(
+          Scenario,
+          'scenario',
+          'scenarioIntervention.scenarioId = scenario.id',
+        )
+        .andWhere('scenario.id = :scenarioId', {
+          scenarioId: supplierTreeOptions.scenarioId,
+        });
+    } else {
+      queryBuilder.andWhere('sl.scenarioInterventionId is null');
     }
 
     const [subQuery, subQueryParams]: [string, any[]] =

--- a/api/test/utils/scenario-interventions-preconditions.ts
+++ b/api/test/utils/scenario-interventions-preconditions.ts
@@ -123,3 +123,30 @@ export async function createInterventionPreconditionsWithMultipleYearRecords(): 
 
   return scenarioInterventionPreconditions;
 }
+
+export async function createInterventionPreconditionsForSupplierChange(): Promise<ScenarioInterventionPreconditions> {
+  const scenarioInterventionPreconditions: ScenarioInterventionPreconditions =
+    await createInterventionPreconditionsWithMultipleYearRecords();
+
+  const newSourcingLocation1: SourcingLocation = await createSourcingLocation({
+    materialId: scenarioInterventionPreconditions.material1Descendant.id,
+    t1SupplierId: scenarioInterventionPreconditions.supplier2.id,
+    businessUnitId:
+      scenarioInterventionPreconditions.businessUnit1Descendant.id,
+    adminRegionId: scenarioInterventionPreconditions.adminRegion1Descendant.id,
+  });
+
+  await createSourcingRecord({
+    sourcingLocationId: newSourcingLocation1.id,
+    year: 2018,
+    tonnage: 500,
+  });
+
+  await createSourcingRecord({
+    sourcingLocationId: newSourcingLocation1.id,
+    year: 2019,
+    tonnage: 600,
+  });
+
+  return scenarioInterventionPreconditions;
+}


### PR DESCRIPTION
### General description

1. Scenario Intervention - creating new intervention of type New Supplier:

When multiple Sourcing Locations of type replacing are being created, if they have same material and business unit (geo region will be the same per default - the new supplier location), only one sourcing location will be created with sourcing record tonnages being sums of the initial records.

Example:

We are replacing 2 Sourcing Locations for new location in China(geoRegion3):
-  Cotton from supplier1 from India(geoRegion1) from business unit 'men's cloths' - tonnage: 200,  year: 2020
- Cotton from supplier2 from Australia(geoRegion2) from business unit 'men's cloths' - tonnage: 300,  year: 2020

before fix - 2 Replacing SLs would be created:
- Cotton from null from China(geoRegion3) from business unit 'men's cloths' - tonnage: 200,  year: 2020
- Cotton from null from China(geoRegion3) from business unit 'men's cloths' - tonnage: 300,  year: 2020

now they will be merged and grouped, 1 SL will be created with sum of the tonnages:
-  Cotton from null from China(geoRegion3) from business unit 'men's cloths' - tonnage: 500,  year: 2020

2. Scenario interventions - indicator records are being calculated and saved for SLs of type Cancelled as well (it is need for impact comparison)

3. Impact Table for comparing Scenario impact with actual data:
- scenarioId added to filters to find entities and smart filters (if scenarioId is sent in dto, only materials, suppliers, adminRegions present in this scenario will be shown)
- this helps to avoid empty entities in comparison Impact Table 

### Designs

### Testing instructions

Local test example:

Following POST request to api/v1/scenario-interventions with body:
```
{
  "interventionDescription": "",
  "materialIds": [
    "80d52237-bb4a-4f25-9133-cbbebaa68734"
  ],
  "startYear": 2020,
  "endYear": 2020,
  "percentage": 100,
  "supplierIds": null,
  "adminRegionIds": [
    "86b5b8ee-5354-4699-b0a5-2371800b4440"
  ],
  "scenarioId": "dc61301a-3fca-4344-9145-6b66f8114e33",
  "type": "Source from new supplier or location",
  "title": "InterventionTitle 12",
  "newLocationType": "country-of-production",
  "businessUnitIds": [
    "21bc06fa-17d2-4760-8e9f-fc04c0c03d77"
  ],

  "newLocationCountryInput": "China"
} 
```

2 SL of type CREATED_BY_INTERVENTION should be created (and 49 of type CANCELED_BY_INTERVENTION)
Impact table comparing scenario with actual data can be retrieved by passing scenarioId as param for the Impact Table enpoint (data for Cotton shall be returned)

- Apart from the added feature / bug fix, check overall performance, styling...

## Checklist before merging

- [ ] Branch name / PR includes the related Jira ticket Id.
- [ ] Tests to check core implementation / bug fix added.
- [ ] All checks in Continuous Integration workflow pass.
- [ ] Feature functionally tested by reviewer(s).
- [ ] Code reviewed by reviewer(s).
- [ ] Documentation updated (README, CHANGELOG...) (if required)
