### PR TITLE
Fix impact table performance by updating getTrees methods 

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -64,3 +64,11 @@ Fixed
 Impact years endpoint - returns years for which sourcing record volumes are not 0
 
 
+## 2022-07-11
+
+### Fixed
+
+Fixed
+Update entity methods that build trees - add option to not searh for filters descendants if the treeOptions properties already have them
+
+

--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -69,6 +69,6 @@ Impact years endpoint - returns years for which sourcing record volumes are not 
 ### Fixed
 
 Fixed
-Update entity methods that build trees - add option to not searh for filters descendants if the treeOptions properties already have them
+Update entity methods that build trees - filters descendants search moved to calling functions
 
 

--- a/api/src/modules/admin-regions/admin-regions.service.ts
+++ b/api/src/modules/admin-regions/admin-regions.service.ts
@@ -160,25 +160,29 @@ export class AdminRegionsService extends AppBaseService<
 
   async getAdminRegionTreeWithSourcingLocations(
     adminRegionTreeOptions: GetAdminRegionTreeWithOptionsDto,
+    descendantsFound?: boolean,
   ): Promise<AdminRegion[]> {
-    if (adminRegionTreeOptions.businessUnitIds) {
-      adminRegionTreeOptions.businessUnitIds =
-        await this.businessUnitService.getBusinessUnitsDescendants(
-          adminRegionTreeOptions.businessUnitIds,
-        );
+    if (!descendantsFound) {
+      if (adminRegionTreeOptions.businessUnitIds) {
+        adminRegionTreeOptions.businessUnitIds =
+          await this.businessUnitService.getBusinessUnitsDescendants(
+            adminRegionTreeOptions.businessUnitIds,
+          );
+      }
+      if (adminRegionTreeOptions.supplierIds) {
+        adminRegionTreeOptions.supplierIds =
+          await this.supplierService.getSuppliersDescendants(
+            adminRegionTreeOptions.supplierIds,
+          );
+      }
+      if (adminRegionTreeOptions.materialIds) {
+        adminRegionTreeOptions.materialIds =
+          await this.materialService.getMaterialsDescendants(
+            adminRegionTreeOptions.materialIds,
+          );
+      }
     }
-    if (adminRegionTreeOptions.supplierIds) {
-      adminRegionTreeOptions.supplierIds =
-        await this.supplierService.getSuppliersDescendants(
-          adminRegionTreeOptions.supplierIds,
-        );
-    }
-    if (adminRegionTreeOptions.materialIds) {
-      adminRegionTreeOptions.materialIds =
-        await this.materialService.getMaterialsDescendants(
-          adminRegionTreeOptions.materialIds,
-        );
-    }
+
     const adminRegionLineage: AdminRegion[] =
       await this.adminRegionRepository.getSourcingDataAdminRegionsWithAncestry(
         adminRegionTreeOptions,

--- a/api/src/modules/admin-regions/admin-regions.service.ts
+++ b/api/src/modules/admin-regions/admin-regions.service.ts
@@ -160,9 +160,18 @@ export class AdminRegionsService extends AppBaseService<
 
   async getAdminRegionTreeWithSourcingLocations(
     adminRegionTreeOptions: GetAdminRegionTreeWithOptionsDto,
-    descendantsFound?: boolean,
   ): Promise<AdminRegion[]> {
-    if (!descendantsFound) {
+    const adminRegionLineage: AdminRegion[] =
+      await this.adminRegionRepository.getSourcingDataAdminRegionsWithAncestry(
+        adminRegionTreeOptions,
+      );
+    return this.buildTree<AdminRegion>(adminRegionLineage, null);
+  }
+
+  async getTrees(
+    adminRegionTreeOptions: GetAdminRegionTreeWithOptionsDto,
+  ): Promise<AdminRegion[]> {
+    if (adminRegionTreeOptions.withSourcingLocations) {
       if (adminRegionTreeOptions.businessUnitIds) {
         adminRegionTreeOptions.businessUnitIds =
           await this.businessUnitService.getBusinessUnitsDescendants(
@@ -181,22 +190,11 @@ export class AdminRegionsService extends AppBaseService<
             adminRegionTreeOptions.materialIds,
           );
       }
-    }
-
-    const adminRegionLineage: AdminRegion[] =
-      await this.adminRegionRepository.getSourcingDataAdminRegionsWithAncestry(
-        adminRegionTreeOptions,
-      );
-    return this.buildTree<AdminRegion>(adminRegionLineage, null);
-  }
-
-  async getTrees(
-    adminRegionTreeOptions: GetAdminRegionTreeWithOptionsDto,
-  ): Promise<AdminRegion[]> {
-    if (adminRegionTreeOptions.withSourcingLocations)
       return this.getAdminRegionTreeWithSourcingLocations(
         adminRegionTreeOptions,
       );
+    }
+
     return this.findTreesWithOptions({ depth: adminRegionTreeOptions.depth });
   }
 

--- a/api/src/modules/business-units/business-units.service.ts
+++ b/api/src/modules/business-units/business-units.service.ts
@@ -93,6 +93,24 @@ export class BusinessUnitsService extends AppBaseService<
     businessUnitTreeOptions: GetBusinessUnitTreeWithOptionsDto,
   ): Promise<BusinessUnit[]> {
     //const { depth, withSourcingLocations } = treeOptions;
+    if (businessUnitTreeOptions.materialIds) {
+      businessUnitTreeOptions.materialIds =
+        await this.materialsService.getMaterialsDescendants(
+          businessUnitTreeOptions.materialIds,
+        );
+    }
+    if (businessUnitTreeOptions.supplierIds) {
+      businessUnitTreeOptions.supplierIds =
+        await this.suppliersService.getSuppliersDescendants(
+          businessUnitTreeOptions.supplierIds,
+        );
+    }
+    if (businessUnitTreeOptions.originIds) {
+      businessUnitTreeOptions.originIds =
+        await this.adminRegionService.getAdminRegionDescendants(
+          businessUnitTreeOptions.originIds,
+        );
+    }
     return this.getBusinessUnitTreeWithSourcingLocations(
       businessUnitTreeOptions,
     );
@@ -100,29 +118,7 @@ export class BusinessUnitsService extends AppBaseService<
 
   async getBusinessUnitTreeWithSourcingLocations(
     businessUnitTreeOptions: GetBusinessUnitTreeWithOptionsDto,
-    descendantsFound?: boolean,
   ): Promise<BusinessUnit[]> {
-    if (!descendantsFound) {
-      if (businessUnitTreeOptions.materialIds) {
-        businessUnitTreeOptions.materialIds =
-          await this.materialsService.getMaterialsDescendants(
-            businessUnitTreeOptions.materialIds,
-          );
-      }
-      if (businessUnitTreeOptions.supplierIds) {
-        businessUnitTreeOptions.supplierIds =
-          await this.suppliersService.getSuppliersDescendants(
-            businessUnitTreeOptions.supplierIds,
-          );
-      }
-      if (businessUnitTreeOptions.originIds) {
-        businessUnitTreeOptions.originIds =
-          await this.adminRegionService.getAdminRegionDescendants(
-            businessUnitTreeOptions.originIds,
-          );
-      }
-    }
-
     const businessUnitsLineage: BusinessUnit[] =
       await this.businessUnitRepository.getSourcingDataBusinessUnitssWithAncestry(
         businessUnitTreeOptions,

--- a/api/src/modules/business-units/business-units.service.ts
+++ b/api/src/modules/business-units/business-units.service.ts
@@ -100,25 +100,29 @@ export class BusinessUnitsService extends AppBaseService<
 
   async getBusinessUnitTreeWithSourcingLocations(
     businessUnitTreeOptions: GetBusinessUnitTreeWithOptionsDto,
+    descendantsFound?: boolean,
   ): Promise<BusinessUnit[]> {
-    if (businessUnitTreeOptions.materialIds) {
-      businessUnitTreeOptions.materialIds =
-        await this.materialsService.getMaterialsDescendants(
-          businessUnitTreeOptions.materialIds,
-        );
+    if (!descendantsFound) {
+      if (businessUnitTreeOptions.materialIds) {
+        businessUnitTreeOptions.materialIds =
+          await this.materialsService.getMaterialsDescendants(
+            businessUnitTreeOptions.materialIds,
+          );
+      }
+      if (businessUnitTreeOptions.supplierIds) {
+        businessUnitTreeOptions.supplierIds =
+          await this.suppliersService.getSuppliersDescendants(
+            businessUnitTreeOptions.supplierIds,
+          );
+      }
+      if (businessUnitTreeOptions.originIds) {
+        businessUnitTreeOptions.originIds =
+          await this.adminRegionService.getAdminRegionDescendants(
+            businessUnitTreeOptions.originIds,
+          );
+      }
     }
-    if (businessUnitTreeOptions.supplierIds) {
-      businessUnitTreeOptions.supplierIds =
-        await this.suppliersService.getSuppliersDescendants(
-          businessUnitTreeOptions.supplierIds,
-        );
-    }
-    if (businessUnitTreeOptions.originIds) {
-      businessUnitTreeOptions.originIds =
-        await this.adminRegionService.getAdminRegionDescendants(
-          businessUnitTreeOptions.originIds,
-        );
-    }
+
     const businessUnitsLineage: BusinessUnit[] =
       await this.businessUnitRepository.getSourcingDataBusinessUnitssWithAncestry(
         businessUnitTreeOptions,

--- a/api/src/modules/impact/impact.service.ts
+++ b/api/src/modules/impact/impact.service.ts
@@ -263,16 +263,19 @@ export class ImpactService {
       case GROUP_BY_VALUES.MATERIAL: {
         return this.materialsService.getMaterialsTreeWithSourcingLocations(
           treeOptions,
+          true,
         );
       }
       case GROUP_BY_VALUES.REGION: {
         return this.adminRegionsService.getAdminRegionTreeWithSourcingLocations(
           treeOptions,
+          true,
         );
       }
       case GROUP_BY_VALUES.SUPPLIER: {
         return this.suppliersService.getSuppliersWithSourcingLocations(
           treeOptions,
+          true,
         );
       }
       case GROUP_BY_VALUES.BUSINESS_UNIT:

--- a/api/src/modules/impact/impact.service.ts
+++ b/api/src/modules/impact/impact.service.ts
@@ -263,25 +263,21 @@ export class ImpactService {
       case GROUP_BY_VALUES.MATERIAL: {
         return this.materialsService.getMaterialsTreeWithSourcingLocations(
           treeOptions,
-          true,
         );
       }
       case GROUP_BY_VALUES.REGION: {
         return this.adminRegionsService.getAdminRegionTreeWithSourcingLocations(
           treeOptions,
-          true,
         );
       }
       case GROUP_BY_VALUES.SUPPLIER: {
         return this.suppliersService.getSuppliersWithSourcingLocations(
           treeOptions,
-          true,
         );
       }
       case GROUP_BY_VALUES.BUSINESS_UNIT:
         return this.businessUnitsService.getBusinessUnitTreeWithSourcingLocations(
           treeOptions,
-          true,
         );
 
       case GROUP_BY_VALUES.LOCATION_TYPE:

--- a/api/src/modules/impact/impact.service.ts
+++ b/api/src/modules/impact/impact.service.ts
@@ -280,7 +280,8 @@ export class ImpactService {
       }
       case GROUP_BY_VALUES.BUSINESS_UNIT:
         return this.businessUnitsService.getBusinessUnitTreeWithSourcingLocations(
-          {},
+          treeOptions,
+          true,
         );
 
       case GROUP_BY_VALUES.LOCATION_TYPE:

--- a/api/src/modules/materials/materials.service.ts
+++ b/api/src/modules/materials/materials.service.ts
@@ -170,9 +170,18 @@ export class MaterialsService extends AppBaseService<
 
   async getMaterialsTreeWithSourcingLocations(
     materialTreeOptions: GetMaterialTreeWithOptionsDto,
-    descendantsFound?: boolean,
   ): Promise<Material[]> {
-    if (!descendantsFound) {
+    const materialLineage: Material[] =
+      await this.materialRepository.getSourcingDataMaterialsWithAncestry(
+        materialTreeOptions,
+      );
+    return this.buildTree<Material>(materialLineage, null);
+  }
+
+  async getTrees(
+    materialTreeOptions: GetMaterialTreeWithOptionsDto,
+  ): Promise<Material[]> {
+    if (materialTreeOptions.withSourcingLocations) {
       if (materialTreeOptions.originIds) {
         materialTreeOptions.originIds =
           await this.adminRegionService.getAdminRegionDescendants(
@@ -191,20 +200,9 @@ export class MaterialsService extends AppBaseService<
             materialTreeOptions.supplierIds,
           );
       }
+      return this.getMaterialsTreeWithSourcingLocations(materialTreeOptions);
     }
 
-    const materialLineage: Material[] =
-      await this.materialRepository.getSourcingDataMaterialsWithAncestry(
-        materialTreeOptions,
-      );
-    return this.buildTree<Material>(materialLineage, null);
-  }
-
-  async getTrees(
-    materialTreeOptions: GetMaterialTreeWithOptionsDto,
-  ): Promise<Material[]> {
-    if (materialTreeOptions.withSourcingLocations)
-      return this.getMaterialsTreeWithSourcingLocations(materialTreeOptions);
     return this.findTreesWithOptions({ depth: materialTreeOptions.depth });
   }
 

--- a/api/src/modules/materials/materials.service.ts
+++ b/api/src/modules/materials/materials.service.ts
@@ -170,25 +170,29 @@ export class MaterialsService extends AppBaseService<
 
   async getMaterialsTreeWithSourcingLocations(
     materialTreeOptions: GetMaterialTreeWithOptionsDto,
+    descendantsFound?: boolean,
   ): Promise<Material[]> {
-    if (materialTreeOptions.originIds) {
-      materialTreeOptions.originIds =
-        await this.adminRegionService.getAdminRegionDescendants(
-          materialTreeOptions.originIds,
-        );
+    if (!descendantsFound) {
+      if (materialTreeOptions.originIds) {
+        materialTreeOptions.originIds =
+          await this.adminRegionService.getAdminRegionDescendants(
+            materialTreeOptions.originIds,
+          );
+      }
+      if (materialTreeOptions.businessUnitIds) {
+        materialTreeOptions.businessUnitIds =
+          await this.businessUnitsService.getBusinessUnitsDescendants(
+            materialTreeOptions.businessUnitIds,
+          );
+      }
+      if (materialTreeOptions.supplierIds) {
+        materialTreeOptions.supplierIds =
+          await this.suppliersService.getSuppliersDescendants(
+            materialTreeOptions.supplierIds,
+          );
+      }
     }
-    if (materialTreeOptions.businessUnitIds) {
-      materialTreeOptions.businessUnitIds =
-        await this.businessUnitsService.getBusinessUnitsDescendants(
-          materialTreeOptions.businessUnitIds,
-        );
-    }
-    if (materialTreeOptions.supplierIds) {
-      materialTreeOptions.supplierIds =
-        await this.suppliersService.getSuppliersDescendants(
-          materialTreeOptions.supplierIds,
-        );
-    }
+
     const materialLineage: Material[] =
       await this.materialRepository.getSourcingDataMaterialsWithAncestry(
         materialTreeOptions,

--- a/api/src/modules/suppliers/suppliers.service.ts
+++ b/api/src/modules/suppliers/suppliers.service.ts
@@ -143,25 +143,29 @@ export class SuppliersService extends AppBaseService<
 
   async getSuppliersWithSourcingLocations(
     supplierTreeOptions: GetSupplierTreeWithOptions,
+    descendantsFound?: boolean,
   ): Promise<any> {
-    if (supplierTreeOptions.originIds) {
-      supplierTreeOptions.originIds =
-        await this.adminRegionService.getAdminRegionDescendants(
-          supplierTreeOptions.originIds,
-        );
+    if (!descendantsFound) {
+      if (supplierTreeOptions.originIds) {
+        supplierTreeOptions.originIds =
+          await this.adminRegionService.getAdminRegionDescendants(
+            supplierTreeOptions.originIds,
+          );
+      }
+      if (supplierTreeOptions.businessUnitIds) {
+        supplierTreeOptions.businessUnitIds =
+          await this.businessUnitsService.getBusinessUnitsDescendants(
+            supplierTreeOptions.businessUnitIds,
+          );
+      }
+      if (supplierTreeOptions.materialIds) {
+        supplierTreeOptions.materialIds =
+          await this.materialsService.getMaterialsDescendants(
+            supplierTreeOptions.materialIds,
+          );
+      }
     }
-    if (supplierTreeOptions.businessUnitIds) {
-      supplierTreeOptions.businessUnitIds =
-        await this.businessUnitsService.getBusinessUnitsDescendants(
-          supplierTreeOptions.businessUnitIds,
-        );
-    }
-    if (supplierTreeOptions.materialIds) {
-      supplierTreeOptions.materialIds =
-        await this.materialsService.getMaterialsDescendants(
-          supplierTreeOptions.materialIds,
-        );
-    }
+
     const supplierLineage: Supplier[] =
       await this.supplierRepository.getSourcingDataSuppliersWithAncestry(
         supplierTreeOptions,

--- a/api/src/modules/suppliers/suppliers.service.ts
+++ b/api/src/modules/suppliers/suppliers.service.ts
@@ -110,8 +110,28 @@ export class SuppliersService extends AppBaseService<
   async getTrees(
     supplierTreeOptions: GetSupplierTreeWithOptions,
   ): Promise<Supplier[]> {
-    if (supplierTreeOptions.withSourcingLocations)
+    if (supplierTreeOptions.withSourcingLocations) {
+      if (supplierTreeOptions.originIds) {
+        supplierTreeOptions.originIds =
+          await this.adminRegionService.getAdminRegionDescendants(
+            supplierTreeOptions.originIds,
+          );
+      }
+      if (supplierTreeOptions.businessUnitIds) {
+        supplierTreeOptions.businessUnitIds =
+          await this.businessUnitsService.getBusinessUnitsDescendants(
+            supplierTreeOptions.businessUnitIds,
+          );
+      }
+      if (supplierTreeOptions.materialIds) {
+        supplierTreeOptions.materialIds =
+          await this.materialsService.getMaterialsDescendants(
+            supplierTreeOptions.materialIds,
+          );
+      }
       return this.getSuppliersWithSourcingLocations(supplierTreeOptions);
+    }
+
     return this.findTreesWithOptions(supplierTreeOptions.depth);
   }
 
@@ -143,29 +163,7 @@ export class SuppliersService extends AppBaseService<
 
   async getSuppliersWithSourcingLocations(
     supplierTreeOptions: GetSupplierTreeWithOptions,
-    descendantsFound?: boolean,
   ): Promise<any> {
-    if (!descendantsFound) {
-      if (supplierTreeOptions.originIds) {
-        supplierTreeOptions.originIds =
-          await this.adminRegionService.getAdminRegionDescendants(
-            supplierTreeOptions.originIds,
-          );
-      }
-      if (supplierTreeOptions.businessUnitIds) {
-        supplierTreeOptions.businessUnitIds =
-          await this.businessUnitsService.getBusinessUnitsDescendants(
-            supplierTreeOptions.businessUnitIds,
-          );
-      }
-      if (supplierTreeOptions.materialIds) {
-        supplierTreeOptions.materialIds =
-          await this.materialsService.getMaterialsDescendants(
-            supplierTreeOptions.materialIds,
-          );
-      }
-    }
-
     const supplierLineage: Supplier[] =
       await this.supplierRepository.getSourcingDataSuppliersWithAncestry(
         supplierTreeOptions,


### PR DESCRIPTION
### General description

Core entities (Material, Business Unit, Supplier, Admin Region) have methods to get those entities, that are present in Sourcing Locations in form of tree - get<Entity>TreeWithSourcingLocations(). 
Those options can accept filters (treeOptions) with ids of other entities and if such filter is received, the descendants of those filters are currently being found.

However, it is possible that there is no need to look for filters descendants as they were already searched and added to dto, before being sent to getTree() method, which leads to duplicated descendants search.

Example in Impact Service:

1. Dto with user filters is received (groupBy - material, filter - id of a large country)
2. All the filters pass through loadDescendantEntityIds() method. 
Now all the child regions of a large country are being added to initial dto to dto.originIds.
3. In order to find entities for the Impact table, trees with material names should be retrieved. Updated dto with countries children is passed to getEntityTree() method. 
4. Since case is 'group by material', all the large country's children will be passed as tree options to materialsService.getMaterialsTreeWithSourcingLocations(). Receiving them as treeOptions.originIds the method will once again search for the descendants (now not only of the original large country, but also for each and every of all its descendants previously found by loadDescendantEntityIds() method) - that is redundant and badly affecting performance..

on the other hand, when we use same get<Entity>TreeWithSourcingLocations() method for smart filters, we need them to be able to find descendant of filters.

Solution (Updated) - move the descendants search outside of get<Entity>TreeWithSourcingLocations() and make it responsibility of the function calling it.

### Designs


### Testing instructions
Currently, when we request an Impact table, groupBy material, and add several large countries as filters (f.e. China, Australia, Canada) , data load takes very long time (due to excessive repeated descendants search).

With the fix - data is loaded many times faster.

- Apart from the added feature / bug fix, check overall performance, styling...

## Checklist before merging

- [x] Branch name / PR includes the related Jira ticket Id.
- [x] Tests to check core implementation / bug fix added.
- [x] All checks in Continuous Integration workflow pass.
- [x] Feature functionally tested by reviewer(s).
- [x] Code reviewed by reviewer(s).
- [x] Documentation updated (README, CHANGELOG...) (if required)
