### PR TITLE
fixed selector for the intervention creation in the step 2

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - UI fixes in the intervention creation form [LANDGRIF-742](https://vizzuality.atlassian.net/browse/LANDGRIF-742)
 - Styles for the sort dropdown in the scenarios list [LANDGRIF-738](https://vizzuality.atlassian.net/browse/LANDGRIF-738)
 - Sort country list alphabetically and added search functionality to the input in the intervention form [LANDGRIF-776](https://vizzuality.atlassian.net/browse/LANDGRIF-776)
+- User was not able to choice an option in the selectors for intervention creation [LANDGRIF-785](https://vizzuality.atlassian.net/browse/LANDGRIF-785)
 
 ## 2022.06.27
 

--- a/client/src/containers/interventions/new/step2/supplier/component.tsx
+++ b/client/src/containers/interventions/new/step2/supplier/component.tsx
@@ -122,6 +122,7 @@ const Supplier: FC = () => {
             </Label>
             <Select
               {...register('newT1SupplierId')}
+              showSearch
               loading={isLoadingSuppliers}
               current={optionsSuppliers.find((option) => option.value === watch('newT1SupplierId'))}
               options={optionsSuppliers}
@@ -138,8 +139,9 @@ const Supplier: FC = () => {
             </Label>
             <Select
               {...register('newProducerId')}
+              showSearch
               loading={isLoadingProducers}
-              current={watch('newProducerId')}
+              current={optionsProducers.find((option) => option.value === watch('newProducerId'))}
               options={optionsProducers}
               placeholder="Select"
               onChange={(value) => handleDropdown('newProducerId', value)}
@@ -180,7 +182,7 @@ const Supplier: FC = () => {
                 showSearch
                 loading={isLoadingCountries}
                 current={optionsCountries.find(
-                  (option) => option.value === watch('newLocationCountryInput'),
+                  (option) => option.label === watch('newLocationCountryInput'),
                 )}
                 options={optionsCountries}
                 placeholder="All Countries"


### PR DESCRIPTION
### General description

Fixed an issue where the user could not choose any option in the selectors of the intervention creation form.

### Testing instructions

- Try to create an intervention
- Fill the step 1, and pass to the next step
- In step 2, ensure the selectors choice is working as expected

## Checklist before merging

- [ ] Branch name / PR includes the related Jira ticket Id.
- [ ] Tests to check core implementation / bug fix added.
- [ ] All checks in Continuous Integration workflow pass.
- [ ] Feature functionally tested by reviewer(s).
- [ ] Code reviewed by reviewer(s).
- [ ] Documentation updated (README, CHANGELOG...) (if required)
