### PR TITLE
Fix impact years endpoint

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -56,3 +56,11 @@ Impact table - fix filters when retrieving 'group by' entities for table skeleto
 Updated
 Creating Scenario Intervention can cover only 1 material, business units and admin regions filters are not obligatory
 
+## 2022-07-08
+
+### Fixed
+
+Fixed
+Impact years endpoint - returns years for which sourcing record volumes are not 0
+
+

--- a/api/src/modules/sourcing-records/sourcing-record.repository.ts
+++ b/api/src/modules/sourcing-records/sourcing-record.repository.ts
@@ -44,6 +44,7 @@ export class SourcingRecordRepository extends Repository<SourcingRecord> {
     const queryBuilder: SelectQueryBuilder<SourcingRecord> =
       this.createQueryBuilder('sr')
         .select('year')
+        .where('sr.tonnage > 0')
         .distinct(true)
         .orderBy('year', 'ASC');
 

--- a/api/test/e2e/h3-data/h3-data.spec.ts
+++ b/api/test/e2e/h3-data/h3-data.spec.ts
@@ -406,13 +406,24 @@ describe('H3-Data Module (e2e) - Get H3 data', () => {
       name: 'grandChildMaterial',
       parent: childMaterial1,
     });
+
+    // Creating 3 Sourcing Records with 0 toonage, years of those should not be included in response
     const sourcingRecord3: SourcingRecord = await createSourcingRecord({
       year: 2022,
     });
 
+    const sourcingRecord4: SourcingRecord = await createSourcingRecord({
+      year: 2019,
+      tonnage: 0,
+    });
+
+    const sourcingRecord5: SourcingRecord = await createSourcingRecord({
+      year: 2018,
+      tonnage: 0,
+    });
     await createSourcingLocation({
       material: grandChildMaterial,
-      sourcingRecords: [sourcingRecord3],
+      sourcingRecords: [sourcingRecord3, sourcingRecord4, sourcingRecord5],
     });
 
     const response4 = await request(app.getHttpServer())


### PR DESCRIPTION
### General description

Endpoint returning all available years for impact layer returns all years existing in Sourcing Records. 
Extra filter added so it returns only years for Sourcing Records with tonnage > 0.
Test precondition extended to cover the case.

### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

- Apart from the added feature / bug fix, check overall performance, styling...

Calling the endpoint with latest import should return only years 2019 and 2020

## Checklist before merging

- [x] Branch name / PR includes the related Jira ticket Id.
- [x] Tests to check core implementation / bug fix added.
- [x] All checks in Continuous Integration workflow pass.
- [x] Feature functionally tested by reviewer(s).
- [x] Code reviewed by reviewer(s).
- [x] Documentation updated (README, CHANGELOG...) (if required)
