### PR TITLE
Update validation of inputs for new Intervention

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -79,7 +79,7 @@ Fixed
 Scenario Interventions - when creating new intervention of type new supplier location, replacing SLs with identical entities relations 
 are grouped into one with tonnage accumulated
 
-## 2022-07-12
+## 2022-07-13
 
 ### Fixed
 

--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -79,3 +79,11 @@ Fixed
 Scenario Interventions - when creating new intervention of type new supplier location, replacing SLs with identical entities relations 
 are grouped into one with tonnage accumulated
 
+## 2022-07-12
+
+### Fixed
+
+Fixed
+Scenario Interventions - fix conditional validations of inputs
+
+

--- a/api/src/modules/scenario-interventions/dto/create.scenario-intervention.dto.ts
+++ b/api/src/modules/scenario-interventions/dto/create.scenario-intervention.dto.ts
@@ -10,6 +10,7 @@ import {
   IsUUID,
   MaxLength,
   MinLength,
+  Validate,
   ValidateIf,
   ValidateNested,
 } from 'class-validator';
@@ -21,6 +22,9 @@ import {
 import { IndicatorCoefficientsDto } from 'modules/indicator-coefficients/dto/indicator-coefficients.dto';
 import { Transform, Type } from 'class-transformer';
 import { transformSingleLocationType } from 'utils/transform-location-type.util';
+import { InterventionLocationAddressInputValidator } from 'modules/scenario-interventions/dto/custom-validators/address-input.custom.validator';
+import { InterventionLocationLatitudeInputValidator } from 'modules/scenario-interventions/dto/custom-validators/latitude-input.custom.validator';
+import { InterventionLocationLongitudeInputValidator } from 'modules/scenario-interventions/dto/custom-validators/longitude-input.custom.validator';
 
 export class CreateScenarioInterventionDto {
   @IsString()
@@ -204,19 +208,26 @@ export class CreateScenarioInterventionDto {
   @ApiPropertyOptional({
     description: `
     New Supplier Location address, is required for Intervention types: ${SCENARIO_INTERVENTION_TYPE.NEW_MATERIAL}, ${SCENARIO_INTERVENTION_TYPE.NEW_SUPPLIER}
-    and New Supplier Locations of types: ${LOCATION_TYPES.POINT_OF_PRODUCTION} and ${LOCATION_TYPES.AGGREGATION_POINT}.
+    and New Supplier Locations of types: ${LOCATION_TYPES.POINT_OF_PRODUCTION} and ${LOCATION_TYPES.AGGREGATION_POINT} in case no coordintaes were provided.
+    Address OR coordinates must be provided.
 
     Must be NULL for New Supplier Locations of types: ${LOCATION_TYPES.UNKNOWN} and ${LOCATION_TYPES.COUNTRY_OF_PRODUCTION}
     or if coordinates are provided for the relevant location types`,
     type: String,
     example: 'Main Street, 1',
   })
+  @ValidateIf(
+    (dto: CreateScenarioInterventionDto) =>
+      dto.type !== SCENARIO_INTERVENTION_TYPE.CHANGE_PRODUCTION_EFFICIENCY,
+  )
+  @Validate(InterventionLocationAddressInputValidator)
   newLocationAddressInput?: string;
 
   @ApiPropertyOptional({
     description: `
     New Supplier Location latitude, is required for Intervention types: ${SCENARIO_INTERVENTION_TYPE.NEW_MATERIAL}, ${SCENARIO_INTERVENTION_TYPE.NEW_SUPPLIER}
-    and New Supplier Locations of types: ${LOCATION_TYPES.POINT_OF_PRODUCTION} and ${LOCATION_TYPES.AGGREGATION_POINT}.
+    and New Supplier Locations of types: ${LOCATION_TYPES.POINT_OF_PRODUCTION} and ${LOCATION_TYPES.AGGREGATION_POINT} in case no address was provided.
+    Address OR coordinates must be provided.
 
     Must be NULL for New Supplier Locations of types: ${LOCATION_TYPES.UNKNOWN} and ${LOCATION_TYPES.COUNTRY_OF_PRODUCTION}
     or if address is provided for the relevant location types.`,
@@ -225,12 +236,18 @@ export class CreateScenarioInterventionDto {
     maximum: 90,
     example: 30.123,
   })
+  @ValidateIf(
+    (dto: CreateScenarioInterventionDto) =>
+      dto.type !== SCENARIO_INTERVENTION_TYPE.CHANGE_PRODUCTION_EFFICIENCY,
+  )
+  @Validate(InterventionLocationLatitudeInputValidator)
   newLocationLatitude?: number;
 
   @ApiPropertyOptional({
     description: `
     New Supplier Location longitude, is required for Intervention types: ${SCENARIO_INTERVENTION_TYPE.NEW_MATERIAL}, ${SCENARIO_INTERVENTION_TYPE.NEW_SUPPLIER}
-    and New Supplier Locations of types: ${LOCATION_TYPES.POINT_OF_PRODUCTION} and ${LOCATION_TYPES.AGGREGATION_POINT}.
+    and New Supplier Locations of types: ${LOCATION_TYPES.POINT_OF_PRODUCTION} and ${LOCATION_TYPES.AGGREGATION_POINT} in case no address was provided.
+    Address OR coordinates must be provided.
 
     Must be NULL for New Supplier Locations of type: ${LOCATION_TYPES.UNKNOWN} and ${LOCATION_TYPES.COUNTRY_OF_PRODUCTION}
     or if address is provided for the relevant location types.`,
@@ -239,6 +256,11 @@ export class CreateScenarioInterventionDto {
     maximum: 180,
     example: 100.123,
   })
+  @ValidateIf(
+    (dto: CreateScenarioInterventionDto) =>
+      dto.type !== SCENARIO_INTERVENTION_TYPE.CHANGE_PRODUCTION_EFFICIENCY,
+  )
+  @Validate(InterventionLocationLongitudeInputValidator)
   newLocationLongitude?: number;
 
   @ValidateIf(

--- a/api/src/modules/scenario-interventions/dto/custom-validators/address-input.custom.validator.ts
+++ b/api/src/modules/scenario-interventions/dto/custom-validators/address-input.custom.validator.ts
@@ -15,30 +15,14 @@ export class InterventionLocationAddressInputValidator
     newLocationAddressInput: string,
     args: ValidationArguments,
   ): boolean {
-    if (
-      (args.object as CreateScenarioInterventionDto).newLocationType ===
-        LOCATION_TYPES.UNKNOWN ||
-      (args.object as CreateScenarioInterventionDto).newLocationType ===
-        LOCATION_TYPES.COUNTRY_OF_PRODUCTION
-    ) {
+    const dto: CreateScenarioInterventionDto =
+      args.object as CreateScenarioInterventionDto;
+
+    if (this.addressMustBeEmpty(dto)) {
       return !newLocationAddressInput;
-    } else if (
-      ((args.object as CreateScenarioInterventionDto).newLocationType ===
-        LOCATION_TYPES.AGGREGATION_POINT ||
-        (args.object as CreateScenarioInterventionDto).newLocationType ===
-          LOCATION_TYPES.POINT_OF_PRODUCTION) &&
-      ((args.object as CreateScenarioInterventionDto).newLocationLatitude ||
-        (args.object as CreateScenarioInterventionDto).newLocationLongitude)
-    ) {
+    } else if (this.dtoAlreadyHasCoordinates(dto)) {
       return !newLocationAddressInput;
-    } else if (
-      ((args.object as CreateScenarioInterventionDto).newLocationType ===
-        LOCATION_TYPES.AGGREGATION_POINT ||
-        (args.object as CreateScenarioInterventionDto).newLocationType ===
-          LOCATION_TYPES.POINT_OF_PRODUCTION) &&
-      (!(args.object as CreateScenarioInterventionDto).newLocationLatitude ||
-        !(args.object as CreateScenarioInterventionDto).newLocationLongitude)
-    ) {
+    } else if (this.addressIsRequired(dto)) {
       return (
         typeof newLocationAddressInput === 'string' &&
         newLocationAddressInput.length > 2
@@ -48,30 +32,43 @@ export class InterventionLocationAddressInputValidator
     }
   }
   defaultMessage(args: ValidationArguments): string {
-    if (
-      (args.object as CreateScenarioInterventionDto).newLocationType ===
-        LOCATION_TYPES.UNKNOWN ||
-      (args.object as CreateScenarioInterventionDto).newLocationType ===
-        LOCATION_TYPES.COUNTRY_OF_PRODUCTION
-    ) {
+    const dto: CreateScenarioInterventionDto =
+      args.object as CreateScenarioInterventionDto;
+
+    if (this.addressMustBeEmpty(dto)) {
       return `Address must be empty for locations of type ${
-        JSON.parse(JSON.stringify(args.object)).newLocationType
+        JSON.parse(JSON.stringify(dto)).newLocationType
       }`;
-    } else if (
-      ((args.object as CreateScenarioInterventionDto).newLocationType ===
-        LOCATION_TYPES.AGGREGATION_POINT ||
-        (args.object as CreateScenarioInterventionDto).newLocationType ===
-          LOCATION_TYPES.POINT_OF_PRODUCTION) &&
-      ((args.object as CreateScenarioInterventionDto).newLocationLatitude ||
-        (args.object as CreateScenarioInterventionDto).newLocationLongitude)
-    ) {
-      return `Address input OR coordinates are required for locations of type ${
-        (args.object as CreateScenarioInterventionDto).newLocationType
-      }. Address must be empty if coordinates are provided`;
+    } else if (this.dtoAlreadyHasCoordinates(dto)) {
+      return `Address input OR coordinates are required for locations of type ${dto.newLocationType}. Address must be empty if coordinates are provided`;
     } else {
-      return `Address input or coordinates are required for locations of type ${
-        (args.object as CreateScenarioInterventionDto).newLocationType
-      }.`;
+      return `Address input or coordinates are required for locations of type ${dto.newLocationType}.`;
     }
   }
+
+  addressMustBeEmpty(dto: CreateScenarioInterventionDto): boolean {
+    return dto.newLocationType === LOCATION_TYPES.UNKNOWN ||
+      dto.newLocationType === LOCATION_TYPES.COUNTRY_OF_PRODUCTION
+      ? true
+      : false;
+  }
+
+  dtoAlreadyHasCoordinates(dto: CreateScenarioInterventionDto): boolean {
+    return (dto.newLocationType === LOCATION_TYPES.AGGREGATION_POINT ||
+      dto.newLocationType === LOCATION_TYPES.POINT_OF_PRODUCTION) &&
+      (dto.newLocationLatitude || dto.newLocationLongitude)
+      ? true
+      : false;
+  }
+
+  addressIsRequired(dto: CreateScenarioInterventionDto): boolean {
+    return (dto.newLocationType === LOCATION_TYPES.AGGREGATION_POINT ||
+      dto.newLocationType === LOCATION_TYPES.POINT_OF_PRODUCTION) &&
+      (!dto.newLocationLatitude || !dto.newLocationLongitude)
+      ? true
+      : false;
+  }
 }
+
+('Address input or coordinates are required for locations of type aggregation point. Latitude values must be min: -90, max: 90,Address input or coordinates are required for locations of type aggregation point. Longitude values must be min: -180, max: 180,New Location Country input is required for the selected intervention and location type');
+('Address input or coordinates are required for locations of type aggregation point.,Address input or coordinates are required for locations of type aggregation point. Latitude values must be min: -90, max: 90,Address input or coordinates are required for locations of type aggregation point. Longitude values must be min: -180, max: 180,New Location Country input is required for the selected intervention and location type');

--- a/api/src/modules/scenario-interventions/dto/custom-validators/address-input.custom.validator.ts
+++ b/api/src/modules/scenario-interventions/dto/custom-validators/address-input.custom.validator.ts
@@ -1,0 +1,77 @@
+import {
+  ValidationArguments,
+  ValidatorConstraint,
+  ValidatorConstraintInterface,
+} from 'class-validator';
+import { LOCATION_TYPES } from 'modules/sourcing-locations/sourcing-location.entity';
+
+import { CreateScenarioInterventionDto } from '../create.scenario-intervention.dto';
+
+@ValidatorConstraint({ name: 'newLocationAddressInput', async: false })
+export class InterventionLocationAddressInputValidator
+  implements ValidatorConstraintInterface
+{
+  validate(
+    newLocationAddressInput: string,
+    args: ValidationArguments,
+  ): boolean {
+    if (
+      (args.object as CreateScenarioInterventionDto).newLocationType ===
+        LOCATION_TYPES.UNKNOWN ||
+      (args.object as CreateScenarioInterventionDto).newLocationType ===
+        LOCATION_TYPES.COUNTRY_OF_PRODUCTION
+    ) {
+      return !newLocationAddressInput;
+    } else if (
+      ((args.object as CreateScenarioInterventionDto).newLocationType ===
+        LOCATION_TYPES.AGGREGATION_POINT ||
+        (args.object as CreateScenarioInterventionDto).newLocationType ===
+          LOCATION_TYPES.POINT_OF_PRODUCTION) &&
+      ((args.object as CreateScenarioInterventionDto).newLocationLatitude ||
+        (args.object as CreateScenarioInterventionDto).newLocationLongitude)
+    ) {
+      return !newLocationAddressInput;
+    } else if (
+      ((args.object as CreateScenarioInterventionDto).newLocationType ===
+        LOCATION_TYPES.AGGREGATION_POINT ||
+        (args.object as CreateScenarioInterventionDto).newLocationType ===
+          LOCATION_TYPES.POINT_OF_PRODUCTION) &&
+      (!(args.object as CreateScenarioInterventionDto).newLocationLatitude ||
+        !(args.object as CreateScenarioInterventionDto).newLocationLongitude)
+    ) {
+      return (
+        typeof newLocationAddressInput === 'string' &&
+        newLocationAddressInput.length > 2
+      );
+    } else {
+      return true;
+    }
+  }
+  defaultMessage(args: ValidationArguments): string {
+    if (
+      (args.object as CreateScenarioInterventionDto).newLocationType ===
+        LOCATION_TYPES.UNKNOWN ||
+      (args.object as CreateScenarioInterventionDto).newLocationType ===
+        LOCATION_TYPES.COUNTRY_OF_PRODUCTION
+    ) {
+      return `Address must be empty for locations of type ${
+        JSON.parse(JSON.stringify(args.object)).newLocationType
+      }`;
+    } else if (
+      ((args.object as CreateScenarioInterventionDto).newLocationType ===
+        LOCATION_TYPES.AGGREGATION_POINT ||
+        (args.object as CreateScenarioInterventionDto).newLocationType ===
+          LOCATION_TYPES.POINT_OF_PRODUCTION) &&
+      ((args.object as CreateScenarioInterventionDto).newLocationLatitude ||
+        (args.object as CreateScenarioInterventionDto).newLocationLongitude)
+    ) {
+      return `Address input OR coordinates are required for locations of type ${
+        (args.object as CreateScenarioInterventionDto).newLocationType
+      }. Address must be empty if coordinates are provided`;
+    } else {
+      return `Address input or coordinates are required for locations of type ${
+        (args.object as CreateScenarioInterventionDto).newLocationType
+      }.`;
+    }
+  }
+}

--- a/api/src/modules/scenario-interventions/dto/custom-validators/address-input.custom.validator.ts
+++ b/api/src/modules/scenario-interventions/dto/custom-validators/address-input.custom.validator.ts
@@ -69,6 +69,3 @@ export class InterventionLocationAddressInputValidator
       : false;
   }
 }
-
-('Address input or coordinates are required for locations of type aggregation point. Latitude values must be min: -90, max: 90,Address input or coordinates are required for locations of type aggregation point. Longitude values must be min: -180, max: 180,New Location Country input is required for the selected intervention and location type');
-('Address input or coordinates are required for locations of type aggregation point.,Address input or coordinates are required for locations of type aggregation point. Latitude values must be min: -90, max: 90,Address input or coordinates are required for locations of type aggregation point. Longitude values must be min: -180, max: 180,New Location Country input is required for the selected intervention and location type');

--- a/api/src/modules/scenario-interventions/dto/custom-validators/latitude-input.custom.validator.ts
+++ b/api/src/modules/scenario-interventions/dto/custom-validators/latitude-input.custom.validator.ts
@@ -11,64 +11,55 @@ export class InterventionLocationLatitudeInputValidator
   implements ValidatorConstraintInterface
 {
   validate(newLocationLatitude: number, args: ValidationArguments): boolean {
-    if (
-      (args.object as CreateScenarioInterventionDto).newLocationType ===
-        LOCATION_TYPES.UNKNOWN ||
-      (args.object as CreateScenarioInterventionDto).newLocationType ===
-        LOCATION_TYPES.COUNTRY_OF_PRODUCTION
-    ) {
+    const dto: CreateScenarioInterventionDto =
+      args.object as CreateScenarioInterventionDto;
+
+    if (this.coordinatesMustBeEmpty(dto)) {
       return !newLocationLatitude;
-    } else if (
-      ((args.object as CreateScenarioInterventionDto).newLocationType ===
-        LOCATION_TYPES.AGGREGATION_POINT ||
-        (args.object as CreateScenarioInterventionDto).newLocationType ===
-          LOCATION_TYPES.POINT_OF_PRODUCTION) &&
-      (args.object as CreateScenarioInterventionDto).newLocationAddressInput
-    ) {
+    } else if (this.dtoAlreadyHasAddress(dto)) {
       return !newLocationLatitude;
-    } else if (
-      ((args.object as CreateScenarioInterventionDto).newLocationType ===
-        LOCATION_TYPES.AGGREGATION_POINT ||
-        (args.object as CreateScenarioInterventionDto).newLocationType ===
-          LOCATION_TYPES.POINT_OF_PRODUCTION) &&
-      !(args.object as CreateScenarioInterventionDto).newLocationAddressInput
-    ) {
+    } else if (this.coordinateIsRequired(dto)) {
       return newLocationLatitude >= -90 && newLocationLatitude <= 90;
     } else {
       return true;
     }
   }
   defaultMessage(args: ValidationArguments): string {
-    if (
-      (args.object as CreateScenarioInterventionDto).newLocationType ===
-        LOCATION_TYPES.UNKNOWN ||
-      (args.object as CreateScenarioInterventionDto).newLocationType ===
-        LOCATION_TYPES.COUNTRY_OF_PRODUCTION
-    ) {
-      return `Coordinates must be empty for locations of type ${
-        (args.object as CreateScenarioInterventionDto).newLocationType
-      }`;
-    } else if (
-      ((args.object as CreateScenarioInterventionDto).newLocationType ===
-        LOCATION_TYPES.AGGREGATION_POINT ||
-        (args.object as CreateScenarioInterventionDto).newLocationType ===
-          LOCATION_TYPES.POINT_OF_PRODUCTION) &&
-      (args.object as CreateScenarioInterventionDto).newLocationAddressInput
-    ) {
-      return `Address input OR coordinates must be provided for locations of type ${
-        (args.object as CreateScenarioInterventionDto).newLocationType
-      }. Latitude must be empty if address is provided`;
-    } else if (
-      (args.object as CreateScenarioInterventionDto).newLocationType ===
-        LOCATION_TYPES.AGGREGATION_POINT ||
-      (args.object as CreateScenarioInterventionDto).newLocationType ===
-        LOCATION_TYPES.POINT_OF_PRODUCTION
-    ) {
+    const dto: CreateScenarioInterventionDto =
+      args.object as CreateScenarioInterventionDto;
+    if (this.coordinatesMustBeEmpty(dto)) {
+      return `Coordinates must be empty for locations of type ${dto.newLocationType}`;
+    } else if (this.dtoAlreadyHasAddress(dto)) {
+      return `Address input OR coordinates must be provided for locations of type ${dto.newLocationType}. Latitude must be empty if address is provided`;
+    } else if (this.coordinateIsRequired(dto)) {
       return `Address input or coordinates are required for locations of type ${
         (args.object as CreateScenarioInterventionDto).newLocationType
       }. Latitude values must be min: -90, max: 90`;
     } else {
       return 'Incorrect Input value for selected location type';
     }
+  }
+
+  coordinatesMustBeEmpty(dto: CreateScenarioInterventionDto): boolean {
+    return dto.newLocationType === LOCATION_TYPES.UNKNOWN ||
+      dto.newLocationType === LOCATION_TYPES.COUNTRY_OF_PRODUCTION
+      ? true
+      : false;
+  }
+
+  dtoAlreadyHasAddress(dto: CreateScenarioInterventionDto): boolean {
+    return (dto.newLocationType === LOCATION_TYPES.AGGREGATION_POINT ||
+      dto.newLocationType === LOCATION_TYPES.POINT_OF_PRODUCTION) &&
+      dto.newLocationAddressInput
+      ? true
+      : false;
+  }
+
+  coordinateIsRequired(dto: CreateScenarioInterventionDto): boolean {
+    return (dto.newLocationType === LOCATION_TYPES.AGGREGATION_POINT ||
+      dto.newLocationType === LOCATION_TYPES.POINT_OF_PRODUCTION) &&
+      !dto.newLocationAddressInput
+      ? true
+      : false;
   }
 }

--- a/api/src/modules/scenario-interventions/dto/custom-validators/latitude-input.custom.validator.ts
+++ b/api/src/modules/scenario-interventions/dto/custom-validators/latitude-input.custom.validator.ts
@@ -1,0 +1,74 @@
+import {
+  ValidationArguments,
+  ValidatorConstraint,
+  ValidatorConstraintInterface,
+} from 'class-validator';
+import { LOCATION_TYPES } from 'modules/sourcing-locations/sourcing-location.entity';
+import { CreateScenarioInterventionDto } from '../create.scenario-intervention.dto';
+
+@ValidatorConstraint({ name: 'newLocationLatitude', async: false })
+export class InterventionLocationLatitudeInputValidator
+  implements ValidatorConstraintInterface
+{
+  validate(newLocationLatitude: number, args: ValidationArguments): boolean {
+    if (
+      (args.object as CreateScenarioInterventionDto).newLocationType ===
+        LOCATION_TYPES.UNKNOWN ||
+      (args.object as CreateScenarioInterventionDto).newLocationType ===
+        LOCATION_TYPES.COUNTRY_OF_PRODUCTION
+    ) {
+      return !newLocationLatitude;
+    } else if (
+      ((args.object as CreateScenarioInterventionDto).newLocationType ===
+        LOCATION_TYPES.AGGREGATION_POINT ||
+        (args.object as CreateScenarioInterventionDto).newLocationType ===
+          LOCATION_TYPES.POINT_OF_PRODUCTION) &&
+      (args.object as CreateScenarioInterventionDto).newLocationAddressInput
+    ) {
+      return !newLocationLatitude;
+    } else if (
+      ((args.object as CreateScenarioInterventionDto).newLocationType ===
+        LOCATION_TYPES.AGGREGATION_POINT ||
+        (args.object as CreateScenarioInterventionDto).newLocationType ===
+          LOCATION_TYPES.POINT_OF_PRODUCTION) &&
+      !(args.object as CreateScenarioInterventionDto).newLocationAddressInput
+    ) {
+      return newLocationLatitude >= -90 && newLocationLatitude <= 90;
+    } else {
+      return true;
+    }
+  }
+  defaultMessage(args: ValidationArguments): string {
+    if (
+      (args.object as CreateScenarioInterventionDto).newLocationType ===
+        LOCATION_TYPES.UNKNOWN ||
+      (args.object as CreateScenarioInterventionDto).newLocationType ===
+        LOCATION_TYPES.COUNTRY_OF_PRODUCTION
+    ) {
+      return `Coordinates must be empty for locations of type ${
+        (args.object as CreateScenarioInterventionDto).newLocationType
+      }`;
+    } else if (
+      ((args.object as CreateScenarioInterventionDto).newLocationType ===
+        LOCATION_TYPES.AGGREGATION_POINT ||
+        (args.object as CreateScenarioInterventionDto).newLocationType ===
+          LOCATION_TYPES.POINT_OF_PRODUCTION) &&
+      (args.object as CreateScenarioInterventionDto).newLocationAddressInput
+    ) {
+      return `Address input OR coordinates must be provided for locations of type ${
+        (args.object as CreateScenarioInterventionDto).newLocationType
+      }. Latitude must be empty if address is provided`;
+    } else if (
+      (args.object as CreateScenarioInterventionDto).newLocationType ===
+        LOCATION_TYPES.AGGREGATION_POINT ||
+      (args.object as CreateScenarioInterventionDto).newLocationType ===
+        LOCATION_TYPES.POINT_OF_PRODUCTION
+    ) {
+      return `Address input or coordinates are required for locations of type ${
+        (args.object as CreateScenarioInterventionDto).newLocationType
+      }. Latitude values must be min: -90, max: 90`;
+    } else {
+      return 'Incorrect Input value for selected location type';
+    }
+  }
+}

--- a/api/src/modules/scenario-interventions/dto/custom-validators/longitude-input.custom.validator.ts
+++ b/api/src/modules/scenario-interventions/dto/custom-validators/longitude-input.custom.validator.ts
@@ -11,57 +11,55 @@ export class InterventionLocationLongitudeInputValidator
   implements ValidatorConstraintInterface
 {
   validate(newLocationLongitude: number, args: ValidationArguments): boolean {
-    if (
-      (args.object as CreateScenarioInterventionDto).newLocationType ===
-        LOCATION_TYPES.UNKNOWN ||
-      (args.object as CreateScenarioInterventionDto).newLocationType ===
-        LOCATION_TYPES.COUNTRY_OF_PRODUCTION
-    ) {
+    const dto: CreateScenarioInterventionDto =
+      args.object as CreateScenarioInterventionDto;
+
+    if (this.coordinatesMustBeEmpty(dto)) {
       return !newLocationLongitude;
-    } else if (
-      ((args.object as CreateScenarioInterventionDto).newLocationType ===
-        LOCATION_TYPES.AGGREGATION_POINT ||
-        (args.object as CreateScenarioInterventionDto).newLocationType ===
-          LOCATION_TYPES.POINT_OF_PRODUCTION) &&
-      (args.object as CreateScenarioInterventionDto).newLocationAddressInput
-    ) {
+    } else if (this.dtoAlreadyHasAddress(dto)) {
       return !newLocationLongitude;
-    } else if (
-      ((args.object as CreateScenarioInterventionDto).newLocationType ===
-        LOCATION_TYPES.AGGREGATION_POINT ||
-        (args.object as CreateScenarioInterventionDto).newLocationType ===
-          LOCATION_TYPES.POINT_OF_PRODUCTION) &&
-      !(args.object as CreateScenarioInterventionDto).newLocationAddressInput
-    ) {
+    } else if (this.coordinateIsRequired(dto)) {
       return newLocationLongitude >= -180 && newLocationLongitude <= 180;
     } else {
       return true;
     }
   }
   defaultMessage(args: ValidationArguments): string {
-    if (
-      (args.object as CreateScenarioInterventionDto).newLocationType ===
-        LOCATION_TYPES.UNKNOWN ||
-      (args.object as CreateScenarioInterventionDto).newLocationType ===
-        LOCATION_TYPES.COUNTRY_OF_PRODUCTION
-    ) {
-      return `Coordinates must be empty for locations of type ${
-        (args.object as CreateScenarioInterventionDto).newLocationType
-      }`;
-    } else if (
-      ((args.object as CreateScenarioInterventionDto).newLocationType ===
-        LOCATION_TYPES.AGGREGATION_POINT ||
-        (args.object as CreateScenarioInterventionDto).newLocationType ===
-          LOCATION_TYPES.POINT_OF_PRODUCTION) &&
-      (args.object as CreateScenarioInterventionDto).newLocationAddressInput
-    ) {
-      return `Address input OR coordinates must be provided for locations of type ${
-        (args.object as CreateScenarioInterventionDto).newLocationType
-      }. Latitude must be empty if address is provided`;
-    } else {
+    const dto: CreateScenarioInterventionDto =
+      args.object as CreateScenarioInterventionDto;
+    if (this.coordinatesMustBeEmpty(dto)) {
+      return `Coordinates must be empty for locations of type ${dto.newLocationType}`;
+    } else if (this.dtoAlreadyHasAddress(dto)) {
+      return `Address input OR coordinates must be provided for locations of type ${dto.newLocationType}. Longitude must be empty if address is provided`;
+    } else if (this.coordinateIsRequired(dto)) {
       return `Address input or coordinates are required for locations of type ${
         (args.object as CreateScenarioInterventionDto).newLocationType
       }. Longitude values must be min: -180, max: 180`;
+    } else {
+      return 'Incorrect Input value for selected location type';
     }
+  }
+
+  coordinatesMustBeEmpty(dto: CreateScenarioInterventionDto): boolean {
+    return dto.newLocationType === LOCATION_TYPES.UNKNOWN ||
+      dto.newLocationType === LOCATION_TYPES.COUNTRY_OF_PRODUCTION
+      ? true
+      : false;
+  }
+
+  dtoAlreadyHasAddress(dto: CreateScenarioInterventionDto): boolean {
+    return (dto.newLocationType === LOCATION_TYPES.AGGREGATION_POINT ||
+      dto.newLocationType === LOCATION_TYPES.POINT_OF_PRODUCTION) &&
+      dto.newLocationAddressInput
+      ? true
+      : false;
+  }
+
+  coordinateIsRequired(dto: CreateScenarioInterventionDto): boolean {
+    return (dto.newLocationType === LOCATION_TYPES.AGGREGATION_POINT ||
+      dto.newLocationType === LOCATION_TYPES.POINT_OF_PRODUCTION) &&
+      !dto.newLocationAddressInput
+      ? true
+      : false;
   }
 }

--- a/api/src/modules/scenario-interventions/dto/custom-validators/longitude-input.custom.validator.ts
+++ b/api/src/modules/scenario-interventions/dto/custom-validators/longitude-input.custom.validator.ts
@@ -1,0 +1,67 @@
+import {
+  ValidationArguments,
+  ValidatorConstraint,
+  ValidatorConstraintInterface,
+} from 'class-validator';
+import { LOCATION_TYPES } from 'modules/sourcing-locations/sourcing-location.entity';
+import { CreateScenarioInterventionDto } from '../create.scenario-intervention.dto';
+
+@ValidatorConstraint({ name: 'newLocationLongitude', async: false })
+export class InterventionLocationLongitudeInputValidator
+  implements ValidatorConstraintInterface
+{
+  validate(newLocationLongitude: number, args: ValidationArguments): boolean {
+    if (
+      (args.object as CreateScenarioInterventionDto).newLocationType ===
+        LOCATION_TYPES.UNKNOWN ||
+      (args.object as CreateScenarioInterventionDto).newLocationType ===
+        LOCATION_TYPES.COUNTRY_OF_PRODUCTION
+    ) {
+      return !newLocationLongitude;
+    } else if (
+      ((args.object as CreateScenarioInterventionDto).newLocationType ===
+        LOCATION_TYPES.AGGREGATION_POINT ||
+        (args.object as CreateScenarioInterventionDto).newLocationType ===
+          LOCATION_TYPES.POINT_OF_PRODUCTION) &&
+      (args.object as CreateScenarioInterventionDto).newLocationAddressInput
+    ) {
+      return !newLocationLongitude;
+    } else if (
+      ((args.object as CreateScenarioInterventionDto).newLocationType ===
+        LOCATION_TYPES.AGGREGATION_POINT ||
+        (args.object as CreateScenarioInterventionDto).newLocationType ===
+          LOCATION_TYPES.POINT_OF_PRODUCTION) &&
+      !(args.object as CreateScenarioInterventionDto).newLocationAddressInput
+    ) {
+      return newLocationLongitude >= -180 && newLocationLongitude <= 180;
+    } else {
+      return true;
+    }
+  }
+  defaultMessage(args: ValidationArguments): string {
+    if (
+      (args.object as CreateScenarioInterventionDto).newLocationType ===
+        LOCATION_TYPES.UNKNOWN ||
+      (args.object as CreateScenarioInterventionDto).newLocationType ===
+        LOCATION_TYPES.COUNTRY_OF_PRODUCTION
+    ) {
+      return `Coordinates must be empty for locations of type ${
+        (args.object as CreateScenarioInterventionDto).newLocationType
+      }`;
+    } else if (
+      ((args.object as CreateScenarioInterventionDto).newLocationType ===
+        LOCATION_TYPES.AGGREGATION_POINT ||
+        (args.object as CreateScenarioInterventionDto).newLocationType ===
+          LOCATION_TYPES.POINT_OF_PRODUCTION) &&
+      (args.object as CreateScenarioInterventionDto).newLocationAddressInput
+    ) {
+      return `Address input OR coordinates must be provided for locations of type ${
+        (args.object as CreateScenarioInterventionDto).newLocationType
+      }. Latitude must be empty if address is provided`;
+    } else {
+      return `Address input or coordinates are required for locations of type ${
+        (args.object as CreateScenarioInterventionDto).newLocationType
+      }. Longitude values must be min: -180, max: 180`;
+    }
+  }
+}

--- a/api/test/e2e/scenario-interventions/scenario-interventions.spec.ts
+++ b/api/test/e2e/scenario-interventions/scenario-interventions.spec.ts
@@ -1099,7 +1099,7 @@ describe('ScenarioInterventionsModule (e2e)', () => {
         [
           'Address input OR coordinates are required for locations of type aggregation point. Address must be empty if coordinates are provided',
           'Address input OR coordinates must be provided for locations of type aggregation point. Latitude must be empty if address is provided',
-          'Address input OR coordinates must be provided for locations of type aggregation point. Latitude must be empty if address is provided',
+          'Address input OR coordinates must be provided for locations of type aggregation point. Longitude must be empty if address is provided',
         ],
       );
     });


### PR DESCRIPTION
### General description

Add conditional custom validations for inputs new location address, longitude and latitude, depending on new intervention type and new location type

### Designs

### Testing instructions

- Apart from the added feature / bug fix, check overall performance, styling...

Validated only for Intervention types - New material and New supplier location:

For location type Unknown and Country of production - only new country input must be sent (address and coordinates must be empty)

For location type Aggregation point and Point of productions - new country is also required, address OR coordinates (longitude and latitude) must be provided - one or another, both will return error

## Checklist before merging

- [x] Branch name / PR includes the related Jira ticket Id.
- [ ] Tests to check core implementation / bug fix added.
- [x] All checks in Continuous Integration workflow pass.
- [ ] Feature functionally tested by reviewer(s).
- [ ] Code reviewed by reviewer(s).
- [x] Documentation updated (README, CHANGELOG...) (if required)
