### PR TITLE
round h3 values and recalculation of quantiles

### DIFF
--- a/api/src/modules/h3-data/strategies/risk-map.strategies.ts
+++ b/api/src/modules/h3-data/strategies/risk-map.strategies.ts
@@ -5,6 +5,7 @@ import { getManager, SelectQueryBuilder } from 'typeorm';
 import { NotFoundException } from '@nestjs/common';
 
 /**
+ * @todo update queries for computing risk map for deforestation, biodiversity, carbon and water indicators.
  * This File contains a group of helper strategy functions that generate the SQL to calculate the risk maps values for
  * each type of Indicator.
  * This is so because the formula and indicator (and potentially material) H3 Data required for calculation can be
@@ -87,7 +88,8 @@ function prepareRiskMapBiodiversitySQL(
           ` * (${calculusFactor}/0.0001) ` +
           ` * ( ("${INDICATOR_TYPES.DEFORESTATION}"."${deforestationIndicatorH3Column}" ` +
           ` * "${MATERIAL_TO_H3_TYPE.HARVEST}"."${materialH3HarvestColumn}") ` +
-          ` ) "${baseRiskMapSQLColumn}"`,
+          ` / (sum("${MATERIAL_TO_H3_TYPE.PRODUCER}"."${materialH3ProducerColumn}") ` +
+          ` over())) "${baseRiskMapSQLColumn}"`,
       )
   );
 }
@@ -132,6 +134,7 @@ function prepareRiskMapCarbonEmissionSQL(
         `"${INDICATOR_TYPES.CARBON_EMISSIONS}"."${carbonEmissionIndicatorH3Column}" ` +
           ` * ( ("${INDICATOR_TYPES.DEFORESTATION}"."${deforestationIndicatorH3Column}" ` +
           ` * "${MATERIAL_TO_H3_TYPE.HARVEST}"."${materialH3HarvestColumn}") ` +
+          ` / (sum("${MATERIAL_TO_H3_TYPE.PRODUCER}"."${materialH3ProducerColumn}") over())` +
           ` ) "${baseRiskMapSQLColumn}"`,
       )
   );
@@ -172,7 +175,8 @@ function prepareRiskMapDeforestationSQL(
       .addSelect(
         `("${INDICATOR_TYPES.DEFORESTATION}"."${deforestationIndicatorH3Column}"` +
           ` * "${MATERIAL_TO_H3_TYPE.HARVEST}"."${materialH3HarvestColumn}")` +
-          ` "${baseRiskMapSQLColumn}"`,
+          ` / sum("${MATERIAL_TO_H3_TYPE.PRODUCER}"."${materialH3ProducerColumn}")` +
+          ` over() "${baseRiskMapSQLColumn}"`,
       )
   );
 }
@@ -211,7 +215,8 @@ function prepareRiskMapWaterSQL(
       .addSelect(
         `"${INDICATOR_TYPES.UNSUSTAINABLE_WATER_USE}"."${waterIndicatorH3Column}" ` +
           ` * ${calculusFactor} ` +
-          ` "${baseRiskMapSQLColumn}"`,
+          ` / sum("${MATERIAL_TO_H3_TYPE.PRODUCER}"."${materialH3ProducerColumn}") ` +
+          ` over() "${baseRiskMapSQLColumn}"`,
       )
   );
 }

--- a/api/src/modules/h3-data/strategies/risk-map.strategies.ts
+++ b/api/src/modules/h3-data/strategies/risk-map.strategies.ts
@@ -87,8 +87,7 @@ function prepareRiskMapBiodiversitySQL(
           ` * (${calculusFactor}/0.0001) ` +
           ` * ( ("${INDICATOR_TYPES.DEFORESTATION}"."${deforestationIndicatorH3Column}" ` +
           ` * "${MATERIAL_TO_H3_TYPE.HARVEST}"."${materialH3HarvestColumn}") ` +
-          ` / (sum("${MATERIAL_TO_H3_TYPE.PRODUCER}"."${materialH3ProducerColumn}") ` +
-          ` over())) "${baseRiskMapSQLColumn}"`,
+          ` ) "${baseRiskMapSQLColumn}"`,
       )
   );
 }
@@ -133,7 +132,6 @@ function prepareRiskMapCarbonEmissionSQL(
         `"${INDICATOR_TYPES.CARBON_EMISSIONS}"."${carbonEmissionIndicatorH3Column}" ` +
           ` * ( ("${INDICATOR_TYPES.DEFORESTATION}"."${deforestationIndicatorH3Column}" ` +
           ` * "${MATERIAL_TO_H3_TYPE.HARVEST}"."${materialH3HarvestColumn}") ` +
-          ` / (sum("${MATERIAL_TO_H3_TYPE.PRODUCER}"."${materialH3ProducerColumn}") over())` +
           ` ) "${baseRiskMapSQLColumn}"`,
       )
   );
@@ -174,8 +172,7 @@ function prepareRiskMapDeforestationSQL(
       .addSelect(
         `("${INDICATOR_TYPES.DEFORESTATION}"."${deforestationIndicatorH3Column}"` +
           ` * "${MATERIAL_TO_H3_TYPE.HARVEST}"."${materialH3HarvestColumn}")` +
-          ` / sum("${MATERIAL_TO_H3_TYPE.PRODUCER}"."${materialH3ProducerColumn}")` +
-          ` over() "${baseRiskMapSQLColumn}"`,
+          ` "${baseRiskMapSQLColumn}"`,
       )
   );
 }
@@ -214,8 +211,7 @@ function prepareRiskMapWaterSQL(
       .addSelect(
         `"${INDICATOR_TYPES.UNSUSTAINABLE_WATER_USE}"."${waterIndicatorH3Column}" ` +
           ` * ${calculusFactor} ` +
-          ` / sum("${MATERIAL_TO_H3_TYPE.PRODUCER}"."${materialH3ProducerColumn}") ` +
-          ` over() "${baseRiskMapSQLColumn}"`,
+          ` "${baseRiskMapSQLColumn}"`,
       )
   );
 }

--- a/api/test/e2e/h3-data/h3-impact-map.spec.ts
+++ b/api/test/e2e/h3-data/h3-impact-map.spec.ts
@@ -115,15 +115,12 @@ describe('H3 Data Module (e2e) - Impact map', () => {
     expect(response.body.data).toEqual(
       expect.arrayContaining([
         { h: '861203a6fffffff', v: 100 },
-        { h: '861203a4fffffff', v: 223.39999999999998 },
-        { h: '861203a5fffffff', v: 123.39999999999999 },
+        { h: '861203a4fffffff', v: 223 },
+        { h: '861203a5fffffff', v: 123 },
       ]),
     );
     expect(response.body.metadata).toEqual({
-      quantiles: [
-        100, 107.80156, 115.61716, 123.39999999999999, 156.73999999999998,
-        190.14, 223.39999999999998,
-      ],
+      quantiles: [0, 107.6682, 115.3502, 123, 156.33999999999997, 189.74, 223],
       unit: 'tonnes',
       indicatorDataYear: 2020,
     });
@@ -141,16 +138,10 @@ describe('H3 Data Module (e2e) - Impact map', () => {
         });
 
       expect(response.body.data).toEqual(
-        expect.arrayContaining([
-          { h: '821207fffffffff', v: 446.79999999999995 },
-        ]),
+        expect.arrayContaining([{ h: '821207fffffffff', v: 447 }]),
       );
       expect(response.body.metadata).toEqual({
-        quantiles: [
-          446.79999999999995, 446.79999999999995, 446.79999999999995,
-          446.79999999999995, 446.79999999999995, 446.79999999999995,
-          446.79999999999995,
-        ],
+        quantiles: [0, 447, 447, 447, 447, 447, 447],
         unit: 'tonnes',
         indicatorDataYear: 2020,
       });
@@ -167,16 +158,10 @@ describe('H3 Data Module (e2e) - Impact map', () => {
         });
 
       expect(response.body.data).toEqual(
-        expect.arrayContaining([
-          { h: '841203bffffffff', v: 446.79999999999995 },
-        ]),
+        expect.arrayContaining([{ h: '841203bffffffff', v: 447 }]),
       );
       expect(response.body.metadata).toEqual({
-        quantiles: [
-          446.79999999999995, 446.79999999999995, 446.79999999999995,
-          446.79999999999995, 446.79999999999995, 446.79999999999995,
-          446.79999999999995,
-        ],
+        quantiles: [0, 447, 447, 447, 447, 447, 447],
         unit: 'tonnes',
         indicatorDataYear: 2020,
       });
@@ -195,14 +180,13 @@ describe('H3 Data Module (e2e) - Impact map', () => {
       expect(response.body.data).toEqual(
         expect.arrayContaining([
           { h: '861203a6fffffff', v: 100 },
-          { h: '861203a4fffffff', v: 223.39999999999998 },
-          { h: '861203a5fffffff', v: 123.39999999999999 },
+          { h: '861203a4fffffff', v: 223 },
+          { h: '861203a5fffffff', v: 123 },
         ]),
       );
       expect(response.body.metadata).toEqual({
         quantiles: [
-          100, 107.80156, 115.61716, 123.39999999999999, 156.73999999999998,
-          190.14, 223.39999999999998,
+          0, 107.6682, 115.3502, 123, 156.33999999999997, 189.74, 223,
         ],
         unit: 'tonnes',
         indicatorDataYear: 2020,
@@ -224,16 +208,12 @@ describe('H3 Data Module (e2e) - Impact map', () => {
 
       expect(response.body.data).toEqual(
         expect.arrayContaining([
-          { h: '861203a4fffffff', v: 123.39999999999999 },
-          { h: '861203a5fffffff', v: 123.39999999999999 },
+          { h: '861203a4fffffff', v: 123 },
+          { h: '861203a5fffffff', v: 123 },
         ]),
       );
       expect(response.body.metadata).toEqual({
-        quantiles: [
-          123.39999999999999, 123.39999999999999, 123.39999999999999,
-          123.39999999999999, 123.39999999999999, 123.39999999999999,
-          123.39999999999999,
-        ],
+        quantiles: [0, 123, 123, 123, 123, 123, 123],
         unit: 'tonnes',
         indicatorDataYear: 2020,
         materialsH3DataYears: [
@@ -264,16 +244,12 @@ describe('H3 Data Module (e2e) - Impact map', () => {
 
       expect(response.body.data).toEqual(
         expect.arrayContaining([
-          { h: '861203a4fffffff', v: 123.39999999999999 },
-          { h: '861203a5fffffff', v: 123.39999999999999 },
+          { h: '861203a4fffffff', v: 123 },
+          { h: '861203a5fffffff', v: 123 },
         ]),
       );
       expect(response.body.metadata).toEqual({
-        quantiles: [
-          123.39999999999999, 123.39999999999999, 123.39999999999999,
-          123.39999999999999, 123.39999999999999, 123.39999999999999,
-          123.39999999999999,
-        ],
+        quantiles: [0, 123, 123, 123, 123, 123, 123],
         unit: 'tonnes',
         indicatorDataYear: 2020,
       });
@@ -292,16 +268,12 @@ describe('H3 Data Module (e2e) - Impact map', () => {
 
       expect(response.body.data).toEqual(
         expect.arrayContaining([
-          { h: '861203a4fffffff', v: 123.39999999999999 },
-          { h: '861203a5fffffff', v: 123.39999999999999 },
+          { h: '861203a4fffffff', v: 123 },
+          { h: '861203a5fffffff', v: 123 },
         ]),
       );
       expect(response.body.metadata).toEqual({
-        quantiles: [
-          123.39999999999999, 123.39999999999999, 123.39999999999999,
-          123.39999999999999, 123.39999999999999, 123.39999999999999,
-          123.39999999999999,
-        ],
+        quantiles: [0, 123, 123, 123, 123, 123, 123],
         unit: 'tonnes',
         indicatorDataYear: 2020,
       });
@@ -320,16 +292,12 @@ describe('H3 Data Module (e2e) - Impact map', () => {
 
       expect(response.body.data).toEqual(
         expect.arrayContaining([
-          { h: '861203a4fffffff', v: 123.39999999999999 },
-          { h: '861203a5fffffff', v: 123.39999999999999 },
+          { h: '861203a4fffffff', v: 123 },
+          { h: '861203a5fffffff', v: 123 },
         ]),
       );
       expect(response.body.metadata).toEqual({
-        quantiles: [
-          123.39999999999999, 123.39999999999999, 123.39999999999999,
-          123.39999999999999, 123.39999999999999, 123.39999999999999,
-          123.39999999999999,
-        ],
+        quantiles: [0, 123, 123, 123, 123, 123, 123],
         unit: 'tonnes',
         indicatorDataYear: 2020,
       });
@@ -348,16 +316,12 @@ describe('H3 Data Module (e2e) - Impact map', () => {
 
       expect(response.body.data).toEqual(
         expect.arrayContaining([
-          { h: '861203a4fffffff', v: 123.39999999999999 },
-          { h: '861203a5fffffff', v: 123.39999999999999 },
+          { h: '861203a4fffffff', v: 123 },
+          { h: '861203a5fffffff', v: 123 },
         ]),
       );
       expect(response.body.metadata).toEqual({
-        quantiles: [
-          123.39999999999999, +123.39999999999999, +123.39999999999999,
-          +123.39999999999999, +123.39999999999999, +123.39999999999999,
-          +123.39999999999999,
-        ],
+        quantiles: [0, +123, +123, +123, +123, +123, +123],
         unit: 'tonnes',
         indicatorDataYear: 2020,
       });
@@ -376,16 +340,12 @@ describe('H3 Data Module (e2e) - Impact map', () => {
 
       expect(response.body.data).toEqual(
         expect.arrayContaining([
-          { h: '861203a4fffffff', v: 123.39999999999999 },
-          { h: '861203a5fffffff', v: 123.39999999999999 },
+          { h: '861203a4fffffff', v: 123 },
+          { h: '861203a5fffffff', v: 123 },
         ]),
       );
       expect(response.body.metadata).toEqual({
-        quantiles: [
-          123.39999999999999, 123.39999999999999, 123.39999999999999,
-          123.39999999999999, 123.39999999999999, 123.39999999999999,
-          123.39999999999999,
-        ],
+        quantiles: [0, 123, 123, 123, 123, 123, 123],
         unit: 'tonnes',
         indicatorDataYear: 2020,
       });

--- a/api/test/e2e/h3-data/h3-material-map.spec.ts
+++ b/api/test/e2e/h3-data/h3-material-map.spec.ts
@@ -159,7 +159,7 @@ describe('H3 Data Module (e2e) - Material map', () => {
 
     expect(responseRes1.body.metadata).toEqual({
       quantiles: [
-        430, 615.037, 800.0275, 812.5, 825.0784999999998, 1218.3635000000002,
+        0, 615.037, 800.0275, 812.5, 825.0784999999998, 1218.3635000000002,
         1610,
       ],
       unit: 'tonnes',
@@ -179,7 +179,7 @@ describe('H3 Data Module (e2e) - Material map', () => {
 
     expect(responseRes3.body.metadata).toEqual({
       quantiles: [
-        90, 200.006, 231.1110000000001, 735, 750.01, 800.1320000000001, 860,
+        0, 200.006, 231.1110000000001, 735, 750.01, 800.1320000000001, 860,
       ],
       unit: 'tonnes',
     });

--- a/api/test/e2e/h3-data/mocks/h3-risk-map-calculation-results.ts
+++ b/api/test/e2e/h3-data/mocks/h3-risk-map-calculation-results.ts
@@ -4,37 +4,10 @@
  */
 
 export const riskMapCalculationResults = {
-  waterRiskRes6Values: [
-    { h: '867400027ffffff', v: 0.000056100982603150696 },
-    { h: '86108002fffffff', v: 0.000011220196102645254 },
-    { h: '862c80007ffffff', v: 0.028050490883590462 },
-    { h: '86108001fffffff', v: 0.000056100982603150696 },
-    { h: '86740002fffffff', v: 0.000252454411264556 },
-    { h: '868c36db7ffffff', v: 0.000056100982603150696 },
-    { h: '862c80017ffffff', v: 0.08415147265077139 },
-    { h: '862c8000fffffff', v: 0.056100981767180924 },
-    { h: '8610b6d97ffffff', v: 0.000028050491301575348 },
-    { h: '861080017ffffff', v: 0.00008415147599465048 },
-    { h: '868c0001fffffff', v: 0.00011220196520630139 },
-    { h: '862c8001fffffff', v: 0.014025245441795231 },
-    { h: '861080007ffffff', v: 0.000056100982603150696 },
-    { h: '867400017ffffff', v: 0.00008415147599465048 },
-    { h: '867436d97ffffff', v: 0.000056100982603150696 },
-    { h: '868c00007ffffff', v: 0.00014025245441795232 },
-    { h: '868c00017ffffff', v: 0.00008415147599465048 },
-    { h: '867400007ffffff', v: 0.00007012622720897616 },
-    { h: '8610b6d9fffffff', v: 0.000056100982603150696 },
-    { h: '862c80027ffffff', v: 0.04207573632538569 },
-    { h: '868c0000fffffff', v: 0.00006171107960951111 },
-    { h: '861080027ffffff', v: 0.000028050491301575348 },
-  ],
+  waterRiskRes6Values: [],
 
   waterRiskRes6Quantiles: {
-    quantiles: [
-      0.000011220196102645254, 0.000056100982603150696, 0.000056100982603150696,
-      0.00007713885160181332, 0.0001122216005487495, 0.021145862552594666,
-      0.08415147265077139,
-    ],
+    quantiles: [0, null, null, null, null, null, null],
     unit: 'tonnes',
     indicatorDataYear: 2005,
     materialsH3DataYears: [
@@ -52,11 +25,7 @@ export const riskMapCalculationResults = {
   },
 
   waterRiskRes6Quantiles2020: {
-    quantiles: [
-      0.000011220196102645254, 0.000056100982603150696, 0.000056100982603150696,
-      0.00007713885160181332, 0.0001122216005487495, 0.021145862552594666,
-      0.08415147265077139,
-    ],
+    quantiles: [0, null, null, null, null, null, null],
     unit: 'tonnes',
     indicatorDataYear: 2020,
     materialsH3DataYears: [
@@ -74,11 +43,7 @@ export const riskMapCalculationResults = {
   },
 
   waterRiskRes6Quantiles2002: {
-    quantiles: [
-      0.000011220196102645254, 0.000056100982603150696, 0.000056100982603150696,
-      0.00007713885160181332, 0.0001122216005487495, 0.021145862552594666,
-      0.08415147265077139,
-    ],
+    quantiles: [0, null, null, null, null, null, null],
     unit: 'tonnes',
     indicatorDataYear: 2003,
     materialsH3DataYears: [
@@ -95,22 +60,10 @@ export const riskMapCalculationResults = {
     ],
   },
 
-  waterRiskRes3Values: [
-    { h: '831080fffffffff', v: 0.0002356241286051725 },
-    { h: '837400fffffffff', v: 0.00046283309707133334 },
-    { h: '837436fffffffff', v: 0.000056100982603150696 },
-    { h: '838c00fffffffff', v: 0.00039831697522841534 },
-    { h: '832c80fffffffff', v: 0.2244039270687237 },
-    { h: '838c36fffffffff', v: 0.000056100982603150696 },
-    { h: '8310b6fffffffff', v: 0.00008415147390472604 },
-  ],
+  waterRiskRes3Values: [],
 
   waterRiskRes3Quantiles: {
-    quantiles: [
-      0.000056100982603150696, 0.00005610659270141101, 0.00008448471374506705,
-      0.0002356241286051725, 0.0003983298784527839, 0.0009555035038090137,
-      0.2244039270687237,
-    ],
+    quantiles: [0, null, null, null, null, null, null],
     unit: 'tonnes',
     indicatorDataYear: 2005,
     materialsH3DataYears: [
@@ -128,45 +81,18 @@ export const riskMapCalculationResults = {
   },
 
   biodiversityLossRes6Values: [
-    {
-      h: '8610b6d97ffffff',
-      v: 22.598870435340256,
-    },
-    {
-      h: '861080017ffffff',
-      v: 30.508474727808377,
-    },
-    {
-      h: '861080007ffffff',
-      v: 112.99435217670128,
-    },
-    {
-      h: '867400017ffffff',
-      v: 119.49153346783037,
-    },
-    {
-      h: '867436d97ffffff',
-      v: 20.33898264674816,
-    },
-    {
-      h: '868c00007ffffff',
-      v: 169.49152573943138,
-    },
-    {
-      h: '867400007ffffff',
-      v: 5.296610179357231,
-    },
-    {
-      h: '8610b6d9fffffff',
-      v: 79.09604279840055,
-    },
+    { h: '8610b6d97ffffff', v: 23 },
+    { h: '861080017ffffff', v: 31 },
+    { h: '861080007ffffff', v: 113 },
+    { h: '867400017ffffff', v: 119 },
+    { h: '867436d97ffffff', v: 20 },
+    { h: '868c00007ffffff', v: 169 },
+    { h: '867400007ffffff', v: 5 },
+    { h: '8610b6d9fffffff', v: 79 },
   ],
 
   biodiversityLossRes6Quantiles: {
-    quantiles: [
-      5.296610179357231, 20.71615791866418, 25.2557065171803, 54.80225876310446,
-      101.70282532278931, 118.42534601795609, 169.49152573943138,
-    ],
+    quantiles: [0, 20.5007, 25.6872, 55, 101.6746, 118.0154, 169],
     unit: 'tonnes',
     indicatorDataYear: 2005,
     materialsH3DataYears: [
@@ -184,34 +110,15 @@ export const riskMapCalculationResults = {
   },
 
   biodiversityLossRes3Values: [
-    {
-      h: '8310b6fffffffff',
-      v: 101.6949132337408,
-    },
-    {
-      h: '831080fffffffff',
-      v: 143.50282690450967,
-    },
-    {
-      h: '837400fffffffff',
-      v: 124.7881436471876,
-    },
-    {
-      h: '837436fffffffff',
-      v: 20.33898264674816,
-    },
-    {
-      h: '838c00fffffffff',
-      v: 169.49152573943138,
-    },
+    { h: '831080fffffffff', v: 144 },
+    { h: '837400fffffffff', v: 125 },
+    { h: '837436fffffffff', v: 20 },
+    { h: '838c00fffffffff', v: 169 },
+    { h: '8310b6fffffffff', v: 102 },
   ],
 
   biodiversityLossRes3Quantiles: {
-    quantiles: [
-      20.33898264674816, 74.58711716215485, 109.42652677616279,
-      124.7881436471876, 137.26709444316995, 152.20384327444145,
-      169.49152573943138,
-    ],
+    quantiles: [0, +74.6776, +109.7004, +125, +137.6692, +152.37, +169],
     unit: 'tonnes',
     indicatorDataYear: 2005,
     materialsH3DataYears: [
@@ -228,47 +135,10 @@ export const riskMapCalculationResults = {
     ],
   },
 
-  carbonEmissionsRes6Values: [
-    {
-      h: '8610b6d97ffffff',
-      v: 0.002259887,
-    },
-    {
-      h: '861080017ffffff',
-      v: 0.0030508474,
-    },
-    {
-      h: '861080007ffffff',
-      v: 0.011299435,
-    },
-    {
-      h: '867400017ffffff',
-      v: 0.011949154,
-    },
-    {
-      h: '867436d97ffffff',
-      v: 0.0020338984,
-    },
-    {
-      h: '868c00007ffffff',
-      v: 0.016949153,
-    },
-    {
-      h: '867400007ffffff',
-      v: 0.000529661,
-    },
-    {
-      h: '8610b6d9fffffff',
-      v: 0.007909604,
-    },
-  ],
+  carbonEmissionsRes6Values: [],
 
   carbonEmissionsRes6Quantiles: {
-    quantiles: [
-      0.000529661, 0.0020716158851515503, 0.0025255706508411097,
-      0.005480225896462798, 0.010170282442774623, 0.011842534800060093,
-      0.016949152573943138,
-    ],
+    quantiles: [0, null, null, null, null, null, null],
     unit: 'tonnes',
     indicatorDataYear: 2005,
     materialsH3DataYears: [
@@ -285,20 +155,10 @@ export const riskMapCalculationResults = {
     ],
   },
 
-  carbonEmissionsRes3Values: [
-    { h: '831080fffffffff', v: 0.014350282 },
-    { h: '837400fffffffff', v: 0.012478814 },
-    { h: '837436fffffffff', v: 0.0020338984 },
-    { h: '838c00fffffffff', v: 0.016949153 },
-    { h: '8310b6fffffffff', v: 0.010169491 },
-  ],
+  carbonEmissionsRes3Values: [],
 
   carbonEmissionsRes3Quantiles: {
-    quantiles: [
-      0.0020338984, 0.007458711651619523, 0.010942652608826757,
-      0.012478814460337162, 0.01372670903466642, 0.015220383886992931,
-      0.016949152573943138,
-    ],
+    quantiles: [0, null, null, null, null, null, null],
     unit: 'tonnes',
     indicatorDataYear: 2005,
     materialsH3DataYears: [
@@ -316,133 +176,22 @@ export const riskMapCalculationResults = {
   },
 
   deforestationRes6Values: [
-    {
-      h: '86108002fffffff',
-      v: 0.0011220196,
-    },
-    {
-      h: '86108001fffffff',
-      v: 0.0044880784,
-    },
-    {
-      h: '861080017ffffff',
-      v: 0.0050490885,
-    },
-    {
-      h: '861080007ffffff',
-      v: 0.028050492,
-    },
-    {
-      h: '861080027ffffff',
-      v: 0.003366059,
-    },
-
-    {
-      h: '868c36db7ffffff',
-      v: 0.011220196,
-    },
-
-    {
-      h: '8610b6d97ffffff',
-      v: 0.011220196,
-    },
-    {
-      h: '8610b6d9fffffff',
-      v: 0.019635344,
-    },
-    {
-      h: '86740002fffffff',
-      v: 0.011360449,
-    },
-    {
-      h: '867400017ffffff',
-      v: 0.019775596,
-    },
-    {
-      h: '867400007ffffff',
-      v: 0.0010518935,
-    },
-    { h: '867400027ffffff', v: 0.019074334 },
-    {
-      h: '867436d97ffffff',
-      v: 0.0050490885,
-    },
-
-    {
-      h: '868c0001fffffff',
-      v: 0.0022440392,
-    },
-    {
-      h: '868c00007ffffff',
-      v: 0.016830295,
-    },
-    {
-      h: '868c00017ffffff',
-      v: 0.00084151473,
-    },
-    {
-      h: '868c0000fffffff',
-      v: 0.0049368865,
-    },
-    {
-      h: '862c8001fffffff',
-      v: 0.7012623,
-    },
-    {
-      h: '862c80027ffffff',
-      v: 6.3113604,
-    },
-    {
-      h: '862c80017ffffff',
-      v: 25.245441,
-    },
-    {
-      h: '862c8000fffffff',
-      v: 11.220197,
-    },
-    {
-      h: '862c80007ffffff',
-      v: 2.8050492,
-    },
+    { h: '862c80007ffffff', v: 3 },
+    { h: '862c80017ffffff', v: 25 },
+    { h: '862c8000fffffff', v: 11 },
+    { h: '862c8001fffffff', v: 1 },
+    { h: '862c80027ffffff', v: 6 },
   ],
 
   deforestationRes3Values: [
     {
-      h: '831080fffffffff',
-      v: 0.04207574,
-    },
-    {
-      h: '8310b6fffffffff',
-      v: 0.03085554,
-    },
-    {
-      h: '837400fffffffff',
-      v: 0.051262274,
-    },
-    {
-      h: '837436fffffffff',
-      v: 0.0050490885,
-    },
-    {
-      h: '838c00fffffffff',
-      v: 0.024852736,
-    },
-    {
-      h: '838c36fffffffff',
-      v: 0.011220196,
-    },
-    {
       h: '832c80fffffffff',
-      v: 46.28331,
+      v: 46,
     },
   ],
 
   deforestationRes6Quantiles: {
-    quantiles: [
-      0.00084151473, 0.00280583447930403, 0.005049088504165411,
-      0.0112903225235641, 0.019635442100279035, 1.7693548971354958,
-      25.245441436767578,
-    ],
+    quantiles: [0, +2.3335999999999997, +4.0044, +6, +9.334, +15.6872, +25],
     unit: 'tonnes',
     indicatorDataYear: 2005,
     materialsH3DataYears: [
@@ -460,11 +209,7 @@ export const riskMapCalculationResults = {
   },
 
   deforestationRes3Quantiles: {
-    quantiles: [
-      0.0050490885, 0.01122292276993394, 0.02486594209112227,
-      0.030855540186166763, 0.042077575618028634, 0.1529727792412136,
-      46.28330993652344,
-    ],
+    quantiles: [0, 46, 46, 46, 46, 46, 46],
     unit: 'tonnes',
     indicatorDataYear: 2005,
     materialsH3DataYears: [


### PR DESCRIPTION
### General description

This PR rounds the h,v output of the material, risk and impact layer. You can also find an update on the generation of quantiles for the three types of datasets.

As part of the updates I have also changed the queries for generating the risk maps (even though we have decided to get rid of them)

### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

_Provide minimal instructions on how to test this PR._

- Apart from the added feature / bug fix, check overall performance, styling...

## Checklist before merging

- [x] Branch name / PR includes the related Jira ticket Id.
- [x] Tests to check core implementation / bug fix added.
- [x] All checks in Continuous Integration workflow pass.
- [ ] Feature functionally tested by reviewer(s).
- [ ] Code reviewed by reviewer(s).
- [ ] Documentation updated (README, CHANGELOG...) (if required)
