### PR TITLE
Aggregation type in metadata json of contextual layers.

### DIFF
--- a/data/h3_data_importer/contextual_layers_metadata/contextual_metadata_schema.json
+++ b/data/h3_data_importer/contextual_layers_metadata/contextual_metadata_schema.json
@@ -40,7 +40,10 @@
                 },
                 "type": {
                     "type": "string",
-                    "enum": ["category", "range"],
+                    "enum": [
+                        "category",
+                        "range"
+                    ],
                     "description": "Type of the legend. if 'category', each value of the LegendItem represents a category. if 'range', the value represents the upper bound of the bin, being the Legend.min the start of the first bin."
                 },
                 "items": {
@@ -49,7 +52,14 @@
                         "$ref": "#/$defs/LegendItem"
                     }
                 }
-            }
+            },
+            "required": [
+                "name",
+                "unit",
+                "min",
+                "type",
+                "items"
+            ]
         }
     },
     "type": "object",
@@ -65,15 +75,33 @@
         "legend": {
             "$ref": "#/$defs/Legend"
         },
+        "aggType": {
+            "type": "string",
+            "enum": [
+                "sum",
+                "mean",
+                "median",
+                "min",
+                "max",
+                "mode"
+            ],
+            "description": "The aggregation type that should be used to resample the layer."
+        },
         "source": {
             "type": "string",
             "description": "The citation of the layer"
         },
-        "licence": {
+        "license": {
             "type": "string",
-            "description": "The licence of the layer"
+            "description": "The license of the layer"
         }
-    }
+    },
+    "required": [
+        "name",
+        "description",
+        "legend",
+        "aggType",
+        "source",
+        "license"
+    ]
 }
-
-

--- a/data/h3_data_importer/contextual_layers_metadata/h3_grid_aqueduct_global_metadata.json
+++ b/data/h3_data_importer/contextual_layers_metadata/h3_grid_aqueduct_global_metadata.json
@@ -2,6 +2,7 @@
     "$schema": "./contextual_metadata_schema.json",
     "name": "Baseline water stress",
     "description": "Baseline water stress measures the ratio of total water withdrawals to available renewable surface and groundwater supplies.",
+    "aggType": "mode",
     "legend": {
         "name": "Baseline water stress",
         "id": "",
@@ -42,5 +43,5 @@
         ]
     },
     "source": "Hofste, R., S. Kuzma, S. Walker, E.H. Sutanudjaja, et. al. 2019. “Aqueduct 3.0: Updated DecisionRelevant Global Water Risk Indicators.” Technical Note. Washington, DC: World Resources Institute. Available online at: https://www.wri.org/publication/aqueduct-30",
-    "licence": "Creative Commons"
+    "license": "Creative Commons"
 }

--- a/data/h3_data_importer/contextual_layers_metadata/h3_grid_hdi_global_metadata.json
+++ b/data/h3_data_importer/contextual_layers_metadata/h3_grid_hdi_global_metadata.json
@@ -2,6 +2,7 @@
     "$schema": "./contextual_metadata_schema.json",
     "name": "Human Development Index",
     "description": "The HDI is a measure of human development.",
+    "aggType": "mode",
     "legend": {
         "name": "Human Development Index (HDI)",
         "id": "",
@@ -32,5 +33,5 @@
         ]
     },
     "source": "https://hdr.undp.org/data-center/documentation-and-downloads",
-    "licence": ""
+    "license": ""
 }


### PR DESCRIPTION

Adds `aggType` property to metadata json. This property must be used to aggregate the values of the layer when resampling or converting to parent resolution.

The  possible values of the field are sum, mean, median, min, max and mode.

### General description

_Please write a description. If the PR is hard to understand, provide a quick explanation of the code._

### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

_Provide minimal instructions on how to test this PR._

- Apart from the added feature / bug fix, check overall performance, styling...

## Checklist before merging

- [ ] Branch name / PR includes the related Jira ticket Id.
- [ ] Tests to check core implementation / bug fix added.
- [ ] All checks in Continuous Integration workflow pass.
- [ ] Feature functionally tested by reviewer(s).
- [ ] Code reviewed by reviewer(s).
- [ ] Documentation updated (README, CHANGELOG...) (if required)
