### PR TITLE
Adds rounding in preprocessing for earthstat and mapspam rasters

### DIFF
--- a/data/h3_data_importer/Makefile
+++ b/data/h3_data_importer/Makefile
@@ -47,12 +47,12 @@ contextual-layers:
 # Download MapSPAM crop production
 download-mapspam-crop-production:
 	mkdir -p $(WORKDIR_MAPSPAM)
-	wget -q -O $(WORKDIR_MAPSPAM)/spam2010v2r0_global_prod.geotiff.zip https://s3.amazonaws.com/mapspam/2010/v2.0/geotiff/spam2010v2r0_global_prod.geotiff.zip
+	wget  --show-progress -q -O $(WORKDIR_MAPSPAM)/spam2010v2r0_global_prod.geotiff.zip https://s3.amazonaws.com/mapspam/2010/v2.0/geotiff/spam2010v2r0_global_prod.geotiff.zip
 
 #Download MapSPAM crop harvest area
 download-mapspam-crop-harvest:
 	mkdir -p $(WORKDIR_MAPSPAM)
-	wget -q -O $(WORKDIR_MAPSPAM)/spam2010v2r0_global_harv_area.geotiff.zip https://s3.amazonaws.com/mapspam/2010/v2.0/geotiff/spam2010v2r0_global_harv_area.geotiff.zip
+	wget  --show-progress -q -O $(WORKDIR_MAPSPAM)/spam2010v2r0_global_harv_area.geotiff.zip https://s3.amazonaws.com/mapspam/2010/v2.0/geotiff/spam2010v2r0_global_harv_area.geotiff.zip
 
 #EXTRACT DATASETS:
 # <tiff_folder>: <zipfile>
@@ -61,11 +61,16 @@ download-mapspam-crop-harvest:
 extract-mapspam-crop-production: download-mapspam-crop-production
 	mkdir -p $(WORKDIR_MAPSPAM)/spam2010v2r0_global_prod
 	unzip -u $(WORKDIR_MAPSPAM)/spam2010v2r0_global_prod.geotiff.zip *_A.tif -d $(WORKDIR_MAPSPAM)/spam2010v2r0_global_prod
+	for file in $(WORKDIR_MAPSPAM)/spam2010v2r0_global_prod/*_A.tif; do\
+		gdal_calc.py --quiet --calc="round(A, 4)" -A "$$file" --outfile="$$file";\
+	done
 
 extract-mapspam-crop-harvest: download-mapspam-crop-harvest
 	mkdir -p $(WORKDIR_MAPSPAM)/spam2010v2r0_global_ha
 	unzip -u $(WORKDIR_MAPSPAM)/spam2010v2r0_global_harv_area.geotiff.zip *_A.tif -d $(WORKDIR_MAPSPAM)/spam2010v2r0_global_ha
-
+	for file in $(WORKDIR_MAPSPAM)/spam2010v2r0_global_ha/*_A.tif; do\
+		gdal_calc.py --quiet --calc="round(A, 4)" -A "$$file" --outfile="$$file";\
+	done
 #CONVERT DATASETS:
 # <table>: <tiff_folder>
 # Convert the tiffs in the folder to h3indexes at resolution 6
@@ -84,7 +89,7 @@ convert-mapspam-crop-harvest: extract-mapspam-crop-harvest
 # Download earthstat crop production
 download-earthstat-crop-production:
 	mkdir -p $(WORKDIR_EARTHSTAT)
-	wget -q -O $(WORKDIR_EARTHSTAT)/HarvestedAreaYield175Crops_Geotiff.zip https://s3.us-east-2.amazonaws.com/earthstatdata/HarvestedAreaYield175Crops_Geotiff.zip
+	wget --show-progress -q -O $(WORKDIR_EARTHSTAT)/HarvestedAreaYield175Crops_Geotiff.zip https://s3.us-east-2.amazonaws.com/earthstatdata/HarvestedAreaYield175Crops_Geotiff.zip
 
 # Unzip to folder
 # Only extract the files that contain production. Set the no data to 0 as the mapspam datasets.
@@ -113,6 +118,7 @@ extract-earthstat-crop-production: download-earthstat-crop-production
 		table_name=`basename -s .tif "$$tiffile" | tr -d ' \t\n\r' | tr [:upper:] [:lower:]`; \
 		output_file="$(WORKDIR_EARTHSTAT)/earthstat2000_global_prod/earthstat2000_global_$${table_name}.tif";\
 		gdal_translate -a_nodata 0 -of GTiff "$${tiffile}" "$${output_file}";\
+		gdal_calc.py --quiet --calc="round(A, 4)" -A "$${output_file}" --outfile "$${output_file}";\
 		rm -f "$${tiffile}";\
 	done
 
@@ -143,6 +149,7 @@ extract-earthstat-crop-harvest: download-earthstat-crop-production
 		table_name=`basename -s .tif "$$tiffile" | tr -d ' \t\n\r' | tr [:upper:] [:lower:]`; \
 		output_file="$(WORKDIR_EARTHSTAT)/earthstat2000_global_ha/earthstat2000_global_$${table_name}.tif";\
 		gdal_translate -a_nodata 0 -of GTiff "$${tiffile}" "$${output_file}";\
+		gdal_calc.py --quiet --calc="round(A, 4)" -A "$${output_file}" --outfile "$${output_file}";\
 		rm -f "$${tiffile}";\
 	done
 

--- a/data/h3_data_importer/Makefile
+++ b/data/h3_data_importer/Makefile
@@ -62,14 +62,14 @@ extract-mapspam-crop-production: download-mapspam-crop-production
 	mkdir -p $(WORKDIR_MAPSPAM)/spam2010v2r0_global_prod
 	unzip -u $(WORKDIR_MAPSPAM)/spam2010v2r0_global_prod.geotiff.zip *_A.tif -d $(WORKDIR_MAPSPAM)/spam2010v2r0_global_prod
 	for file in $(WORKDIR_MAPSPAM)/spam2010v2r0_global_prod/*_A.tif; do\
-		gdal_calc.py --quiet --calc="round(A, 4)" -A "$$file" --outfile="$$file";\
+		gdal_calc.py --quiet --calc="numpy.round(A, 4)" -A "$$file" --outfile="$$file";\
 	done
 
 extract-mapspam-crop-harvest: download-mapspam-crop-harvest
 	mkdir -p $(WORKDIR_MAPSPAM)/spam2010v2r0_global_ha
 	unzip -u $(WORKDIR_MAPSPAM)/spam2010v2r0_global_harv_area.geotiff.zip *_A.tif -d $(WORKDIR_MAPSPAM)/spam2010v2r0_global_ha
 	for file in $(WORKDIR_MAPSPAM)/spam2010v2r0_global_ha/*_A.tif; do\
-		gdal_calc.py --quiet --calc="round(A, 4)" -A "$$file" --outfile="$$file";\
+		gdal_calc.py --quiet --calc="numpy.round(A, 4)" -A "$$file" --outfile="$$file";\
 	done
 #CONVERT DATASETS:
 # <table>: <tiff_folder>
@@ -118,7 +118,7 @@ extract-earthstat-crop-production: download-earthstat-crop-production
 		table_name=`basename -s .tif "$$tiffile" | tr -d ' \t\n\r' | tr [:upper:] [:lower:]`; \
 		output_file="$(WORKDIR_EARTHSTAT)/earthstat2000_global_prod/earthstat2000_global_$${table_name}.tif";\
 		gdal_translate -a_nodata 0 -of GTiff "$${tiffile}" "$${output_file}";\
-		gdal_calc.py --quiet --calc="round(A, 4)" -A "$${output_file}" --outfile "$${output_file}";\
+		gdal_calc.py --quiet --calc="numpy.round(A, 4)" -A "$${output_file}" --outfile "$${output_file}";\
 		rm -f "$${tiffile}";\
 	done
 
@@ -149,7 +149,7 @@ extract-earthstat-crop-harvest: download-earthstat-crop-production
 		table_name=`basename -s .tif "$$tiffile" | tr -d ' \t\n\r' | tr [:upper:] [:lower:]`; \
 		output_file="$(WORKDIR_EARTHSTAT)/earthstat2000_global_ha/earthstat2000_global_$${table_name}.tif";\
 		gdal_translate -a_nodata 0 -of GTiff "$${tiffile}" "$${output_file}";\
-		gdal_calc.py --quiet --calc="round(A, 4)" -A "$${output_file}" --outfile "$${output_file}";\
+		gdal_calc.py --quiet --calc="numpy.round(A, 4)" -A "$${output_file}" --outfile "$${output_file}";\
 		rm -f "$${tiffile}";\
 	done
 

--- a/data/notebooks/Lab/QA_round_materials.ipynb
+++ b/data/notebooks/Lab/QA_round_materials.ipynb
@@ -16,30 +16,15 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 2,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "def load_env(env_path: str) -> dict:\n",
-    "    with open(env_path) as f:\n",
-    "        env = {}\n",
-    "        for line in f:\n",
-    "            if line.startswith(\"#\"):\n",
-    "                continue\n",
-    "            env_key, _val = line.split(\"=\", 1)\n",
-    "            env_value = _val.split(\"\\n\")[0]\n",
-    "            env[env_key] = env_value\n",
-    "    return env\n",
-    "\n",
-    "\n",
-    "env_file = \".env\"\n",
-    "env = load_env(env_file)"
+    "## Rounded Earthstat"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -51,15 +36,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "80.596924\n",
-      "1.04898646e-07\n"
+      "80.5969\n",
+      "1e-04\n"
      ]
     }
    ],
@@ -70,17 +55,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
-    "with rio.open(earthstat_base_path / \"raw/HarvestedAreaYield175Crops_Geotiff/GeoTiff/abaca/abaca_Production.tif\") as r:\n",
+    "with rio.open(earthstat_base_path / \"earthstat2000_global_prod_unprocessed/abaca_Production.tif\") as r:\n",
     "    arr_no_round = r.read(1)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -99,23 +84,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "AssertionError",
-     "evalue": "\nArrays are not almost equal to 7 decimals\n\nMismatched elements: 117107 / 9331200 (1.26%)\nMax absolute difference: 5.340576e-05\nMax relative difference: 1.\n x: array([[0., 0., 0., ..., 0., 0., 0.],\n       [0., 0., 0., ..., 0., 0., 0.],\n       [0., 0., 0., ..., 0., 0., 0.],...\n y: array([[0., 0., 0., ..., 0., 0., 0.],\n       [0., 0., 0., ..., 0., 0., 0.],\n       [0., 0., 0., ..., 0., 0., 0.],...",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mAssertionError\u001b[0m                            Traceback (most recent call last)",
-      "Input \u001b[0;32mIn [7]\u001b[0m, in \u001b[0;36m<cell line: 1>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[43mnp\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mtesting\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43massert_almost_equal\u001b[49m\u001b[43m(\u001b[49m\u001b[43mnp\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mround\u001b[49m\u001b[43m(\u001b[49m\u001b[43marr_no_round\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m4\u001b[39;49m\u001b[43m)\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43marr\u001b[49m\u001b[43m)\u001b[49m\n",
-      "    \u001b[0;31m[... skipping hidden 2 frame]\u001b[0m\n",
-      "File \u001b[0;32m~/miniconda3/envs/landgriffon/lib/python3.10/site-packages/numpy/testing/_private/utils.py:844\u001b[0m, in \u001b[0;36massert_array_compare\u001b[0;34m(comparison, x, y, err_msg, verbose, header, precision, equal_nan, equal_inf)\u001b[0m\n\u001b[1;32m    840\u001b[0m         err_msg \u001b[38;5;241m+\u001b[39m\u001b[38;5;241m=\u001b[39m \u001b[38;5;124m'\u001b[39m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[38;5;124m'\u001b[39m \u001b[38;5;241m+\u001b[39m \u001b[38;5;124m'\u001b[39m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[38;5;124m'\u001b[39m\u001b[38;5;241m.\u001b[39mjoin(remarks)\n\u001b[1;32m    841\u001b[0m         msg \u001b[38;5;241m=\u001b[39m build_err_msg([ox, oy], err_msg,\n\u001b[1;32m    842\u001b[0m                             verbose\u001b[38;5;241m=\u001b[39mverbose, header\u001b[38;5;241m=\u001b[39mheader,\n\u001b[1;32m    843\u001b[0m                             names\u001b[38;5;241m=\u001b[39m(\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mx\u001b[39m\u001b[38;5;124m'\u001b[39m, \u001b[38;5;124m'\u001b[39m\u001b[38;5;124my\u001b[39m\u001b[38;5;124m'\u001b[39m), precision\u001b[38;5;241m=\u001b[39mprecision)\n\u001b[0;32m--> 844\u001b[0m         \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mAssertionError\u001b[39;00m(msg)\n\u001b[1;32m    845\u001b[0m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mValueError\u001b[39;00m:\n\u001b[1;32m    846\u001b[0m     \u001b[38;5;28;01mimport\u001b[39;00m \u001b[38;5;21;01mtraceback\u001b[39;00m\n",
-      "\u001b[0;31mAssertionError\u001b[0m: \nArrays are not almost equal to 7 decimals\n\nMismatched elements: 117107 / 9331200 (1.26%)\nMax absolute difference: 5.340576e-05\nMax relative difference: 1.\n x: array([[0., 0., 0., ..., 0., 0., 0.],\n       [0., 0., 0., ..., 0., 0., 0.],\n       [0., 0., 0., ..., 0., 0., 0.],...\n y: array([[0., 0., 0., ..., 0., 0., 0.],\n       [0., 0., 0., ..., 0., 0., 0.],\n       [0., 0., 0., ..., 0., 0., 0.],..."
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "np.testing.assert_almost_equal(np.round(arr_no_round, 4), arr)"
    ]
@@ -124,62 +95,32 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Check that all earthstat rasters are rounded"
+    "### Production"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 74,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
     "earthstat_rounded_rasters = sorted(list((earthstat_base_path / \"earthstat2000_global_prod\").glob(\"*.tif\")))\n",
-    "earthstat_unprocessed_base = earthstat_base_path / \"raw/HarvestedAreaYield175Crops_Geotiff/GeoTiff\""
+    "earthstat_unprocessed_base = earthstat_base_path / \"earthstat2000_global_prod_unprocessed\"\n",
+    "earthstat_unprocessed_rasters = sorted(list(earthstat_unprocessed_base.glob(\"*.tif\")))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 75,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "earthstat_unprocessed_rasters = []\n",
-    "for p in sorted([x for x in earthstat_unprocessed_base.iterdir() if x.is_dir()]):\n",
-    "    earthstat_unprocessed_rasters.extend(p.glob(\"*_Production.tif\"))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 80,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "PosixPath('../../h3_data_importer/data/earthstat/earthstat2000_global_prod/earthstat2000_global_abaca_production.tif')"
+       "175"
       ]
      },
-     "execution_count": 80,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "earthstat_rounded_rasters[0]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 77,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "172"
-      ]
-     },
-     "execution_count": 77,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -190,7 +131,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 78,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -199,7 +140,7 @@
        "182"
       ]
      },
-     "execution_count": 78,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -212,138 +153,109 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "lengths don't match :(, let's check who is out"
+    "Lengths don't match because in `extract-earthstat-crop-production` we create new rasters result of some map algebras"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 94,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "172"
+       "['abaca', 'agave', 'alfalfa']"
       ]
      },
-     "execution_count": 94,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "unprocessed_names = [x.name for x in earthstat_unprocessed_base.iterdir() if x.is_dir()]\n",
-    "len(unprocessed_names)"
+    "# match the names of crop from the raw rasters\n",
+    "patt = r\"(.*)\\_Production\"\n",
+    "unprocessed_names_crop = [re.match(patt, s.name).groups()[0] for s in earthstat_unprocessed_rasters]\n",
+    "unprocessed_names_crop[:3]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 114,
+   "execution_count": 11,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['abaca', 'agave', 'alfalfa']"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
+    "# match the names of crop from the rounded rasters\n",
     "patt = r\"earthstat2000\\_global\\_(.*)\\_production\"\n",
-    "rounded_names = [re.match(patt, x.name).groups()[0] for x in earthstat_rounded_rasters]"
+    "rounded_names = [re.match(patt, x.name).groups()[0] for x in earthstat_rounded_rasters]\n",
+    "rounded_names[:3]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 115,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "182"
+       "True"
       ]
      },
-     "execution_count": 115,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "len(rounded_names)"
+    "len(rounded_names) == len(earthstat_rounded_rasters)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 148,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
-    "rounded_names_to_remove = np.array([n for n in rounded_names if n not in unprocessed_names])"
+    "earthstat_rounded_rasters_clean = [\n",
+    "    earthstat_rounded_rasters[i] for i, name in enumerate(rounded_names) if name in unprocessed_names_crop\n",
+    "]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 119,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "rounded_names = np.array(rounded_names)\n",
-    "rounded_names.sort()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 134,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(172,)"
-      ]
-     },
-     "execution_count": 134,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "earthstat_rounded_rasters = np.array(earthstat_rounded_rasters)\n",
-    "earthstat_rounded_rasters.sort()\n",
-    "earthstat_rounded_rasters_clean = earthstat_rounded_rasters[~np.isin(rounded_names, rounded_names_to_remove)]\n",
-    "earthstat_rounded_rasters_clean.shape"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 146,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "ebcd5e68b42b4a2ba8a56fd54c2b01b8",
+       "model_id": "23fef5cd8f4248f6adcb34b80bb12800",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "  0%|          | 0/172 [00:00<?, ?it/s]"
+       "  0%|          | 0/175 [00:00<?, ?it/s]"
       ]
      },
      "metadata": {},
      "output_type": "display_data"
-    },
-    {
-     "ename": "AssertionError",
-     "evalue": "\nArrays are not almost equal to 4 decimals\n\nMismatched elements: 78 / 9331200 (0.000836%)\nMax absolute difference: 1.8796\nMax relative difference: 0.\n x: array([[[0., 0., 0., ..., 0., 0., 0.],\n        [0., 0., 0., ..., 0., 0., 0.],\n        [0., 0., 0., ..., 0., 0., 0.],...\n y: array([[[0., 0., 0., ..., 0., 0., 0.],\n        [0., 0., 0., ..., 0., 0., 0.],\n        [0., 0., 0., ..., 0., 0., 0.],...",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mAssertionError\u001b[0m                            Traceback (most recent call last)",
-      "Input \u001b[0;32mIn [146]\u001b[0m, in \u001b[0;36m<cell line: 5>\u001b[0;34m()\u001b[0m\n\u001b[1;32m     13\u001b[0m \u001b[38;5;66;03m# convert nans to 0s\u001b[39;00m\n\u001b[1;32m     14\u001b[0m arr_not_rounded \u001b[38;5;241m=\u001b[39m np\u001b[38;5;241m.\u001b[39mwhere(np\u001b[38;5;241m.\u001b[39misnan(arr_not_rounded), \u001b[38;5;241m0\u001b[39m, arr_not_rounded) \n\u001b[0;32m---> 15\u001b[0m \u001b[43mnp\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mtesting\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43massert_almost_equal\u001b[49m\u001b[43m(\u001b[49m\u001b[43mnp\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mround\u001b[49m\u001b[43m(\u001b[49m\u001b[43marr_not_rounded\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m4\u001b[39;49m\u001b[43m)\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43marr_rounded\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mdecimal\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;241;43m4\u001b[39;49m\u001b[43m)\u001b[49m\n",
-      "    \u001b[0;31m[... skipping hidden 2 frame]\u001b[0m\n",
-      "File \u001b[0;32m~/miniconda3/envs/landgriffon/lib/python3.10/site-packages/numpy/testing/_private/utils.py:844\u001b[0m, in \u001b[0;36massert_array_compare\u001b[0;34m(comparison, x, y, err_msg, verbose, header, precision, equal_nan, equal_inf)\u001b[0m\n\u001b[1;32m    840\u001b[0m         err_msg \u001b[38;5;241m+\u001b[39m\u001b[38;5;241m=\u001b[39m \u001b[38;5;124m'\u001b[39m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[38;5;124m'\u001b[39m \u001b[38;5;241m+\u001b[39m \u001b[38;5;124m'\u001b[39m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[38;5;124m'\u001b[39m\u001b[38;5;241m.\u001b[39mjoin(remarks)\n\u001b[1;32m    841\u001b[0m         msg \u001b[38;5;241m=\u001b[39m build_err_msg([ox, oy], err_msg,\n\u001b[1;32m    842\u001b[0m                             verbose\u001b[38;5;241m=\u001b[39mverbose, header\u001b[38;5;241m=\u001b[39mheader,\n\u001b[1;32m    843\u001b[0m                             names\u001b[38;5;241m=\u001b[39m(\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mx\u001b[39m\u001b[38;5;124m'\u001b[39m, \u001b[38;5;124m'\u001b[39m\u001b[38;5;124my\u001b[39m\u001b[38;5;124m'\u001b[39m), precision\u001b[38;5;241m=\u001b[39mprecision)\n\u001b[0;32m--> 844\u001b[0m         \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mAssertionError\u001b[39;00m(msg)\n\u001b[1;32m    845\u001b[0m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mValueError\u001b[39;00m:\n\u001b[1;32m    846\u001b[0m     \u001b[38;5;28;01mimport\u001b[39;00m \u001b[38;5;21;01mtraceback\u001b[39;00m\n",
-      "\u001b[0;31mAssertionError\u001b[0m: \nArrays are not almost equal to 4 decimals\n\nMismatched elements: 78 / 9331200 (0.000836%)\nMax absolute difference: 1.8796\nMax relative difference: 0.\n x: array([[[0., 0., 0., ..., 0., 0., 0.],\n        [0., 0., 0., ..., 0., 0., 0.],\n        [0., 0., 0., ..., 0., 0., 0.],...\n y: array([[[0., 0., 0., ..., 0., 0., 0.],\n        [0., 0., 0., ..., 0., 0., 0.],\n        [0., 0., 0., ..., 0., 0., 0.],..."
-     ]
     }
    ],
    "source": [
     "pbar = tqdm(\n",
-    "    zip(sorted(earthstat_rounded_rasters_clean.tolist()), sorted(earthstat_unprocessed_rasters)),\n",
+    "    zip(sorted(earthstat_rounded_rasters_clean), sorted(earthstat_unprocessed_rasters)),\n",
     "    total=len(earthstat_unprocessed_rasters),\n",
     ")\n",
     "\n",
@@ -361,11 +273,175 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Harvest"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "182 175\n"
+     ]
+    }
+   ],
+   "source": [
+    "earthstat_ha_rounded_rasters = sorted(list((earthstat_base_path / \"earthstat2000_global_ha\").glob(\"*.tif\")))\n",
+    "earthstat_unprocessed_base = earthstat_base_path / \"earthstat2000_global_ha_unprocessed\"\n",
+    "earthstat_unprocessed_ha_rasters = sorted(list(earthstat_unprocessed_base.glob(\"*.tif\")))\n",
+    "\n",
+    "print(len(earthstat_ha_rounded_rasters), len(earthstat_unprocessed_ha_rasters))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# reused the names from production\n",
+    "earthstat_rounded_ha_rasters_clean = [\n",
+    "    earthstat_ha_rounded_rasters[i] for i, name in enumerate(rounded_names) if name in unprocessed_names_crop\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "0e6f09b8327a41009100216b9219fc9a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/175 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "pbar = tqdm(\n",
+    "    zip(sorted(earthstat_rounded_ha_rasters_clean), sorted(earthstat_unprocessed_ha_rasters)),\n",
+    "    total=len(earthstat_unprocessed_ha_rasters),\n",
+    ")\n",
+    "\n",
+    "for rounded, not_rounded in pbar:\n",
+    "    pbar.set_description(f\"Comparing {rounded.name} and {not_rounded.name}\")\n",
+    "    with rio.open(rounded) as r_rounded:\n",
+    "        arr_rounded = r_rounded.read()\n",
+    "        # convert nans to 0s\n",
+    "        arr_rounded = np.where(np.isnan(arr_rounded), 0, arr_rounded)\n",
+    "        with rio.open(not_rounded) as r_not_rounded:\n",
+    "            arr_not_rounded = r_not_rounded.read()\n",
+    "            # convert nans to 0s\n",
+    "            arr_not_rounded = np.where(np.isnan(arr_not_rounded), 0, arr_not_rounded)\n",
+    "            np.testing.assert_almost_equal(np.round(arr_not_rounded, 4), arr_rounded, decimal=4)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Rounded Mapspam"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Production"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mapsmap_base_path = Path(\"../../h3_data_importer/data/mapspam/spam2010v2r0_global_prod/\")\n",
+    "with rio.open(mapsmap_base_path / \"spam2010V2r0_global_P_ACOF_A.tif\") as r:\n",
+    "    arr_rounded = r.read(1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "unprocessed_mapspam_base_path = Path(\"../../h3_data_importer/data/mapspam/spam2010v2r0_global_prod_unprocessed/\")\n",
+    "with rio.open(unprocessed_mapspam_base_path / \"spam2010V2r0_global_P_ACOF_A.tif\") as r:\n",
+    "    arr = r.read(1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "np.testing.assert_almost_equal(arr, arr_rounded)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rasters = mapsmap_base_path.glob(\"*.tif\")\n",
+    "for raster in rasters:\n",
+    "    with rio.open(raster) as src_rounded:\n",
+    "        arr_rounded = src_rounded.read(1)\n",
+    "    with rio.open(unprocessed_mapspam_base_path / raster.name) as src:\n",
+    "        arr = src.read(1)\n",
+    "    np.testing.assert_almost_equal(np.round(arr, 4), arr_rounded)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Harvest"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mapsmap_base_path_ha = Path(\"../../h3_data_importer/data/mapspam/spam2010v2r0_global_ha/\")\n",
+    "unprocessed_mapspam_base_path_ha = Path(\"../../h3_data_importer/data/mapspam/spam2010v2r0_global_ha_unprocessed/\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rasters = mapsmap_base_path_ha.glob(\"*.tif\")\n",
+    "for raster in rasters:\n",
+    "    with rio.open(raster) as src_rounded:\n",
+    "        arr_rounded = src_rounded.read(1)\n",
+    "    with rio.open(unprocessed_mapspam_base_path_ha / raster.name) as src:\n",
+    "        arr = src.read(1)\n",
+    "    np.testing.assert_almost_equal(np.round(arr, 4), arr_rounded)"
+   ]
   }
  ],
  "metadata": {

--- a/data/notebooks/Lab/QA_round_materials.ipynb
+++ b/data/notebooks/Lab/QA_round_materials.ipynb
@@ -1,0 +1,397 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import re\n",
+    "from pathlib import Path\n",
+    "\n",
+    "import numpy as np\n",
+    "import rasterio as rio\n",
+    "from psycopg import connect\n",
+    "from tqdm.notebook import tqdm"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def load_env(env_path: str) -> dict:\n",
+    "    with open(env_path) as f:\n",
+    "        env = {}\n",
+    "        for line in f:\n",
+    "            if line.startswith(\"#\"):\n",
+    "                continue\n",
+    "            env_key, _val = line.split(\"=\", 1)\n",
+    "            env_value = _val.split(\"\\n\")[0]\n",
+    "            env[env_key] = env_value\n",
+    "    return env\n",
+    "\n",
+    "\n",
+    "env_file = \".env\"\n",
+    "env = load_env(env_file)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# check if earthstat rasters are properly rounded\n",
+    "earthstat_base_path = Path(\"../../h3_data_importer/data/earthstat/\")\n",
+    "with rio.open(earthstat_base_path / \"earthstat2000_global_prod/earthstat2000_global_abaca_production.tif\") as r:\n",
+    "    arr = r.read(1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "80.596924\n",
+      "1.04898646e-07\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(np.max(arr))\n",
+    "print(np.min(arr[arr > 0]))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with rio.open(earthstat_base_path / \"raw/HarvestedAreaYield175Crops_Geotiff/GeoTiff/abaca/abaca_Production.tif\") as r:\n",
+    "    arr_no_round = r.read(1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "80.596924\n",
+      "1.04898646e-07\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(np.max(arr_no_round))\n",
+    "print(np.min(arr_no_round[arr_no_round > 0]))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "AssertionError",
+     "evalue": "\nArrays are not almost equal to 7 decimals\n\nMismatched elements: 117107 / 9331200 (1.26%)\nMax absolute difference: 5.340576e-05\nMax relative difference: 1.\n x: array([[0., 0., 0., ..., 0., 0., 0.],\n       [0., 0., 0., ..., 0., 0., 0.],\n       [0., 0., 0., ..., 0., 0., 0.],...\n y: array([[0., 0., 0., ..., 0., 0., 0.],\n       [0., 0., 0., ..., 0., 0., 0.],\n       [0., 0., 0., ..., 0., 0., 0.],...",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mAssertionError\u001b[0m                            Traceback (most recent call last)",
+      "Input \u001b[0;32mIn [7]\u001b[0m, in \u001b[0;36m<cell line: 1>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[43mnp\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mtesting\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43massert_almost_equal\u001b[49m\u001b[43m(\u001b[49m\u001b[43mnp\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mround\u001b[49m\u001b[43m(\u001b[49m\u001b[43marr_no_round\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m4\u001b[39;49m\u001b[43m)\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43marr\u001b[49m\u001b[43m)\u001b[49m\n",
+      "    \u001b[0;31m[... skipping hidden 2 frame]\u001b[0m\n",
+      "File \u001b[0;32m~/miniconda3/envs/landgriffon/lib/python3.10/site-packages/numpy/testing/_private/utils.py:844\u001b[0m, in \u001b[0;36massert_array_compare\u001b[0;34m(comparison, x, y, err_msg, verbose, header, precision, equal_nan, equal_inf)\u001b[0m\n\u001b[1;32m    840\u001b[0m         err_msg \u001b[38;5;241m+\u001b[39m\u001b[38;5;241m=\u001b[39m \u001b[38;5;124m'\u001b[39m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[38;5;124m'\u001b[39m \u001b[38;5;241m+\u001b[39m \u001b[38;5;124m'\u001b[39m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[38;5;124m'\u001b[39m\u001b[38;5;241m.\u001b[39mjoin(remarks)\n\u001b[1;32m    841\u001b[0m         msg \u001b[38;5;241m=\u001b[39m build_err_msg([ox, oy], err_msg,\n\u001b[1;32m    842\u001b[0m                             verbose\u001b[38;5;241m=\u001b[39mverbose, header\u001b[38;5;241m=\u001b[39mheader,\n\u001b[1;32m    843\u001b[0m                             names\u001b[38;5;241m=\u001b[39m(\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mx\u001b[39m\u001b[38;5;124m'\u001b[39m, \u001b[38;5;124m'\u001b[39m\u001b[38;5;124my\u001b[39m\u001b[38;5;124m'\u001b[39m), precision\u001b[38;5;241m=\u001b[39mprecision)\n\u001b[0;32m--> 844\u001b[0m         \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mAssertionError\u001b[39;00m(msg)\n\u001b[1;32m    845\u001b[0m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mValueError\u001b[39;00m:\n\u001b[1;32m    846\u001b[0m     \u001b[38;5;28;01mimport\u001b[39;00m \u001b[38;5;21;01mtraceback\u001b[39;00m\n",
+      "\u001b[0;31mAssertionError\u001b[0m: \nArrays are not almost equal to 7 decimals\n\nMismatched elements: 117107 / 9331200 (1.26%)\nMax absolute difference: 5.340576e-05\nMax relative difference: 1.\n x: array([[0., 0., 0., ..., 0., 0., 0.],\n       [0., 0., 0., ..., 0., 0., 0.],\n       [0., 0., 0., ..., 0., 0., 0.],...\n y: array([[0., 0., 0., ..., 0., 0., 0.],\n       [0., 0., 0., ..., 0., 0., 0.],\n       [0., 0., 0., ..., 0., 0., 0.],..."
+     ]
+    }
+   ],
+   "source": [
+    "np.testing.assert_almost_equal(np.round(arr_no_round, 4), arr)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Check that all earthstat rasters are rounded"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 74,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "earthstat_rounded_rasters = sorted(list((earthstat_base_path / \"earthstat2000_global_prod\").glob(\"*.tif\")))\n",
+    "earthstat_unprocessed_base = earthstat_base_path / \"raw/HarvestedAreaYield175Crops_Geotiff/GeoTiff\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 75,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "earthstat_unprocessed_rasters = []\n",
+    "for p in sorted([x for x in earthstat_unprocessed_base.iterdir() if x.is_dir()]):\n",
+    "    earthstat_unprocessed_rasters.extend(p.glob(\"*_Production.tif\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 80,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "PosixPath('../../h3_data_importer/data/earthstat/earthstat2000_global_prod/earthstat2000_global_abaca_production.tif')"
+      ]
+     },
+     "execution_count": 80,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "earthstat_rounded_rasters[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 77,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "172"
+      ]
+     },
+     "execution_count": 77,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(earthstat_unprocessed_rasters)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 78,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "182"
+      ]
+     },
+     "execution_count": 78,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(earthstat_rounded_rasters)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "lengths don't match :(, let's check who is out"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 94,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "172"
+      ]
+     },
+     "execution_count": 94,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "unprocessed_names = [x.name for x in earthstat_unprocessed_base.iterdir() if x.is_dir()]\n",
+    "len(unprocessed_names)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 114,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "patt = r\"earthstat2000\\_global\\_(.*)\\_production\"\n",
+    "rounded_names = [re.match(patt, x.name).groups()[0] for x in earthstat_rounded_rasters]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 115,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "182"
+      ]
+     },
+     "execution_count": 115,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(rounded_names)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 148,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rounded_names_to_remove = np.array([n for n in rounded_names if n not in unprocessed_names])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 119,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rounded_names = np.array(rounded_names)\n",
+    "rounded_names.sort()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 134,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(172,)"
+      ]
+     },
+     "execution_count": 134,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "earthstat_rounded_rasters = np.array(earthstat_rounded_rasters)\n",
+    "earthstat_rounded_rasters.sort()\n",
+    "earthstat_rounded_rasters_clean = earthstat_rounded_rasters[~np.isin(rounded_names, rounded_names_to_remove)]\n",
+    "earthstat_rounded_rasters_clean.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 146,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ebcd5e68b42b4a2ba8a56fd54c2b01b8",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/172 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "ename": "AssertionError",
+     "evalue": "\nArrays are not almost equal to 4 decimals\n\nMismatched elements: 78 / 9331200 (0.000836%)\nMax absolute difference: 1.8796\nMax relative difference: 0.\n x: array([[[0., 0., 0., ..., 0., 0., 0.],\n        [0., 0., 0., ..., 0., 0., 0.],\n        [0., 0., 0., ..., 0., 0., 0.],...\n y: array([[[0., 0., 0., ..., 0., 0., 0.],\n        [0., 0., 0., ..., 0., 0., 0.],\n        [0., 0., 0., ..., 0., 0., 0.],...",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mAssertionError\u001b[0m                            Traceback (most recent call last)",
+      "Input \u001b[0;32mIn [146]\u001b[0m, in \u001b[0;36m<cell line: 5>\u001b[0;34m()\u001b[0m\n\u001b[1;32m     13\u001b[0m \u001b[38;5;66;03m# convert nans to 0s\u001b[39;00m\n\u001b[1;32m     14\u001b[0m arr_not_rounded \u001b[38;5;241m=\u001b[39m np\u001b[38;5;241m.\u001b[39mwhere(np\u001b[38;5;241m.\u001b[39misnan(arr_not_rounded), \u001b[38;5;241m0\u001b[39m, arr_not_rounded) \n\u001b[0;32m---> 15\u001b[0m \u001b[43mnp\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mtesting\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43massert_almost_equal\u001b[49m\u001b[43m(\u001b[49m\u001b[43mnp\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mround\u001b[49m\u001b[43m(\u001b[49m\u001b[43marr_not_rounded\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m4\u001b[39;49m\u001b[43m)\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43marr_rounded\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mdecimal\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;241;43m4\u001b[39;49m\u001b[43m)\u001b[49m\n",
+      "    \u001b[0;31m[... skipping hidden 2 frame]\u001b[0m\n",
+      "File \u001b[0;32m~/miniconda3/envs/landgriffon/lib/python3.10/site-packages/numpy/testing/_private/utils.py:844\u001b[0m, in \u001b[0;36massert_array_compare\u001b[0;34m(comparison, x, y, err_msg, verbose, header, precision, equal_nan, equal_inf)\u001b[0m\n\u001b[1;32m    840\u001b[0m         err_msg \u001b[38;5;241m+\u001b[39m\u001b[38;5;241m=\u001b[39m \u001b[38;5;124m'\u001b[39m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[38;5;124m'\u001b[39m \u001b[38;5;241m+\u001b[39m \u001b[38;5;124m'\u001b[39m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[38;5;124m'\u001b[39m\u001b[38;5;241m.\u001b[39mjoin(remarks)\n\u001b[1;32m    841\u001b[0m         msg \u001b[38;5;241m=\u001b[39m build_err_msg([ox, oy], err_msg,\n\u001b[1;32m    842\u001b[0m                             verbose\u001b[38;5;241m=\u001b[39mverbose, header\u001b[38;5;241m=\u001b[39mheader,\n\u001b[1;32m    843\u001b[0m                             names\u001b[38;5;241m=\u001b[39m(\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mx\u001b[39m\u001b[38;5;124m'\u001b[39m, \u001b[38;5;124m'\u001b[39m\u001b[38;5;124my\u001b[39m\u001b[38;5;124m'\u001b[39m), precision\u001b[38;5;241m=\u001b[39mprecision)\n\u001b[0;32m--> 844\u001b[0m         \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mAssertionError\u001b[39;00m(msg)\n\u001b[1;32m    845\u001b[0m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mValueError\u001b[39;00m:\n\u001b[1;32m    846\u001b[0m     \u001b[38;5;28;01mimport\u001b[39;00m \u001b[38;5;21;01mtraceback\u001b[39;00m\n",
+      "\u001b[0;31mAssertionError\u001b[0m: \nArrays are not almost equal to 4 decimals\n\nMismatched elements: 78 / 9331200 (0.000836%)\nMax absolute difference: 1.8796\nMax relative difference: 0.\n x: array([[[0., 0., 0., ..., 0., 0., 0.],\n        [0., 0., 0., ..., 0., 0., 0.],\n        [0., 0., 0., ..., 0., 0., 0.],...\n y: array([[[0., 0., 0., ..., 0., 0., 0.],\n        [0., 0., 0., ..., 0., 0., 0.],\n        [0., 0., 0., ..., 0., 0., 0.],..."
+     ]
+    }
+   ],
+   "source": [
+    "pbar = tqdm(\n",
+    "    zip(sorted(earthstat_rounded_rasters_clean.tolist()), sorted(earthstat_unprocessed_rasters)),\n",
+    "    total=len(earthstat_unprocessed_rasters),\n",
+    ")\n",
+    "\n",
+    "for rounded, not_rounded in pbar:\n",
+    "    pbar.set_description(f\"Comparing {rounded.name} and {not_rounded.name}\")\n",
+    "    with rio.open(rounded) as r_rounded:\n",
+    "        arr_rounded = r_rounded.read()\n",
+    "        # convert nans to 0s\n",
+    "        arr_rounded = np.where(np.isnan(arr_rounded), 0, arr_rounded)\n",
+    "        with rio.open(not_rounded) as r_not_rounded:\n",
+    "            arr_not_rounded = r_not_rounded.read()\n",
+    "            # convert nans to 0s\n",
+    "            arr_not_rounded = np.where(np.isnan(arr_not_rounded), 0, arr_not_rounded)\n",
+    "            np.testing.assert_almost_equal(np.round(arr_not_rounded, 4), arr_rounded, decimal=4)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.4"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "6addb0d07f699a9d710e5c02e8d45032a9b3661e89b54ef82f51d0b80542df0d"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
### General description

Rounds the earthstat and mapspam crop rasters to 4 decimal places to avoid overflowing issues when operating with the values since the raw rasters contain incredible small values.

### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

_Provide minimal instructions on how to test this PR._

- Apart from the added feature / bug fix, check overall performance, styling...

## Checklist before merging

- [ ] Branch name / PR includes the related Jira ticket Id.
- [ ] Tests to check core implementation / bug fix added.
- [ ] All checks in Continuous Integration workflow pass.
- [ ] Feature functionally tested by reviewer(s).
- [ ] Code reviewed by reviewer(s).
- [ ] Documentation updated (README, CHANGELOG...) (if required)
