### PR TITLE
Fix rounding issue in impact map 

### DIFF
--- a/api/src/modules/h3-data/h3-data.repository.ts
+++ b/api/src/modules/h3-data/h3-data.repository.ts
@@ -231,7 +231,7 @@ export class H3DataRepository extends Repository<H3Data> {
     const withDynamicResolution: SelectQueryBuilder<any> = getManager()
       .createQueryBuilder()
       .addSelect(`h3_to_parent(q.h3index, ${resolution})`, `h`)
-      .addSelect(`round(sum(sum))`, `v`)
+      .addSelect(`round(sum(sum)::numeric, 2)`, `v`)
       .from(`( ${selectQueryBuilder.getSql()} )`, `q`)
       .groupBy('h');
 

--- a/api/test/e2e/h3-data/h3-impact-map.spec.ts
+++ b/api/test/e2e/h3-data/h3-impact-map.spec.ts
@@ -114,13 +114,13 @@ describe('H3 Data Module (e2e) - Impact map', () => {
 
     expect(response.body.data).toEqual(
       expect.arrayContaining([
-        { h: '861203a6fffffff', v: 100 },
-        { h: '861203a4fffffff', v: 223 },
-        { h: '861203a5fffffff', v: 123 },
+        { h: '861203a6fffffff', v: '100.00' },
+        { h: '861203a5fffffff', v: '123.40' },
+        { h: '861203a4fffffff', v: '223.40' },
       ]),
     );
     expect(response.body.metadata).toEqual({
-      quantiles: [0, 107.6682, 115.3502, 123, 156.33999999999997, 189.74, 223],
+      quantiles: [0, +107.80156, +115.61716, +123.4, +156.74, +190.14, +223.4],
       unit: 'tonnes',
       indicatorDataYear: 2020,
     });
@@ -138,10 +138,10 @@ describe('H3 Data Module (e2e) - Impact map', () => {
         });
 
       expect(response.body.data).toEqual(
-        expect.arrayContaining([{ h: '821207fffffffff', v: 447 }]),
+        expect.arrayContaining([{ h: '821207fffffffff', v: '446.80' }]),
       );
       expect(response.body.metadata).toEqual({
-        quantiles: [0, 447, 447, 447, 447, 447, 447],
+        quantiles: [0, +446.8, +446.8, +446.8, +446.8, +446.8, +446.8],
         unit: 'tonnes',
         indicatorDataYear: 2020,
       });
@@ -158,10 +158,10 @@ describe('H3 Data Module (e2e) - Impact map', () => {
         });
 
       expect(response.body.data).toEqual(
-        expect.arrayContaining([{ h: '841203bffffffff', v: 447 }]),
+        expect.arrayContaining([{ h: '841203bffffffff', v: '446.80' }]),
       );
       expect(response.body.metadata).toEqual({
-        quantiles: [0, 447, 447, 447, 447, 447, 447],
+        quantiles: [0, 446.8, 446.8, 446.8, 446.8, 446.8, 446.8],
         unit: 'tonnes',
         indicatorDataYear: 2020,
       });
@@ -179,14 +179,14 @@ describe('H3 Data Module (e2e) - Impact map', () => {
 
       expect(response.body.data).toEqual(
         expect.arrayContaining([
-          { h: '861203a6fffffff', v: 100 },
-          { h: '861203a4fffffff', v: 223 },
-          { h: '861203a5fffffff', v: 123 },
+          { h: '861203a6fffffff', v: '100.00' },
+          { h: '861203a5fffffff', v: '123.40' },
+          { h: '861203a4fffffff', v: '223.40' },
         ]),
       );
       expect(response.body.metadata).toEqual({
         quantiles: [
-          0, 107.6682, 115.3502, 123, 156.33999999999997, 189.74, 223,
+          0, +107.80156, +115.61716, +123.4, +156.74, +190.14, +223.4,
         ],
         unit: 'tonnes',
         indicatorDataYear: 2020,
@@ -208,12 +208,12 @@ describe('H3 Data Module (e2e) - Impact map', () => {
 
       expect(response.body.data).toEqual(
         expect.arrayContaining([
-          { h: '861203a4fffffff', v: 123 },
-          { h: '861203a5fffffff', v: 123 },
+          { h: '861203a4fffffff', v: '123.40' },
+          { h: '861203a5fffffff', v: '123.40' },
         ]),
       );
       expect(response.body.metadata).toEqual({
-        quantiles: [0, 123, 123, 123, 123, 123, 123],
+        quantiles: [0, +123.4, +123.4, +123.4, +123.4, +123.4, +123.4],
         unit: 'tonnes',
         indicatorDataYear: 2020,
         materialsH3DataYears: [
@@ -244,12 +244,12 @@ describe('H3 Data Module (e2e) - Impact map', () => {
 
       expect(response.body.data).toEqual(
         expect.arrayContaining([
-          { h: '861203a4fffffff', v: 123 },
-          { h: '861203a5fffffff', v: 123 },
+          { h: '861203a4fffffff', v: '123.40' },
+          { h: '861203a5fffffff', v: '123.40' },
         ]),
       );
       expect(response.body.metadata).toEqual({
-        quantiles: [0, 123, 123, 123, 123, 123, 123],
+        quantiles: [0, +123.4, +123.4, +123.4, +123.4, +123.4, +123.4],
         unit: 'tonnes',
         indicatorDataYear: 2020,
       });
@@ -268,12 +268,12 @@ describe('H3 Data Module (e2e) - Impact map', () => {
 
       expect(response.body.data).toEqual(
         expect.arrayContaining([
-          { h: '861203a4fffffff', v: 123 },
-          { h: '861203a5fffffff', v: 123 },
+          { h: '861203a4fffffff', v: '123.40' },
+          { h: '861203a5fffffff', v: '123.40' },
         ]),
       );
       expect(response.body.metadata).toEqual({
-        quantiles: [0, 123, 123, 123, 123, 123, 123],
+        quantiles: [0, +123.4, +123.4, +123.4, +123.4, +123.4, +123.4],
         unit: 'tonnes',
         indicatorDataYear: 2020,
       });
@@ -292,12 +292,12 @@ describe('H3 Data Module (e2e) - Impact map', () => {
 
       expect(response.body.data).toEqual(
         expect.arrayContaining([
-          { h: '861203a4fffffff', v: 123 },
-          { h: '861203a5fffffff', v: 123 },
+          { h: '861203a4fffffff', v: '123.40' },
+          { h: '861203a5fffffff', v: '123.40' },
         ]),
       );
       expect(response.body.metadata).toEqual({
-        quantiles: [0, 123, 123, 123, 123, 123, 123],
+        quantiles: [0, +123.4, +123.4, +123.4, +123.4, +123.4, +123.4],
         unit: 'tonnes',
         indicatorDataYear: 2020,
       });
@@ -316,12 +316,20 @@ describe('H3 Data Module (e2e) - Impact map', () => {
 
       expect(response.body.data).toEqual(
         expect.arrayContaining([
-          { h: '861203a4fffffff', v: 123 },
-          { h: '861203a5fffffff', v: 123 },
+          { h: '861203a4fffffff', v: '123.40' },
+          { h: '861203a5fffffff', v: '123.40' },
         ]),
       );
       expect(response.body.metadata).toEqual({
-        quantiles: [0, +123, +123, +123, +123, +123, +123],
+        quantiles: [
+          0,
+          +'123.40',
+          +'123.40',
+          +'123.40',
+          +'123.40',
+          +'123.40',
+          +'123.40',
+        ],
         unit: 'tonnes',
         indicatorDataYear: 2020,
       });
@@ -340,12 +348,12 @@ describe('H3 Data Module (e2e) - Impact map', () => {
 
       expect(response.body.data).toEqual(
         expect.arrayContaining([
-          { h: '861203a4fffffff', v: 123 },
-          { h: '861203a5fffffff', v: 123 },
+          { h: '861203a4fffffff', v: '123.40' },
+          { h: '861203a5fffffff', v: '123.40' },
         ]),
       );
       expect(response.body.metadata).toEqual({
-        quantiles: [0, 123, 123, 123, 123, 123, 123],
+        quantiles: [0, +123.4, +123.4, +123.4, +123.4, +123.4, +123.4],
         unit: 'tonnes',
         indicatorDataYear: 2020,
       });


### PR DESCRIPTION
Fixes rounding  deforestation impact map that was showing duplicated legend entries by  rounding up to 2 decimal places instead of 0


### General description

_Please write a description. If the PR is hard to understand, provide a quick explanation of the code._

### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

_Provide minimal instructions on how to test this PR._

- Apart from the added feature / bug fix, check overall performance, styling...

## Checklist before merging

- [ ] Branch name / PR includes the related Jira ticket Id.
- [ ] Tests to check core implementation / bug fix added.
- [ ] All checks in Continuous Integration workflow pass.
- [ ] Feature functionally tested by reviewer(s).
- [ ] Code reviewed by reviewer(s).
- [ ] Documentation updated (README, CHANGELOG...) (if required)
