### PR TITLE
Bugix: Intervention: empty replaced elements when no selected from UI

### DIFF
--- a/api/src/modules/admin-regions/admin-region.repository.ts
+++ b/api/src/modules/admin-regions/admin-region.repository.ts
@@ -162,13 +162,13 @@ export class AdminRegionRepository extends ExtendedTreeRepository<
    ** @description Retrieves Admin Regions and their ancestors (in a plain format) when there are associated Sourcing Locations
    */
 
-  async getSourcingDataAdminRegionsWithAncestry(
+  async getSourcingDataAdminRegions(
     adminRegionTreeOptions: GetAdminRegionTreeWithOptionsDto,
+    withAncestry: boolean = true,
   ): Promise<AdminRegion[]> {
     // Join and filters over materials present in sourcing-locations. Resultant query returns IDs of elements meeting the filters
     const queryBuilder: SelectQueryBuilder<AdminRegion> =
       this.createQueryBuilder('ar')
-        .select('ar.id')
         .innerJoin(SourcingLocation, 'sl', 'sl.adminRegionId = ar.id')
         .distinct(true);
     if (adminRegionTreeOptions.originIds) {
@@ -222,6 +222,10 @@ export class AdminRegionRepository extends ExtendedTreeRepository<
     } else {
       queryBuilder.andWhere('sl.scenarioInterventionId is null');
     }
+    if (!withAncestry) {
+      return queryBuilder.select().getMany();
+    }
+    queryBuilder.select('ar.id');
 
     const [subQuery, subQueryParams]: [string, any[]] =
       queryBuilder.getQueryAndParameters();

--- a/api/src/modules/admin-regions/admin-regions.service.ts
+++ b/api/src/modules/admin-regions/admin-regions.service.ts
@@ -159,13 +159,18 @@ export class AdminRegionsService extends AppBaseService<
    * @description Get a tree of AdminRegions where there are sourcing-locations registered within
    */
 
-  async getAdminRegionTreeWithSourcingLocations(
+  async getAdminRegionWithSourcingLocations(
     adminRegionTreeOptions: GetAdminRegionTreeWithOptionsDto,
+    withAncestry: boolean = true,
   ): Promise<AdminRegion[]> {
     const adminRegionLineage: AdminRegion[] =
-      await this.adminRegionRepository.getSourcingDataAdminRegionsWithAncestry(
+      await this.adminRegionRepository.getSourcingDataAdminRegions(
         adminRegionTreeOptions,
+        withAncestry,
       );
+    if (!withAncestry) {
+      return adminRegionLineage;
+    }
     return this.buildTree<AdminRegion>(adminRegionLineage, null);
   }
 
@@ -191,9 +196,7 @@ export class AdminRegionsService extends AppBaseService<
             adminRegionTreeOptions.materialIds,
           );
       }
-      return this.getAdminRegionTreeWithSourcingLocations(
-        adminRegionTreeOptions,
-      );
+      return this.getAdminRegionWithSourcingLocations(adminRegionTreeOptions);
     }
 
     return this.findTreesWithOptions({ depth: adminRegionTreeOptions.depth });

--- a/api/src/modules/business-units/business-unit.repository.ts
+++ b/api/src/modules/business-units/business-unit.repository.ts
@@ -7,7 +7,7 @@ import {
 import { BusinessUnit } from 'modules/business-units/business-unit.entity';
 import { ExtendedTreeRepository } from 'utils/tree.repository';
 import { CreateBusinessUnitDto } from 'modules/business-units/dto/create.business-unit.dto';
-import { Logger, NotFoundException } from '@nestjs/common';
+import { Logger } from '@nestjs/common';
 import { SourcingLocation } from 'modules/sourcing-locations/sourcing-location.entity';
 import { GetBusinessUnitTreeWithOptionsDto } from 'modules/business-units/dto/get-business-unit-tree-with-options.dto';
 
@@ -22,13 +22,13 @@ export class BusinessUnitRepository extends ExtendedTreeRepository<
    * @description Retrieves business-units and it's ancestors (in a plain format) there are registered sourcingLocations for
    */
 
-  async getSourcingDataBusinessUnitssWithAncestry(
+  async getSourcingDataBusinessUnits(
     businessUnitTreeOptions: GetBusinessUnitTreeWithOptionsDto,
+    withAncestry: boolean = true,
   ): Promise<BusinessUnit[]> {
     // Join and filters over business-units present in sourcing-locations. Resultant query returns IDs of elements meeting the filters
     const queryBuilder: SelectQueryBuilder<BusinessUnit> =
       this.createQueryBuilder('bu')
-        .select('bu.id')
         .innerJoin(SourcingLocation, 'sl', 'sl.businessUnitId = bu.id')
         .distinct(true);
 
@@ -59,6 +59,11 @@ export class BusinessUnitRepository extends ExtendedTreeRepository<
         locationTypes: businessUnitTreeOptions.locationTypes,
       });
     }
+
+    if (!withAncestry) {
+      return queryBuilder.getMany();
+    }
+    queryBuilder.select('bu.id');
 
     const [subQuery, subQueryParams]: [string, any[]] =
       queryBuilder.getQueryAndParameters();

--- a/api/src/modules/business-units/business-units.service.ts
+++ b/api/src/modules/business-units/business-units.service.ts
@@ -111,18 +111,21 @@ export class BusinessUnitsService extends AppBaseService<
           businessUnitTreeOptions.originIds,
         );
     }
-    return this.getBusinessUnitTreeWithSourcingLocations(
-      businessUnitTreeOptions,
-    );
+    return this.getBusinessUnitWithSourcingLocations(businessUnitTreeOptions);
   }
 
-  async getBusinessUnitTreeWithSourcingLocations(
+  async getBusinessUnitWithSourcingLocations(
     businessUnitTreeOptions: GetBusinessUnitTreeWithOptionsDto,
+    withAncestry: boolean = true,
   ): Promise<BusinessUnit[]> {
     const businessUnitsLineage: BusinessUnit[] =
-      await this.businessUnitRepository.getSourcingDataBusinessUnitssWithAncestry(
+      await this.businessUnitRepository.getSourcingDataBusinessUnits(
         businessUnitTreeOptions,
+        withAncestry,
       );
+    if (!withAncestry) {
+      return businessUnitsLineage;
+    }
     return this.buildTree<BusinessUnit>(businessUnitsLineage, null);
   }
 

--- a/api/src/modules/impact/impact.service.ts
+++ b/api/src/modules/impact/impact.service.ts
@@ -279,7 +279,7 @@ export class ImpactService {
         );
       }
       case GROUP_BY_VALUES.BUSINESS_UNIT:
-        return this.businessUnitsService.getBusinessUnitTreeWithSourcingLocations(
+        return this.businessUnitsService.getBusinessUnitWithSourcingLocations(
           treeOptions,
         );
 

--- a/api/src/modules/impact/impact.service.ts
+++ b/api/src/modules/impact/impact.service.ts
@@ -269,7 +269,7 @@ export class ImpactService {
         );
       }
       case GROUP_BY_VALUES.REGION: {
-        return this.adminRegionsService.getAdminRegionTreeWithSourcingLocations(
+        return this.adminRegionsService.getAdminRegionWithSourcingLocations(
           treeOptions,
         );
       }

--- a/api/src/modules/scenario-interventions/services/intervention-generator.service.ts
+++ b/api/src/modules/scenario-interventions/services/intervention-generator.service.ts
@@ -90,13 +90,26 @@ export class InterventionGeneratorService {
           false,
         );
     }
-
-    newIntervention.replacedBusinessUnits =
-      await this.businessUnitService.getBusinessUnitsById(businessUnitIds);
+    if (businessUnitIds) {
+      newIntervention.replacedBusinessUnits =
+        await this.businessUnitService.getBusinessUnitsById(businessUnitIds);
+    } else {
+      newIntervention.replacedBusinessUnits =
+        await this.businessUnitService.getBusinessUnitWithSourcingLocations(
+          {},
+          false,
+        );
+    }
 
     if (supplierIds.length) {
       newIntervention.replacedSuppliers =
         await this.suppliersService.getSuppliersById(supplierIds);
+    } else {
+      newIntervention.replacedSuppliers =
+        await this.suppliersService.getSuppliersWithSourcingLocations(
+          {},
+          false,
+        );
     }
 
     newIntervention.replacedSourcingLocations = cancelledSourcingLocations;

--- a/api/src/modules/scenario-interventions/services/intervention-generator.service.ts
+++ b/api/src/modules/scenario-interventions/services/intervention-generator.service.ts
@@ -80,9 +80,16 @@ export class InterventionGeneratorService {
 
     newIntervention.replacedMaterials =
       await this.materialService.getMaterialsById(materialIds);
-
-    newIntervention.replacedAdminRegions =
-      await this.adminRegionService.getAdminRegionsById(adminRegionsIds);
+    if (adminRegionsIds.length) {
+      newIntervention.replacedAdminRegions =
+        await this.adminRegionService.getAdminRegionsById(adminRegionsIds);
+    } else {
+      newIntervention.replacedAdminRegions =
+        await this.adminRegionService.getAdminRegionWithSourcingLocations(
+          {},
+          false,
+        );
+    }
 
     newIntervention.replacedBusinessUnits =
       await this.businessUnitService.getBusinessUnitsById(businessUnitIds);

--- a/api/src/modules/suppliers/supplier.repository.ts
+++ b/api/src/modules/suppliers/supplier.repository.ts
@@ -2,7 +2,7 @@ import { EntityRepository, SelectQueryBuilder } from 'typeorm';
 import { Supplier } from 'modules/suppliers/supplier.entity';
 import { ExtendedTreeRepository } from 'utils/tree.repository';
 import { CreateSupplierDto } from 'modules/suppliers/dto/create.supplier.dto';
-import { Logger, NotFoundException } from '@nestjs/common';
+import { Logger } from '@nestjs/common';
 import { SourcingLocation } from 'modules/sourcing-locations/sourcing-location.entity';
 import { GetSupplierTreeWithOptions } from 'modules/suppliers/dto/get-supplier-tree-with-options.dto';
 import { ScenarioIntervention } from 'modules/scenario-interventions/scenario-intervention.entity';
@@ -19,14 +19,14 @@ export class SupplierRepository extends ExtendedTreeRepository<
    * @description Retrieves suppliers and it's ancestors (in a plain format) there are registered sourcingLocations for
    */
 
-  async getSourcingDataSuppliersWithAncestry(
+  async getSourcingDataSuppliers(
     supplierTreeOptions: GetSupplierTreeWithOptions,
+    withAncestry: boolean = true,
   ): Promise<Supplier[]> {
     // Join and filters over materials present in sourcing-locations. Resultant query returns IDs of elements meeting the filters
     const queryBuilder: SelectQueryBuilder<Supplier> = this.createQueryBuilder(
       's',
     )
-      .select('s.id')
       .innerJoin(
         SourcingLocation,
         'sl',
@@ -79,6 +79,11 @@ export class SupplierRepository extends ExtendedTreeRepository<
     } else {
       queryBuilder.andWhere('sl.scenarioInterventionId is null');
     }
+
+    if (!withAncestry) {
+      return queryBuilder.getMany();
+    }
+    queryBuilder.select('s.id');
 
     const [subQuery, subQueryParams]: [string, any[]] =
       queryBuilder.getQueryAndParameters();

--- a/api/src/modules/suppliers/suppliers.service.ts
+++ b/api/src/modules/suppliers/suppliers.service.ts
@@ -163,11 +163,16 @@ export class SuppliersService extends AppBaseService<
 
   async getSuppliersWithSourcingLocations(
     supplierTreeOptions: GetSupplierTreeWithOptions,
+    withAncesty: boolean = true,
   ): Promise<any> {
     const supplierLineage: Supplier[] =
-      await this.supplierRepository.getSourcingDataSuppliersWithAncestry(
+      await this.supplierRepository.getSourcingDataSuppliers(
         supplierTreeOptions,
+        withAncesty,
       );
+    if (!withAncesty) {
+      return supplierLineage;
+    }
     return this.buildTree<Supplier>(supplierLineage, null);
   }
 

--- a/api/test/e2e/admin-regions/admin-regions-tree-smart-filters.spec.ts
+++ b/api/test/e2e/admin-regions/admin-regions-tree-smart-filters.spec.ts
@@ -136,7 +136,7 @@ describe('Admin Regions - Get trees - Smart Filters', () => {
     },
   );
 
-  test.skip(
+  test(
     'When I query a Admin Region Tree endpoint ' +
       'And I query the ones with sourcing locations' +
       'And I filter them by a related Location Types' +

--- a/api/test/e2e/scenario-interventions/scenario-interventions.spec.ts
+++ b/api/test/e2e/scenario-interventions/scenario-interventions.spec.ts
@@ -1519,7 +1519,12 @@ describe('ScenarioInterventionsModule (e2e)', () => {
         });
         // Included in Sourcing Locations
         const childBusinessUnit: BusinessUnit = await createBusinessUnit({
-          name: 'child business unit',
+          name: 'child business unit 1',
+          parent: parentBusinessUnit,
+        });
+        // Included in Sourcing Locations
+        const childBusinessUnit2: BusinessUnit = await createBusinessUnit({
+          name: 'child business unit 2',
           parent: parentBusinessUnit,
         });
         // Not included in Sourcing Locations
@@ -1548,7 +1553,7 @@ describe('ScenarioInterventionsModule (e2e)', () => {
 
         await createSourcingLocation({
           material: childMaterial,
-          businessUnit: childBusinessUnit,
+          businessUnit: childBusinessUnit2,
           t1Supplier: childSupplier,
           sourcingRecords: [sourcingRecord2],
         });
@@ -1573,6 +1578,24 @@ describe('ScenarioInterventionsModule (e2e)', () => {
             expect(parseInt(adminRegion.name.split(':')[1]) % 2 === 0).toBe(
               true,
             ),
+        );
+
+        const response2 = await request(app.getHttpServer())
+          .post('/api/v1/scenario-interventions')
+          .set('Authorization', `Bearer ${jwtToken}`)
+          .send({
+            title: 'test scenario intervention',
+            startYear: 2020,
+            percentage: 50,
+            scenarioId: scenario.id,
+            materialIds: [parentMaterial.id],
+            supplierIds: [parentSupplier.id],
+            type: SCENARIO_INTERVENTION_TYPE.CHANGE_PRODUCTION_EFFICIENCY,
+          });
+
+        response2.body.data.attributes.replacedBusinessUnits.forEach(
+          (bu: any) =>
+            expect(bu.name.includes('child business unit')).toBe(true),
         );
       },
     );

--- a/api/test/e2e/scenario-interventions/scenario-interventions.spec.ts
+++ b/api/test/e2e/scenario-interventions/scenario-interventions.spec.ts
@@ -1531,7 +1531,7 @@ describe('ScenarioInterventionsModule (e2e)', () => {
         const parentSupplier: Supplier = await createSupplier({
           name: 'parent supplier',
         });
-
+        //Included in Sourcing Locations
         const childSupplier: Supplier = await createSupplier({
           name: 'child supplier',
           parent: parentSupplier,
@@ -1559,7 +1559,7 @@ describe('ScenarioInterventionsModule (e2e)', () => {
         });
         const scenario: Scenario = await createScenario();
 
-        const response = await request(app.getHttpServer())
+        const responseAdminRegions = await request(app.getHttpServer())
           .post('/api/v1/scenario-interventions')
           .set('Authorization', `Bearer ${jwtToken}`)
           .send({
@@ -1573,14 +1573,14 @@ describe('ScenarioInterventionsModule (e2e)', () => {
             type: SCENARIO_INTERVENTION_TYPE.CHANGE_PRODUCTION_EFFICIENCY,
           });
 
-        response.body.data.attributes.replacedAdminRegions.every(
+        responseAdminRegions.body.data.attributes.replacedAdminRegions.every(
           (adminRegion: any) =>
             expect(parseInt(adminRegion.name.split(':')[1]) % 2 === 0).toBe(
               true,
             ),
         );
 
-        const response2 = await request(app.getHttpServer())
+        const responseBusinessUnits = await request(app.getHttpServer())
           .post('/api/v1/scenario-interventions')
           .set('Authorization', `Bearer ${jwtToken}`)
           .send({
@@ -1593,10 +1593,26 @@ describe('ScenarioInterventionsModule (e2e)', () => {
             type: SCENARIO_INTERVENTION_TYPE.CHANGE_PRODUCTION_EFFICIENCY,
           });
 
-        response2.body.data.attributes.replacedBusinessUnits.forEach(
+        responseBusinessUnits.body.data.attributes.replacedBusinessUnits.forEach(
           (bu: any) =>
             expect(bu.name.includes('child business unit')).toBe(true),
         );
+
+        const responseSuppliers = await request(app.getHttpServer())
+          .post('/api/v1/scenario-interventions')
+          .set('Authorization', `Bearer ${jwtToken}`)
+          .send({
+            title: 'test scenario intervention',
+            startYear: 2020,
+            percentage: 50,
+            scenarioId: scenario.id,
+            materialIds: [parentMaterial.id],
+            type: SCENARIO_INTERVENTION_TYPE.CHANGE_PRODUCTION_EFFICIENCY,
+          });
+
+        expect(
+          responseSuppliers.body.data.attributes.replacedSuppliers[0].name,
+        ).toEqual(childSupplier.name);
       },
     );
 


### PR DESCRIPTION
### General description

This PR fixes not adding any BusinessUnit / Suppliers / Admin Regios to Intervention replacing<Entity> property, when no elements is selected. 
Not picking any BU / Supplier / Admin Regions means selecting all of them therefore according to data all of them should be added to said props, always meeting the filters, if any

### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

Spin up both the Frontend and Backend apps (you can test it via request but can be a pain). Create some interventions without selecting any supplier or business unit. In the response you should see that all SU/BU that are meeting the filtering (Material etc) are added.

There are some bugs in the frontend so apparently only Switch to a new location Intervention type works. The rest is not querying the API


- Apart from the added feature / bug fix, check overall performance, styling...

## Checklist before merging

- [ ] Branch name / PR includes the related Jira ticket Id.
- [x] Tests to check core implementation / bug fix added.
- [ ] All checks in Continuous Integration workflow pass.
- [ ] Feature functionally tested by reviewer(s).
- [ ] Code reviewed by reviewer(s).
- [ ] Documentation updated (README, CHANGELOG...) (if required)
