### PR TITLE
Bugix/landgrif 842 replace canceled calculations

### DIFF
--- a/api/src/modules/admin-regions/admin-region.entity.ts
+++ b/api/src/modules/admin-regions/admin-region.entity.ts
@@ -95,7 +95,7 @@ export class AdminRegion extends BaseEntity {
   @ApiPropertyOptional()
   @OneToMany(
     () => SourcingLocation,
-    (srcLoc: SourcingLocation) => srcLoc.material,
+    (srcLoc: SourcingLocation) => srcLoc.adminRegion,
   )
   sourcingLocations: SourcingLocation[];
 

--- a/api/src/modules/indicator-records/indicator-records.service.ts
+++ b/api/src/modules/indicator-records/indicator-records.service.ts
@@ -287,7 +287,7 @@ export class IndicatorRecordsService extends AppBaseService<
       },
     );
 
-    return this.indicatorRecordRepository.save(indicatorRecords);
+    return indicatorRecords;
   }
 
   /**

--- a/api/src/modules/scenario-interventions/scenario-interventions.controller.ts
+++ b/api/src/modules/scenario-interventions/scenario-interventions.controller.ts
@@ -92,8 +92,12 @@ export class ScenarioInterventionsController {
   })
   @UsePipes(ValidationPipe)
   @Post()
-  async create(@Body() dto: CreateScenarioInterventionDto): Promise<void> {
-    await this.scenarioInterventionsService.createScenarioIntervention(dto);
+  async create(
+    @Body() dto: CreateScenarioInterventionDto,
+  ): Promise<Partial<ScenarioIntervention>> {
+    return await this.scenarioInterventionsService.serialize(
+      await this.scenarioInterventionsService.createScenarioIntervention(dto),
+    );
   }
 
   @ApiOperation({ description: 'Update a scenario intervention' })

--- a/api/src/modules/scenario-interventions/scenario-interventions.controller.ts
+++ b/api/src/modules/scenario-interventions/scenario-interventions.controller.ts
@@ -92,12 +92,8 @@ export class ScenarioInterventionsController {
   })
   @UsePipes(ValidationPipe)
   @Post()
-  async create(
-    @Body() dto: CreateScenarioInterventionDto,
-  ): Promise<ScenarioIntervention> {
-    return this.scenarioInterventionsService.serialize(
-      await this.scenarioInterventionsService.createScenarioIntervention(dto),
-    );
+  async create(@Body() dto: CreateScenarioInterventionDto): Promise<void> {
+    await this.scenarioInterventionsService.createScenarioIntervention(dto);
   }
 
   @ApiOperation({ description: 'Update a scenario intervention' })

--- a/api/src/modules/scenario-interventions/scenario-interventions.service.ts
+++ b/api/src/modules/scenario-interventions/scenario-interventions.service.ts
@@ -125,7 +125,8 @@ export class ScenarioInterventionsService extends AppBaseService<
       await this.interventionGenerator.addDescendantsEntitiesForFiltering(dto);
 
     /**
-     * Getting Sourcing Locations and Sourcing Records for start year of all Materials of the intervention with applied filters
+     * Getting Sourcing Locations and Sourcing Records and Indicator records
+     * for start year of all Materials of the intervention with applied filters
      */
 
     const actualSourcingDataWithTonnage: SourcingLocation[] =
@@ -137,10 +138,18 @@ export class ScenarioInterventionsService extends AppBaseService<
       throw new BadRequestException('No actual data for requested filters');
     }
 
-    // Applying percentage received from user to the volume of tonnes of filter-matching Sourcing Locations
+    /**
+     * Applying percentage received from user to the volume of tonnes of filter-matching Sourcing Locations
+     * and to values of Indicator Records
+     */
+
     actualSourcingDataWithTonnage.forEach((sl: SourcingLocation) => {
-      sl.sourcingRecords.map((sr: SourcingRecord) => {
+      sl.sourcingRecords.forEach((sr: SourcingRecord) => {
         sr.tonnage = sr.tonnage * (dto.percentage / 100);
+
+        sr.indicatorRecords.map((ir: IndicatorRecord) => {
+          ir.value = ir.value * (dto.percentage / 100);
+        });
       });
     });
 
@@ -156,26 +165,6 @@ export class ScenarioInterventionsService extends AppBaseService<
         actualSourcingDataWithTonnage,
         SOURCING_LOCATION_TYPE_BY_INTERVENTION.CANCELED,
       );
-
-    // Creating Indicator records for newly created Sourcing Locations of type canceled
-    // Since a user could apply a percentage to apply for a record in the actual data
-
-    for (const sourcingLocation of newCancelledByInterventionLocationsData) {
-      for await (const sourcingRecord of sourcingLocation.sourcingRecords) {
-        const indicatorRecordsWithNewTonnage: IndicatorRecord[] =
-          await this.indicatorRecordsService.createIndicatorRecordsBySourcingRecords(
-            {
-              sourcingRecordId: sourcingRecord.id,
-              tonnage: sourcingRecord.tonnage,
-              geoRegionId: sourcingLocation.geoRegionId,
-              materialId: sourcingLocation.materialId,
-              year: sourcingRecord.year,
-            },
-            dto.newIndicatorCoefficients,
-          );
-        sourcingRecord.indicatorRecords = indicatorRecordsWithNewTonnage;
-      }
-    }
 
     /**
      *  Creating New Intervention to be saved in scenario_interventions table
@@ -469,7 +458,11 @@ export class ScenarioInterventionsService extends AppBaseService<
       newCancelledInterventionLocation.adminRegionId = location.adminRegionId;
       newCancelledInterventionLocation.sourcingRecords =
         location.sourcingRecords.map((elem: any) => {
-          return { year: elem.year, tonnage: elem.tonnage } as SourcingRecord;
+          return {
+            year: elem.year,
+            tonnage: elem.tonnage,
+            indicatorRecords: elem.indicatorRecords,
+          } as SourcingRecord;
         });
       newCancelledInterventionLocation.interventionType = canceledOrReplacing;
       cancelledSourcingLocations.push(newCancelledInterventionLocation);

--- a/api/src/modules/scenario-interventions/services/intervention-generator.service.ts
+++ b/api/src/modules/scenario-interventions/services/intervention-generator.service.ts
@@ -81,46 +81,32 @@ export class InterventionGeneratorService {
       if (sourcingLocation.producerId || sourcingLocation.t1SupplierId) {
         supplierIds.push(
           sourcingLocation.producerId
-            ? sourcingLocation.producerId
-            : sourcingLocation.t1SupplierId,
+            ? (sourcingLocation.producerId as string)
+            : (sourcingLocation.t1SupplierId as string),
         );
       }
     }
 
+    /**Canceled Sourcing locations already have the ids of AdminRegion, Material and Business Unit that will be canceled by the intervention
+     * Fetching those entities to add them as 'replaced' to the intervention
+     *
+     */
     newIntervention.replacedMaterials =
       await this.materialService.getMaterialsById(materialIds);
-    // If Ids are received, get those
-    if (adminRegionsIds.length) {
-      newIntervention.replacedAdminRegions =
-        await this.adminRegionService.getAdminRegionsById(adminRegionsIds);
-      // If no Id is received, the user want to replace all of them present in Sourcing Locations
-    } else {
-      newIntervention.replacedAdminRegions =
-        await this.adminRegionService.getAdminRegionWithSourcingLocations(
-          {},
-          false,
-        );
-    }
-    if (businessUnitIds) {
-      newIntervention.replacedBusinessUnits =
-        await this.businessUnitService.getBusinessUnitsById(businessUnitIds);
-    } else {
-      newIntervention.replacedBusinessUnits =
-        await this.businessUnitService.getBusinessUnitWithSourcingLocations(
-          {},
-          false,
-        );
-    }
+
+    newIntervention.replacedAdminRegions =
+      await this.adminRegionService.getAdminRegionsById(adminRegionsIds);
+
+    newIntervention.replacedBusinessUnits =
+      await this.businessUnitService.getBusinessUnitsById(businessUnitIds);
+
+    /** t1SupplierId and producerId columns are not obligatorey for Sourcing location, so if Canceles Sourcing Locations have suppliers or producer -
+     *  they will be added as replaced, else - replacedSuppliers will be empty
+     */
 
     if (supplierIds.length) {
       newIntervention.replacedSuppliers =
         await this.suppliersService.getSuppliersById(supplierIds);
-    } else {
-      newIntervention.replacedSuppliers =
-        await this.suppliersService.getSuppliersWithSourcingLocations(
-          {},
-          false,
-        );
     }
 
     newIntervention.replacedSourcingLocations = cancelledSourcingLocations;

--- a/api/src/modules/sourcing-locations/sourcing-location.entity.ts
+++ b/api/src/modules/sourcing-locations/sourcing-location.entity.ts
@@ -175,7 +175,7 @@ export class SourcingLocation extends TimestampedBaseEntity {
   t1Supplier: Supplier;
 
   @Column({ nullable: true })
-  t1SupplierId: string;
+  t1SupplierId?: string;
 
   @ManyToOne(
     () => Supplier,
@@ -188,7 +188,7 @@ export class SourcingLocation extends TimestampedBaseEntity {
   @JoinColumn({ name: 'producerId' })
   producer: Supplier;
   @Column({ nullable: true })
-  producerId: string;
+  producerId?: string;
 
   @ManyToOne(
     () => SourcingLocationGroup,

--- a/api/src/modules/sourcing-locations/sourcing-locations.service.ts
+++ b/api/src/modules/sourcing-locations/sourcing-locations.service.ts
@@ -110,7 +110,12 @@ export class SourcingLocationsService extends AppBaseService<
     return await this.sourcingLocationRepository.saveChunks(sourcingLocations);
   }
 
-  async findFilteredSourcingLocationsForIntervention(
+  /**
+   * @description: Find Sourcing Locations by filters applying the custom percentage
+   * @param createInterventionDto
+   */
+
+  async findSourcingLocationsWithAppliedPercentageForSourcingRecords(
     createInterventionDto: CreateScenarioInterventionDto,
   ): Promise<SourcingLocation[]> {
     const queryBuilder: SelectQueryBuilder<SourcingLocation> =
@@ -130,7 +135,9 @@ export class SourcingLocationsService extends AppBaseService<
           'sl.locationLongitude',
           'sl.locationLatitude',
           'sr.year',
-          'sr.tonnage',
+          `sr.tonnage * ${
+            createInterventionDto.percentage / 100
+          } as sr.tonnage`,
         ])
         .leftJoin('sl.sourcingRecords', 'sr')
         .where('sl."materialId" IN (:...materialIds)', {
@@ -172,6 +179,7 @@ export class SourcingLocationsService extends AppBaseService<
         }),
       );
     }
+    const query: any = queryBuilder.getQueryAndParameters();
 
     return queryBuilder.getMany();
   }

--- a/api/src/modules/sourcing-locations/sourcing-locations.service.ts
+++ b/api/src/modules/sourcing-locations/sourcing-locations.service.ts
@@ -135,9 +135,7 @@ export class SourcingLocationsService extends AppBaseService<
           'sl.locationLongitude',
           'sl.locationLatitude',
           'sr.year',
-          `sr.tonnage * ${
-            createInterventionDto.percentage / 100
-          } as sr.tonnage`,
+          'sr.tonnage',
         ])
         .leftJoin('sl.sourcingRecords', 'sr')
         .where('sl."materialId" IN (:...materialIds)', {

--- a/api/src/modules/sourcing-locations/sourcing-locations.service.ts
+++ b/api/src/modules/sourcing-locations/sourcing-locations.service.ts
@@ -136,8 +136,12 @@ export class SourcingLocationsService extends AppBaseService<
           'sl.locationLatitude',
           'sr.year',
           'sr.tonnage',
+          'ir.value',
+          'ir.indicatorId',
+          'ir.materialH3DataId',
         ])
         .leftJoin('sl.sourcingRecords', 'sr')
+        .leftJoin('sr.indicatorRecords', 'ir')
         .where('sl."materialId" IN (:...materialIds)', {
           materialIds: createInterventionDto.materialIds,
         })

--- a/api/test/e2e/scenario-interventions/scenario-interventions.spec.ts
+++ b/api/test/e2e/scenario-interventions/scenario-interventions.spec.ts
@@ -210,24 +210,10 @@ describe('ScenarioInterventionsModule (e2e)', () => {
 
       expect(response.status).toBe(HttpStatus.CREATED);
 
-      const createdScenarioIntervention =
-        await scenarioInterventionRepository.findOne(response.body.data.id);
-
-      if (!createdScenarioIntervention) {
-        throw new Error('Error loading created Scenario intervention');
-      }
-
-      expect(createdScenarioIntervention.title).toEqual(
-        'test scenario intervention',
-      );
-
-      expect(response).toHaveJSONAPIAttributes([
-        ...expectedJSONAPIAttributes,
-        'replacedMaterials',
-        'replacedBusinessUnits',
-        'replacedAdminRegions',
-        'replacedSuppliers',
-      ]);
+      const allInterventions: [ScenarioIntervention[], number] =
+        await scenarioInterventionRepository.findAndCount();
+      expect(allInterventions[1]).toEqual(1);
+      expect(typeof allInterventions[0][0].id).toBe('string');
 
       const allSourcingLocations: [SourcingLocation[], number] =
         await sourcingLocationRepository.findAndCount();
@@ -266,7 +252,7 @@ describe('ScenarioInterventionsModule (e2e)', () => {
 
       expect(canceledSourcingLocations.length).toBe(1);
       expect(canceledSourcingLocations[0].scenarioInterventionId).toEqual(
-        response.body.data.id,
+        allInterventions[0][0].id,
       );
       expect(canceledSourcingLocations[0].materialId).toEqual(
         preconditions.material1Descendant.id,
@@ -287,7 +273,7 @@ describe('ScenarioInterventionsModule (e2e)', () => {
         });
 
       expect(canceledSourcingRecords.length).toBe(1);
-      expect(canceledSourcingRecords[0].tonnage).toEqual('500');
+      expect(canceledSourcingRecords[0].tonnage).toEqual('250');
 
       const newSourcingLocations: SourcingLocation[] =
         await sourcingLocationRepository.find({
@@ -298,7 +284,7 @@ describe('ScenarioInterventionsModule (e2e)', () => {
 
       expect(newSourcingLocations.length).toBe(1);
       expect(newSourcingLocations[0].scenarioInterventionId).toEqual(
-        response.body.data.id,
+        allInterventions[0][0].id,
       );
       expect(newSourcingLocations[0].adminRegionId).toEqual(
         preconditions.adminRegion1Descendant.id,
@@ -312,7 +298,7 @@ describe('ScenarioInterventionsModule (e2e)', () => {
         });
 
       expect(newSourcingRecords.length).toBe(1);
-      expect(newSourcingRecords[0].tonnage).toEqual('500');
+      expect(newSourcingRecords[0].tonnage).toEqual('250');
     });
   });
 
@@ -352,24 +338,14 @@ describe('ScenarioInterventionsModule (e2e)', () => {
 
       expect(response.status).toBe(HttpStatus.CREATED);
 
-      const createdScenarioIntervention =
-        await scenarioInterventionRepository.findOne(response.body.data.id);
+      const allInterventions: [ScenarioIntervention[], number] =
+        await scenarioInterventionRepository.findAndCount();
+      expect(allInterventions[1]).toEqual(1);
+      expect(typeof allInterventions[0][0].id).toBe('string');
 
-      if (!createdScenarioIntervention) {
-        throw new Error('Error loading created Scenario intervention');
-      }
-
-      expect(createdScenarioIntervention.title).toEqual(
+      expect(allInterventions[0][0].title).toEqual(
         'scenario intervention supplier',
       );
-
-      expect(response).toHaveJSONAPIAttributes([
-        ...expectedJSONAPIAttributes,
-        'replacedMaterials',
-        'replacedBusinessUnits',
-        'replacedAdminRegions',
-        'replacedSuppliers',
-      ]);
 
       const allSourcingLocations: [SourcingLocation[], number] =
         await sourcingLocationRepository.findAndCount();
@@ -388,7 +364,7 @@ describe('ScenarioInterventionsModule (e2e)', () => {
 
       expect(canceledSourcingLocations.length).toBe(1);
       expect(canceledSourcingLocations[0].scenarioInterventionId).toEqual(
-        response.body.data.id,
+        allInterventions[0][0].id,
       );
       expect(canceledSourcingLocations[0].materialId).toEqual(
         preconditions.material1Descendant.id,
@@ -405,7 +381,7 @@ describe('ScenarioInterventionsModule (e2e)', () => {
         });
 
       expect(canceledSourcingRecords.length).toBe(1);
-      expect(canceledSourcingRecords[0].tonnage).toEqual('500');
+      expect(canceledSourcingRecords[0].tonnage).toEqual('250');
 
       const newSourcingLocations: SourcingLocation[] =
         await sourcingLocationRepository.find({
@@ -416,7 +392,7 @@ describe('ScenarioInterventionsModule (e2e)', () => {
 
       expect(newSourcingLocations.length).toBe(1);
       expect(newSourcingLocations[0].scenarioInterventionId).toEqual(
-        response.body.data.id,
+        allInterventions[0][0].id,
       );
       expect(newSourcingLocations[0].materialId).toEqual(
         preconditions.material1Descendant.id,
@@ -434,7 +410,7 @@ describe('ScenarioInterventionsModule (e2e)', () => {
         });
 
       expect(newSourcingRecords.length).toBe(1);
-      expect(newSourcingRecords[0].tonnage).toEqual('500');
+      expect(newSourcingRecords[0].tonnage).toEqual('250');
     });
 
     test('Create a scenario intervention of type Change of supplier location with start year for which there are multiple years, should be successful', async () => {
@@ -471,24 +447,14 @@ describe('ScenarioInterventionsModule (e2e)', () => {
 
       expect(response.status).toBe(HttpStatus.CREATED);
 
-      const createdScenarioIntervention =
-        await scenarioInterventionRepository.findOne(response.body.data.id);
+      const allInterventions: [ScenarioIntervention[], number] =
+        await scenarioInterventionRepository.findAndCount();
+      expect(allInterventions[1]).toEqual(1);
+      expect(typeof allInterventions[0][0].id).toBe('string');
 
-      if (!createdScenarioIntervention) {
-        throw new Error('Error loading created Scenario intervention');
-      }
-
-      expect(createdScenarioIntervention.title).toEqual(
+      expect(allInterventions[0][0].title).toEqual(
         'scenario intervention supplier',
       );
-
-      expect(response).toHaveJSONAPIAttributes([
-        ...expectedJSONAPIAttributes,
-        'replacedMaterials',
-        'replacedBusinessUnits',
-        'replacedAdminRegions',
-        'replacedSuppliers',
-      ]);
 
       const allSourcingLocations: [SourcingLocation[], number] =
         await sourcingLocationRepository.findAndCount();
@@ -507,7 +473,7 @@ describe('ScenarioInterventionsModule (e2e)', () => {
 
       expect(canceledSourcingLocations.length).toBe(2);
       expect(canceledSourcingLocations[0].scenarioInterventionId).toEqual(
-        response.body.data.id,
+        allInterventions[0][0].id,
       );
       expect(canceledSourcingLocations[0].materialId).toEqual(
         preconditions.material1Descendant.id,
@@ -537,7 +503,7 @@ describe('ScenarioInterventionsModule (e2e)', () => {
 
       expect(newSourcingLocations.length).toBe(1);
       expect(newSourcingLocations[0].scenarioInterventionId).toEqual(
-        response.body.data.id,
+        allInterventions[0][0].id,
       );
       expect(newSourcingLocations[0].materialId).toEqual(
         preconditions.material1Descendant.id,
@@ -555,7 +521,7 @@ describe('ScenarioInterventionsModule (e2e)', () => {
         });
 
       expect(newSourcingRecords.length).toBe(2);
-      expect(newSourcingRecords[0].tonnage).toEqual('500');
+      expect(newSourcingRecords[0].tonnage).toEqual('250');
       expect(newSourcingRecords[0].year).toEqual(2018);
       expect(newSourcingRecords[1].year).toEqual(2019);
     });
@@ -606,26 +572,14 @@ describe('ScenarioInterventionsModule (e2e)', () => {
 
       expect(response.status).toBe(HttpStatus.CREATED);
 
-      const createdScenarioIntervention =
-        await scenarioInterventionRepository.findOne(response.body.data.id);
+      const allInterventions: [ScenarioIntervention[], number] =
+        await scenarioInterventionRepository.findAndCount();
+      expect(allInterventions[1]).toEqual(1);
+      expect(typeof allInterventions[0][0].id).toBe('string');
 
-      if (!createdScenarioIntervention) {
-        throw new Error('Error loading created Scenario intervention');
-      }
-
-      expect(createdScenarioIntervention.title).toEqual(
+      expect(allInterventions[0][0].title).toEqual(
         'scenario intervention material',
       );
-
-      expect(response).toHaveJSONAPIAttributes([
-        ...expectedJSONAPIAttributes,
-        'replacedMaterials',
-        'replacedBusinessUnits',
-        'replacedAdminRegions',
-        'replacedSuppliers',
-        'newAdminRegion',
-        'newMaterial',
-      ]);
 
       const allSourcingLocations: [SourcingLocation[], number] =
         await sourcingLocationRepository.findAndCount();
@@ -653,7 +607,7 @@ describe('ScenarioInterventionsModule (e2e)', () => {
 
       expect(newSourcingLocations.length).toBe(1);
       expect(newSourcingLocations[0].scenarioInterventionId).toEqual(
-        response.body.data.id,
+        allInterventions[0][0].id,
       );
       expect(newSourcingLocations[0].materialId).toEqual(replacingMaterial.id);
       expect(newSourcingLocations[0].adminRegionId).not.toEqual(
@@ -1207,7 +1161,7 @@ describe('ScenarioInterventionsModule (e2e)', () => {
       const preconditions: ScenarioInterventionPreconditions =
         await createInterventionPreconditionsWithMultipleYearRecords();
 
-      const responseOnCreate = await request(app.getHttpServer())
+      await request(app.getHttpServer())
         .post('/api/v1/scenario-interventions')
         .set('Authorization', `Bearer ${jwtToken}`)
         .send({
@@ -1230,21 +1184,26 @@ describe('ScenarioInterventionsModule (e2e)', () => {
         });
 
       expect(HttpStatus.CREATED);
-      const scenarioIntervention =
-        await scenarioInterventionRepository.findOneOrFail(
-          responseOnCreate.body.data.id,
-        );
+
+      const allInterventions: [ScenarioIntervention[], number] =
+        await scenarioInterventionRepository.findAndCount();
+      expect(allInterventions[1]).toEqual(1);
+
       const sourcingRecordsCountBeforeUpdate: number =
         await sourcingRecordRepository.count();
       expect(sourcingRecordsCountBeforeUpdate).toEqual(8);
 
       const response = await request(app.getHttpServer())
-        .patch(`/api/v1/scenario-interventions/${scenarioIntervention.id}`)
+        .patch(`/api/v1/scenario-interventions/${allInterventions[0][0].id}`)
         .set('Authorization', `Bearer ${jwtToken}`)
         .send({
           startYear: 2019,
         })
         .expect(HttpStatus.OK);
+
+      const allInterventionsAfterUpdate: [ScenarioIntervention[], number] =
+        await scenarioInterventionRepository.findAndCount();
+      expect(allInterventionsAfterUpdate[1]).toEqual(1);
 
       const updatedScenarioIntervention =
         await scenarioInterventionRepository.findOneOrFail(
@@ -1253,13 +1212,7 @@ describe('ScenarioInterventionsModule (e2e)', () => {
       expect(updatedScenarioIntervention.updatedById).toEqual(userId);
 
       // Note: Update response does not retrieve the related resources
-      expect(response).toHaveJSONAPIAttributes([
-        ...expectedJSONAPIAttributes,
-        'replacedMaterials',
-        'replacedBusinessUnits',
-        'replacedAdminRegions',
-        'replacedSuppliers',
-      ]);
+
       const sourcingRecordsCountAfterUpdate: number =
         await sourcingRecordRepository.count();
       expect(sourcingRecordsCountAfterUpdate).toEqual(6);
@@ -1573,7 +1526,12 @@ describe('ScenarioInterventionsModule (e2e)', () => {
             type: SCENARIO_INTERVENTION_TYPE.CHANGE_PRODUCTION_EFFICIENCY,
           });
 
-        responseAdminRegions.body.data.attributes.replacedAdminRegions.every(
+        const createdScenarioIntervention1 =
+          await scenarioInterventionRepository.findOneOrFail(
+            responseAdminRegions.body.data.id,
+          );
+
+        createdScenarioIntervention1.replacedAdminRegions.every(
           (adminRegion: any) =>
             expect(parseInt(adminRegion.name.split(':')[1]) % 2 === 0).toBe(
               true,
@@ -1593,9 +1551,13 @@ describe('ScenarioInterventionsModule (e2e)', () => {
             type: SCENARIO_INTERVENTION_TYPE.CHANGE_PRODUCTION_EFFICIENCY,
           });
 
-        responseBusinessUnits.body.data.attributes.replacedBusinessUnits.forEach(
-          (bu: any) =>
-            expect(bu.name.includes('child business unit')).toBe(true),
+        const createdScenarioIntervention2 =
+          await scenarioInterventionRepository.findOneOrFail(
+            responseBusinessUnits.body.data.id,
+          );
+
+        createdScenarioIntervention2.replacedBusinessUnits.forEach((bu: any) =>
+          expect(bu.name.includes('child business unit')).toBe(true),
         );
 
         const responseSuppliers = await request(app.getHttpServer())
@@ -1610,9 +1572,13 @@ describe('ScenarioInterventionsModule (e2e)', () => {
             type: SCENARIO_INTERVENTION_TYPE.CHANGE_PRODUCTION_EFFICIENCY,
           });
 
-        expect(
-          responseSuppliers.body.data.attributes.replacedSuppliers[0].name,
-        ).toEqual(childSupplier.name);
+        const createdScenarioIntervention3 =
+          await scenarioInterventionRepository.findOneOrFail(
+            responseSuppliers.body.data.id,
+          );
+        expect(createdScenarioIntervention3.replacedSuppliers[0].name).toEqual(
+          childSupplier.name,
+        );
       },
     );
 

--- a/api/test/entity-mocks.ts
+++ b/api/test/entity-mocks.ts
@@ -148,6 +148,30 @@ async function createIndicatorRecord(
   return indicatorRecord.save();
 }
 
+async function createIndicatorRecordForIntervention(
+  additionalData: Partial<IndicatorRecord> = {},
+  sourcingRecord: SourcingRecord,
+): Promise<IndicatorRecord> {
+  const basicMaterial: Material = await createMaterial();
+  const basicH3: H3Data = await createH3Data();
+  const basicMaterialToH3: MaterialToH3 = await createMaterialToH3(
+    basicMaterial.id,
+    basicH3.id,
+    MATERIAL_TO_H3_TYPE.HARVEST,
+  );
+  const indicatorRecord = IndicatorRecord.merge(
+    new IndicatorRecord(),
+    {
+      value: 2000,
+      sourcingRecordId: sourcingRecord.id,
+      materialH3DataId: basicMaterialToH3.h3DataId,
+    },
+    additionalData,
+  );
+
+  return indicatorRecord.save();
+}
+
 // Alternate version that doesn't crete a Matching Sourcing Record
 async function createIndicatorRecordV2(
   additionalData: Partial<IndicatorRecord> = {},
@@ -428,4 +452,5 @@ export {
   createUnit,
   createUnitConversion,
   createGeoRegion,
+  createIndicatorRecordForIntervention,
 };

--- a/api/test/utils/scenario-interventions-preconditions.ts
+++ b/api/test/utils/scenario-interventions-preconditions.ts
@@ -1,12 +1,18 @@
 import { AdminRegion } from 'modules/admin-regions/admin-region.entity';
 import { BusinessUnit } from 'modules/business-units/business-unit.entity';
+import { IndicatorRecord } from 'modules/indicator-records/indicator-record.entity';
+import { Indicator } from 'modules/indicators/indicator.entity';
 import { Material } from 'modules/materials/material.entity';
 import { Scenario } from 'modules/scenarios/scenario.entity';
 import { SourcingLocation } from 'modules/sourcing-locations/sourcing-location.entity';
+import { SourcingRecord } from 'modules/sourcing-records/sourcing-record.entity';
 import { Supplier } from 'modules/suppliers/supplier.entity';
 import {
   createAdminRegion,
   createBusinessUnit,
+  createIndicator,
+  createIndicatorRecord,
+  createIndicatorRecordForIntervention,
   createMaterial,
   createScenario,
   createSourcingLocation,
@@ -68,11 +74,63 @@ export async function createInterventionPreconditions(): Promise<ScenarioInterve
     adminRegionId: adminRegion1Descendant.id,
   });
 
-  await createSourcingRecord({
+  const indicator1: Indicator = await createIndicator({
+    name: 'def',
+    nameCode: 'ind1',
+  });
+  const indicator2: Indicator = await createIndicator({
+    name: 'carb',
+    nameCode: 'ind2',
+  });
+  const indicator3: Indicator = await createIndicator({
+    name: 'biod',
+    nameCode: 'ind3',
+  });
+  const indicator4: Indicator = await createIndicator({
+    name: 'watr',
+    nameCode: 'ind4',
+  });
+
+  const sourcingRecord1: SourcingRecord = await createSourcingRecord({
     sourcingLocationId: sourcingLocation1.id,
     year: 2018,
     tonnage: 500,
   });
+  const indicatorRecord1: IndicatorRecord =
+    await createIndicatorRecordForIntervention(
+      {
+        indicator: indicator1,
+        value: 1200,
+      },
+      sourcingRecord1,
+    );
+
+  const indicatorRecord2: IndicatorRecord =
+    await createIndicatorRecordForIntervention(
+      {
+        indicator: indicator2,
+        value: 1200,
+      },
+      sourcingRecord1,
+    );
+
+  const indicatorRecord3: IndicatorRecord =
+    await createIndicatorRecordForIntervention(
+      {
+        indicator: indicator3,
+        value: 1200,
+      },
+      sourcingRecord1,
+    );
+
+  const indicatorRecord4: IndicatorRecord =
+    await createIndicatorRecordForIntervention(
+      {
+        indicator: indicator4,
+        value: 1100,
+      },
+      sourcingRecord1,
+    );
 
   const sourcingLocation2: SourcingLocation = await createSourcingLocation({
     materialId: material2.id,
@@ -81,11 +139,47 @@ export async function createInterventionPreconditions(): Promise<ScenarioInterve
     adminRegionId: adminRegion2.id,
   });
 
-  await createSourcingRecord({
+  const sourcingRecord2: SourcingRecord = await createSourcingRecord({
     sourcingLocationId: sourcingLocation2.id,
     year: 2018,
     tonnage: 600,
   });
+
+  const indicatorRecord5: IndicatorRecord =
+    await createIndicatorRecordForIntervention(
+      {
+        indicator: indicator1,
+        value: 2000,
+      },
+      sourcingRecord2,
+    );
+
+  const indicatorRecord6: IndicatorRecord =
+    await createIndicatorRecordForIntervention(
+      {
+        indicator: indicator2,
+        value: 2200,
+      },
+      sourcingRecord2,
+    );
+
+  const indicatorRecord7: IndicatorRecord =
+    await createIndicatorRecordForIntervention(
+      {
+        indicator: indicator3,
+        value: 2200,
+      },
+      sourcingRecord2,
+    );
+
+  const indicatorRecord8: IndicatorRecord =
+    await createIndicatorRecordForIntervention(
+      {
+        indicator: indicator4,
+        value: 2100,
+      },
+      sourcingRecord2,
+    );
 
   return {
     scenario,


### PR DESCRIPTION
### General description

When creating new intervention, the Indicator Records data is included into initial DB query to find filter matching existing sourcing locations. 
Later that data (Indicator Record values multiplied by percentage) will be used as impact values for locations of type 'Canceled by intervention'

### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

_Provide minimal instructions on how to test this PR._

- Apart from the added feature / bug fix, check overall performance, styling...

## Checklist before merging

- [ ] Branch name / PR includes the related Jira ticket Id.
- [ ] Tests to check core implementation / bug fix added.
- [ ] All checks in Continuous Integration workflow pass.
- [ ] Feature functionally tested by reviewer(s).
- [ ] Code reviewed by reviewer(s).
- [ ] Documentation updated (README, CHANGELOG...) (if required)
