### PR TITLE
Bugfix/general minor fixes interventions

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+
+##  2022-09-102
+### Fixes
+Fixes a issue where the Canceled Sourcing Locations would have a default 'unknown' location type, 
+as the query for filtering the original ones at the beginning of the intervention creation didn't have a 
+select for this field, therefore the instance prop was null,
+and the DB persist it of the default enumerable value, 'unknown'
+
+
+
 ##  2022-08-18
 ### Fixes
 Added a guard in GeoRegion Service to try find either a previously created Point or Radius

--- a/api/src/modules/scenario-interventions/scenario-interventions.service.ts
+++ b/api/src/modules/scenario-interventions/scenario-interventions.service.ts
@@ -601,6 +601,6 @@ export class ScenarioInterventionsService extends AppBaseService<
         ]);
       return geoCodedLocation[0] as SourcingLocation;
     }
-    return [] as unknown as SourcingLocation;
+    return {} as unknown as SourcingLocation;
   }
 }

--- a/api/src/modules/scenario-interventions/scenario-interventions.service.ts
+++ b/api/src/modules/scenario-interventions/scenario-interventions.service.ts
@@ -255,12 +255,6 @@ export class ScenarioInterventionsService extends AppBaseService<
       title: newScenarioIntervention.title,
       updatedById: newIntervention.updatedById,
     };
-    // TODO: try to use insert
-    // await this.sourcingLocationsService.save(
-    //   newCancelledByInterventionLocationsData,
-    // );
-
-    //return this.scenarioInterventionRepository.save(newScenarioIntervention);
   }
 
   /**

--- a/api/src/modules/sourcing-locations/sourcing-locations.service.ts
+++ b/api/src/modules/sourcing-locations/sourcing-locations.service.ts
@@ -134,6 +134,7 @@ export class SourcingLocationsService extends AppBaseService<
           'sl.locationAddressInput',
           'sl.locationLongitude',
           'sl.locationLatitude',
+          'sl.locationType',
           'sr.year',
           'sr.tonnage',
           'ir.value',
@@ -149,7 +150,8 @@ export class SourcingLocationsService extends AppBaseService<
           startYear: createInterventionDto.startYear,
         })
 
-        .andWhere('sl.interventionType IS NULL');
+        .andWhere('sl.interventionType IS NULL')
+        .andWhere('sl.scenarioInterventionId IS NULL');
 
     // Optional filters:
 


### PR DESCRIPTION
### General description

Fixes a issue where the Canceled Sourcing Locations would have a default 'unknown' location type, as the query for filtering the original ones at the beginning of the intervention creation didn't have a select for this field, therefore the instance prop was null, and the DB persist it of the default enumerable value, 'unknown'

### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

Create a intervention of any type, check that the CANCELED locations have the same location types as the original ones

## Checklist before merging

- [ ] Branch name / PR includes the related Jira ticket Id.
- [x] Tests to check core implementation / bug fix added.
- [ ] All checks in Continuous Integration workflow pass.
- [x] Feature functionally tested by reviewer(s).
- [ ] Code reviewed by reviewer(s).
- [x] Documentation updated (README, CHANGELOG...) (if required)
