### PR TITLE
Chore: LANDGRIF-879 save intervention in chunks

### DIFF
--- a/api/src/modules/indicator-records/indicator-record.entity.ts
+++ b/api/src/modules/indicator-records/indicator-record.entity.ts
@@ -1,5 +1,4 @@
 import {
-  AfterInsert,
   Column,
   Entity,
   getManager,
@@ -42,7 +41,7 @@ export enum INDICATOR_RECORD_STATUS {
 export class IndicatorRecord extends TimestampedBaseEntity {
   @ApiProperty()
   @PrimaryGeneratedColumn('uuid')
-  id!: string;
+  id: string;
 
   @ApiProperty()
   @Column({ type: 'float', nullable: true })
@@ -104,7 +103,7 @@ export class IndicatorRecord extends TimestampedBaseEntity {
   @Column({ nullable: false })
   materialH3DataId: string;
 
-  @AfterInsert()
+  //@AfterInsert()
   static async updateImpactView(): Promise<void> {
     await getManager().query(
       `REFRESH MATERIALIZED VIEW ${IMPACT_VIEW_NAME} WITH DATA`,

--- a/api/src/modules/scenario-interventions/intermediate-table-names/intermediate.table.names.ts
+++ b/api/src/modules/scenario-interventions/intermediate-table-names/intermediate.table.names.ts
@@ -1,0 +1,21 @@
+export const REPLACED_ADMIN_REGIONS_TABLE_NAME: string =
+  'replaced_admin_regions';
+
+export const REPLACED_MATERIALS_TABLE_NAME: string = 'replaced_materials';
+
+export const REPLACED_BUSINESS_UNITS_TABLE_NAME: string =
+  'replaced_business_units';
+
+export const REPLACED_SUPPLIERS_TABLE_NAME: string = 'replaced_suppliers';
+
+type interventionId = { scenarioInterventionId: string };
+
+export type ReplacedAdminRegion = { adminRegionId: string } & interventionId;
+
+export type ReplacedMaterial = { materialId: string } & interventionId;
+
+export type ReplacedBusinessUnits = {
+  businessUnitId: string;
+} & interventionId;
+
+export type ReplacedSuppliers = { supplierId: string } & interventionId;

--- a/api/src/modules/scenario-interventions/scenario-intervention.entity.ts
+++ b/api/src/modules/scenario-interventions/scenario-intervention.entity.ts
@@ -22,7 +22,12 @@ import {
 } from 'modules/sourcing-locations/sourcing-location.entity';
 import { TimestampedBaseEntity } from 'baseEntities/timestamped-base-entity';
 import { Scenario } from 'modules/scenarios/scenario.entity';
-
+import {
+  REPLACED_ADMIN_REGIONS_TABLE_NAME,
+  REPLACED_BUSINESS_UNITS_TABLE_NAME,
+  REPLACED_MATERIALS_TABLE_NAME,
+  REPLACED_SUPPLIERS_TABLE_NAME,
+} from 'modules/scenario-interventions/intermediate-table-names/intermediate.table.names';
 export enum SCENARIO_INTERVENTION_STATUS {
   ACTIVE = 'active',
   INACTIVE = 'inactive',
@@ -114,19 +119,19 @@ export class ScenarioIntervention extends TimestampedBaseEntity {
    * Relationships with other entities - links of replaced relationships on this intervention
    */
   @ManyToMany(() => Material, { eager: true })
-  @JoinTable()
+  @JoinTable({ name: REPLACED_MATERIALS_TABLE_NAME })
   replacedMaterials: Material[];
 
   @ManyToMany(() => BusinessUnit, { eager: true })
-  @JoinTable()
+  @JoinTable({ name: REPLACED_BUSINESS_UNITS_TABLE_NAME })
   replacedBusinessUnits: BusinessUnit[];
 
   @ManyToMany(() => Supplier, { eager: true })
-  @JoinTable()
+  @JoinTable({ name: REPLACED_SUPPLIERS_TABLE_NAME })
   replacedSuppliers: Supplier[];
 
   @ManyToMany(() => AdminRegion, { eager: true })
-  @JoinTable()
+  @JoinTable({ name: REPLACED_ADMIN_REGIONS_TABLE_NAME })
   replacedAdminRegions: AdminRegion[];
 
   @OneToMany(
@@ -135,7 +140,7 @@ export class ScenarioIntervention extends TimestampedBaseEntity {
       sourcingLocations.scenarioIntervention,
     { cascade: true, onDelete: 'CASCADE' },
   )
-  replacedSourcingLocations?: SourcingLocation[];
+  replacedSourcingLocations: SourcingLocation[];
 
   /**
    * Relationships with other entities - list of "ne" relationships

--- a/api/src/modules/scenario-interventions/scenario-intervention.repository.ts
+++ b/api/src/modules/scenario-interventions/scenario-intervention.repository.ts
@@ -1,8 +1,33 @@
-import { EntityRepository, Repository } from 'typeorm';
+import {
+  Connection,
+  EntityRepository,
+  getConnection,
+  InsertResult,
+  QueryRunner,
+  Repository,
+} from 'typeorm';
 import { ScenarioIntervention } from 'modules/scenario-interventions/scenario-intervention.entity';
+import { SourcingLocation } from 'modules/sourcing-locations/sourcing-location.entity';
+import { SourcingRecord } from 'modules/sourcing-records/sourcing-record.entity';
+import { IndicatorRecord } from 'modules/indicator-records/indicator-record.entity';
+import { Logger, ServiceUnavailableException } from '@nestjs/common';
+import { v4 as uuidv4 } from 'uuid';
+
+import {
+  REPLACED_ADMIN_REGIONS_TABLE_NAME,
+  REPLACED_BUSINESS_UNITS_TABLE_NAME,
+  REPLACED_MATERIALS_TABLE_NAME,
+  REPLACED_SUPPLIERS_TABLE_NAME,
+  ReplacedAdminRegion,
+  ReplacedBusinessUnits,
+  ReplacedMaterial,
+  ReplacedSuppliers,
+} from 'modules/scenario-interventions/intermediate-table-names/intermediate.table.names';
+import { chunk } from 'lodash';
 
 @EntityRepository(ScenarioIntervention)
 export class ScenarioInterventionRepository extends Repository<ScenarioIntervention> {
+  logger: Logger = new Logger(ScenarioInterventionRepository.name);
   async getScenarioInterventionsByScenarioId(
     scenarioId: string,
   ): Promise<ScenarioIntervention[]> {
@@ -45,5 +70,158 @@ export class ScenarioInterventionRepository extends Repository<ScenarioIntervent
         .where('intervention.scenarioId = :scenarioId', { scenarioId })
         .getMany()
     );
+  }
+
+  // TODO: This is a workaround to bypass TypeORM's issues when bulk inserting. This could be possibly fixed
+  //       By upgrading TypeORM version
+
+  async saveNewIntervention(
+    newIntervention: ScenarioIntervention,
+  ): Promise<any> {
+    const connection: Connection = getConnection();
+    const queryRunner: QueryRunner = connection.createQueryRunner();
+    await queryRunner.connect();
+    await queryRunner.startTransaction();
+    const locations: SourcingLocation[] = [];
+    const records: SourcingRecord[] = [];
+    const impacts: IndicatorRecord[] = [];
+
+    newIntervention.id = uuidv4();
+    const {
+      newSourcingLocations,
+      replacedSourcingLocations,
+      replacedAdminRegions,
+      replacedMaterials,
+      replacedBusinessUnits,
+      replacedSuppliers,
+      ...remainingData
+    } = newIntervention;
+    const allLocations: SourcingLocation[] = replacedSourcingLocations.concat(
+      newSourcingLocations ?? [],
+    );
+    for (const location of allLocations) {
+      location.scenarioInterventionId = newIntervention.id;
+      location.id = uuidv4();
+      locations.push(location);
+      for (const record of location.sourcingRecords) {
+        record.sourcingLocationId = location.id;
+        record.id = uuidv4();
+        records.push(record);
+        for (const impact of record.indicatorRecords) {
+          impact.sourcingRecordId = record.id;
+          impacts.push(impact);
+        }
+      }
+    }
+
+    const replacedSuppliersToSave: ReplacedSuppliers[] = [];
+    const replacedAdminRegionsToSave: ReplacedAdminRegion[] = [];
+    const replacedBusinessUnitsToSave: ReplacedBusinessUnits[] = [];
+    const replacedMaterialsToSave: ReplacedMaterial[] = [];
+    for (const supplier of replacedSuppliers) {
+      replacedSuppliersToSave.push({
+        supplierId: supplier.id,
+        scenarioInterventionId: newIntervention.id,
+      });
+    }
+    for (const region of replacedAdminRegions) {
+      replacedAdminRegionsToSave.push({
+        adminRegionId: region.id,
+        scenarioInterventionId: newIntervention.id,
+      });
+    }
+    for (const material of replacedMaterials) {
+      replacedMaterialsToSave.push({
+        materialId: material.id,
+        scenarioInterventionId: newIntervention.id,
+      });
+    }
+    for (const unit of replacedBusinessUnits) {
+      replacedBusinessUnitsToSave.push({
+        businessUnitId: unit.id,
+        scenarioInterventionId: newIntervention.id,
+      });
+    }
+
+    try {
+      this.logger.log(
+        `Saving ${locations.length} Sourcing Locations for Intervention with Id: ${newIntervention.id}`,
+      );
+      const intervention: InsertResult = await queryRunner.manager.insert(
+        ScenarioIntervention,
+        remainingData,
+      );
+      this.logger.log(
+        `Saving ${locations.length} Sourcing Locations for Intervention with Id: ${newIntervention.id}`,
+      );
+      await queryRunner.manager.insert(SourcingLocation, locations);
+      this.logger.log(
+        `Saving ${records.length} Sourcing Records for Intervention with Id: ${newIntervention.id}`,
+      );
+      await queryRunner.manager.insert(SourcingRecord, records);
+      this.logger.log(
+        `Saving ${impacts.length} Indicator Records for Intervention with Id: ${newIntervention.id}`,
+      );
+      // LOGs suggest to insert one a t a time
+      for (const [index, dataChunk] of chunk(impacts, 1000).entries()) {
+        this.logger.debug(
+          `Inserting chunk #${index} (${dataChunk.length} items)...`,
+        );
+        const promises: Promise<InsertResult>[] = dataChunk.map(
+          (row: IndicatorRecord) =>
+            queryRunner.manager
+              .createQueryBuilder()
+              .insert()
+              .into(IndicatorRecord)
+              .values(row)
+              .execute(),
+        );
+        await Promise.all(promises);
+      }
+      // LOGs suggest being inserted once
+      await queryRunner.manager
+        .createQueryBuilder()
+        .insert()
+        .into(REPLACED_SUPPLIERS_TABLE_NAME)
+        .values(replacedSuppliersToSave)
+        .execute();
+      //
+      await queryRunner.manager
+        .createQueryBuilder()
+        .insert()
+        .into(REPLACED_ADMIN_REGIONS_TABLE_NAME)
+        .values(replacedAdminRegionsToSave)
+        .execute();
+
+      await queryRunner.manager
+        .createQueryBuilder()
+        .insert()
+        .into(REPLACED_MATERIALS_TABLE_NAME)
+        .values(replacedMaterialsToSave)
+        .execute();
+
+      await queryRunner.manager
+        .createQueryBuilder()
+        .insert()
+        .into(REPLACED_BUSINESS_UNITS_TABLE_NAME)
+        .values(replacedBusinessUnitsToSave)
+        .execute();
+      this.logger.log('Committing transaction...');
+
+      await queryRunner.commitTransaction();
+      this.logger.log('New Intervention Saving Finished');
+
+      return intervention;
+    } catch (err) {
+      // rollback changes before throwing error
+      await queryRunner.rollbackTransaction();
+      this.logger.error(err);
+      throw new ServiceUnavailableException(
+        'Intervention could not been saved: ' + err,
+      );
+    } finally {
+      // release query runner which is manually created
+      await queryRunner.release();
+    }
   }
 }

--- a/api/src/modules/scenario-interventions/scenario-interventions.service.ts
+++ b/api/src/modules/scenario-interventions/scenario-interventions.service.ts
@@ -26,6 +26,7 @@ import { SourcingLocationsService } from 'modules/sourcing-locations/sourcing-lo
 import { GeoCodingAbstractClass } from 'modules/geo-coding/geo-coding-abstract-class';
 import { InterventionBuilder } from 'modules/scenario-interventions/services/intervention-builder.service';
 import { SourcingRecord } from 'modules/sourcing-records/sourcing-record.entity';
+import { InsertResult } from 'typeorm';
 
 @Injectable()
 export class ScenarioInterventionsService extends AppBaseService<
@@ -192,15 +193,19 @@ export class ScenarioInterventionsService extends AppBaseService<
      *
      *
      */
-    const savedIntervention: ScenarioIntervention =
-      await this.scenarioInterventionRepository.save(newIntervention);
+    const savedIntervention: InsertResult =
+      await this.scenarioInterventionRepository.saveNewIntervention(
+        newIntervention,
+      );
 
-    this.logger.log(`New Intervention with Id: ${savedIntervention.id} saved.`);
+    this.logger.log(
+      `New Intervention with Id: ${savedIntervention.identifiers[0].id} saved.`,
+    );
 
     return {
-      id: savedIntervention.id,
-      title: savedIntervention.title,
-      updatedById: savedIntervention.updatedById,
+      id: savedIntervention.identifiers[0].id,
+      title: newIntervention.title,
+      updatedById: newIntervention.updatedById,
     };
   }
 

--- a/api/src/modules/scenario-interventions/scenario-interventions.service.ts
+++ b/api/src/modules/scenario-interventions/scenario-interventions.service.ts
@@ -27,6 +27,7 @@ import { GeoCodingAbstractClass } from 'modules/geo-coding/geo-coding-abstract-c
 import { InterventionBuilder } from 'modules/scenario-interventions/services/intervention-builder.service';
 import { SourcingRecord } from 'modules/sourcing-records/sourcing-record.entity';
 import { InsertResult } from 'typeorm';
+import { IndicatorRecord } from 'modules/indicator-records/indicator-record.entity';
 
 @Injectable()
 export class ScenarioInterventionsService extends AppBaseService<
@@ -258,7 +259,13 @@ export class ScenarioInterventionsService extends AppBaseService<
           return {
             year: elem.year,
             tonnage: elem.tonnage,
-            indicatorRecords: elem.indicatorRecords,
+            indicatorRecords: elem.indicatorRecords.map(
+              (impact: IndicatorRecord) => ({
+                value: impact.value,
+                indicatorId: impact.indicatorId,
+                materialH3DataId: impact.materialH3DataId,
+              }),
+            ),
           } as SourcingRecord;
         });
       newCancelledInterventionLocation.interventionType = canceledOrReplacing;

--- a/api/test/e2e/scenario-interventions/scenario-interventions.spec.ts
+++ b/api/test/e2e/scenario-interventions/scenario-interventions.spec.ts
@@ -13,6 +13,8 @@ import {
   createAdminRegion,
   createBusinessUnit,
   createGeoRegion,
+  createIndicatorRecord,
+  createIndicatorSource,
   createMaterial,
   createScenario,
   createScenarioIntervention,
@@ -63,6 +65,7 @@ import { H3Data } from 'modules/h3-data/h3-data.entity';
 import { Indicator } from 'modules/indicators/indicator.entity';
 import { Unit } from 'modules/units/unit.entity';
 import { SourcingLocationGroup } from 'modules/sourcing-location-groups/sourcing-location-group.entity';
+import { FourMockIndicatorRecords } from '../../utils/indicator-records-preconditions';
 
 const expectedJSONAPIAttributes: string[] = [
   'title',
@@ -160,7 +163,9 @@ describe('ScenarioInterventionsModule (e2e)', () => {
       .overrideProvider(GeoCodingAbstractClass)
       .useValue(geoCodingServiceMock)
       .overrideProvider(IndicatorRecordsService)
-      .useValue({ createIndicatorRecordsBySourcingRecords: () => null })
+      .useValue({
+        createIndicatorRecordsBySourcingRecords: () => FourMockIndicatorRecords,
+      })
       .compile();
 
     scenarioInterventionRepository =
@@ -1864,8 +1869,6 @@ describe('ScenarioInterventionsModule (e2e)', () => {
             },
           },
         );
-
-        console.log(canceledSourcingLocations);
 
         expect(canceledSourcingLocations).toHaveLength(2);
         expect(

--- a/api/test/utils/indicator-records-preconditions.ts
+++ b/api/test/utils/indicator-records-preconditions.ts
@@ -86,3 +86,22 @@ export const createWorldToCalculateIndicatorRecords =
       ],
     };
   };
+
+export const FourMockIndicatorRecords = [
+  {
+    value: 600,
+    indicatorId: '8f7f5bab-46fb-40e2-9031-99c06d155289',
+  },
+  {
+    value: 600,
+    indicatorId: 'e0f788eb-aaba-4a23-85f3-936ef672a723',
+  },
+  {
+    value: 600,
+    indicatorId: '04ac7860-75a2-4ad6-9dff-25205f5ce0ac',
+  },
+  {
+    value: 550,
+    indicatorId: 'ce4780ad-fe11-48eb-9d98-3b14dc33f7be',
+  },
+];

--- a/api/test/utils/scenario-interventions-preconditions.ts
+++ b/api/test/utils/scenario-interventions-preconditions.ts
@@ -5,20 +5,25 @@ import { Scenario } from 'modules/scenarios/scenario.entity';
 import { SourcingLocation } from 'modules/sourcing-locations/sourcing-location.entity';
 import { Supplier } from 'modules/suppliers/supplier.entity';
 import { IndicatorRecord } from 'modules/indicator-records/indicator-record.entity';
-import { Indicator } from 'modules/indicators/indicator.entity';
+import {
+  Indicator,
+  INDICATOR_TYPES,
+} from 'modules/indicators/indicator.entity';
 import { SourcingRecord } from 'modules/sourcing-records/sourcing-record.entity';
 import {
   createAdminRegion,
   createBusinessUnit,
+  createH3Data,
+  createIndicator,
+  createIndicatorRecordForIntervention,
   createMaterial,
+  createMaterialToH3,
   createScenario,
   createSourcingLocation,
   createSourcingRecord,
   createSupplier,
-  createIndicator,
-  createIndicatorRecord,
-  createIndicatorRecordForIntervention,
 } from '../entity-mocks';
+import { MATERIAL_TO_H3_TYPE } from '../../src/modules/materials/material-to-h3.entity';
 
 export interface ScenarioInterventionPreconditions {
   scenario: Scenario;
@@ -76,20 +81,46 @@ export async function createInterventionPreconditions(): Promise<ScenarioInterve
 
   const indicator1: Indicator = await createIndicator({
     name: 'def',
-    nameCode: 'ind1',
+    nameCode: INDICATOR_TYPES.CARBON_EMISSIONS,
   });
   const indicator2: Indicator = await createIndicator({
     name: 'carb',
-    nameCode: 'ind2',
+    nameCode: INDICATOR_TYPES.BIODIVERSITY_LOSS,
   });
   const indicator3: Indicator = await createIndicator({
     name: 'biod',
-    nameCode: 'ind3',
+    nameCode: INDICATOR_TYPES.UNSUSTAINABLE_WATER_USE,
   });
   const indicator4: Indicator = await createIndicator({
     name: 'watr',
-    nameCode: 'ind4',
+    nameCode: INDICATOR_TYPES.DEFORESTATION,
   });
+
+  const h3data1 = await createH3Data({ indicatorId: indicator1.id });
+  const h3data2 = await createH3Data({ indicatorId: indicator2.id });
+  const h3data3 = await createH3Data({ indicatorId: indicator3.id });
+  const h3data4 = await createH3Data({ indicatorId: indicator4.id });
+  const harvest = await createMaterialToH3(
+    material1Descendant.id,
+    h3data1.id,
+    MATERIAL_TO_H3_TYPE.HARVEST,
+  );
+  const producer = await createMaterialToH3(
+    material1Descendant.id,
+    h3data1.id,
+    MATERIAL_TO_H3_TYPE.PRODUCER,
+  );
+
+  const harvest1 = await createMaterialToH3(
+    material2.id,
+    h3data1.id,
+    MATERIAL_TO_H3_TYPE.HARVEST,
+  );
+  const producer1 = await createMaterialToH3(
+    material2.id,
+    h3data1.id,
+    MATERIAL_TO_H3_TYPE.PRODUCER,
+  );
 
   const sourcingRecord1: SourcingRecord = await createSourcingRecord({
     sourcingLocationId: sourcingLocation1.id,


### PR DESCRIPTION
### General description

Adds a new method on Intervention Repository to destructure all the Intervention object, and save all elements separately, but in a single transaction, to try to workaround a blocked thread, which happens with the worst case scenario when creating a new intervention.

NOTE: This taks is a patch before we upgrade TypeORM after the demo

### Designs


### Testing instructions

Restore your database with the latests dump available in Data/dumps folder in drive, and create a new intervention that applies to Palm Oil, selecting start year from the first one available (2010). It should take about 2 minutes and a half to complete the process, but succesfully and with no errors (it's a bulk of around +100
k elements
- Apart from the added feature / bug fix, check overall performance, styling...

## Checklist before merging

- [x] Branch name / PR includes the related Jira ticket Id.
- [x] Tests to check core implementation / bug fix added.
- [x] All checks in Continuous Integration workflow pass.
- [x] Feature functionally tested by reviewer(s).
- [x] Code reviewed by reviewer(s).
- [ ] Documentation updated (README, CHANGELOG...) (if required)
