### PR TITLE
Add sql caching option using redis; refactor config values structure

### DIFF
--- a/ENV_VARS.md
+++ b/ENV_VARS.md
@@ -7,5 +7,34 @@ are imported using [node-config](https://www.npmjs.com/package/config) through
 [this file](https://github.com/Vizzuality/landgriffon/blob/044ea856536a868e68b786d841f6b73f1859d28b/api/config/custom-environment-variables.json)
 for the API app.
 
+### Database
+
+* `DB_HOST` (string): hostname in which the database server can be reached.
+* `DB_PORT` (number): port in which the database server can be reached.
+* `DB_USERNAME` (string): username to use when connecting to the database.
+* `DB_PASSWORD` (string): password to use when connecting to the database.
+* `DB_DATABASE` (string): database name to use.
+* `DB_SYNCHRONIZE` (boolean): if set to "true", model changes will be automatically applied to the database on app startup. Defaults to "false".
+* `DB_MIGRATIONS_RUN` (boolean): if set to "true", pending migrations will be automatically applied to the database on app startup. Defaults to "true".
+* `CHUNK_SIZE_FOR_BATCH_DB_OPERATIONS` (number): when batch-saving data, determines how many records are saved per operation. Defaults to "50".
+* `DB_CACHE_ENABLED` (boolean): if the database cache is enabled. Defaults to "true".
+* `DB_CACHE_HOST` (string): hostname in which the Redis server can be reached.
+* `DB_CACHE_PORT` (number): port in which the Redis server can be reached.
+* `DB_CACHE_DATABASE` (number): Redis logical database number to be used for caching. Defaults to "3".
+
+
+### Geocoding cache config
+
 * `GEOCODING_CACHE_ENABLED` (boolean): if the geocoding cache is enabled.
+* `GEOCODING_CACHE_HOST` (string): hostname in which the Redis server can be reached.
+* `GEOCODING_CACHE_PORT` (number): port in which the Redis server can be reached.
+* `GEOCODING_CACHE_DATABASE` (number): Redis logical database number to be used for caching. Defaults to "2".
 * `GEOCODING_TTL` (number): time, in seconds, to keep a geocoding response in cache. Defaults to one day. 
+
+
+### Asynchronous task handling config (message broker)
+
+* `QUEUE_HOST` (string): hostname in which the Redis server can be reached.
+* `QUEUE_PORT` (number): port in which the Redis server can be reached.
+* `QUEUE_DATABASE` (number): Redis logical database number to be used for caching. Defaults to "1".
+* `IMPORT_QUEUE_NAME` (string): name of the Redis queue to use for data import related messages. Defaults to "excel-import"

--- a/api/README.md
+++ b/api/README.md
@@ -9,6 +9,7 @@
 - [PostgreSQL](https://www.postgresql.org/) v13.2 or greater
 - [Postgis](https://postgis.net/) v3.1 or greater
 - [PostgreSQL bindings for H3](https://github.com/bytesandbrains/h3-pg) v3.7.1 or greater
+- [Redis](https://redis.io/) v6 or greater
 
 ## Documentation
 
@@ -28,6 +29,11 @@ Be sure to review the installation process for both these extensions and follow 
 You also need to manually create a database prior to the first execution of this API, and both extensions above need to be enabled for said database.
 
 Once that's in place, you can start the application, which will populate the database structure.
+
+### Redis
+
+Redis is used as a message broker, as well as for caching certain precomputed results. While caching can be disabled using
+configuration environment variables, it is required for message broker operations. 
 
 ### Application setup
 

--- a/api/config/custom-environment-variables.json
+++ b/api/config/custom-environment-variables.json
@@ -20,13 +20,17 @@
   "import": {
     "missingDataFallbackStrategy": "IMPORT_MISSING_DATA_FALLBACK_STRATEGY"
   },
-  "redis": {
-    "host": "REDIS_HOST",
-    "port": "REDIS_PORT",
-    "importQueueName": "REDIS_IMPORT_QUEUE_NAME"
+  "queue": {
+    "host": "QUEUE_HOST",
+    "port": "QUEUE_PORT",
+    "database": "QUEUE_DATABASE",
+    "importQueueName": "IMPORT_QUEUE_NAME"
   },
   "geocodingCache": {
     "enabled": "GEOCODING_CACHE_ENABLED",
+    "host": "GEOCODING_CACHE_HOST",
+    "port": "GEOCODING_CACHE_PORT",
+    "database": "GEOCODING_CACHE_DATABASE",
     "TTL": "GEOCODING_CACHE_TTL"
   },
   "db": {
@@ -37,7 +41,11 @@
     "database": "DB_DATABASE",
     "synchronize": "DB_SYNCHRONIZE",
     "migrationsRun": "DB_MIGRATIONS_RUN",
-    "batchChunkSize": "CHUNK_SIZE_FOR_BATCH_DB_OPERATIONS"
+    "batchChunkSize": "CHUNK_SIZE_FOR_BATCH_DB_OPERATIONS",
+    "cacheEnabled": "DB_CACHE_ENABLED",
+    "cacheHost": "DB_CACHE_HOST",
+    "cachePort": "DB_CACHE_PORT",
+    "cacheDatabase": "DB_CACHE_DATABASE"
   },
   "fileUploads": {
     "sizeLimit": "FILE_SIZE_LIMIT",

--- a/api/config/default.json
+++ b/api/config/default.json
@@ -25,13 +25,17 @@
   "import": {
     "missingDataFallbackStrategy": "fallback"
   },
-  "redis": {
+  "queue": {
     "host": "localhost",
     "port": 6379,
+    "database": 1,
     "importQueueName": "excel-import"
   },
   "geocodingCache": {
     "enabled": true,
+    "host": "localhost",
+    "port": 6379,
+    "database": 2,
     "TTL": 86400
   },
   "db": {
@@ -45,7 +49,10 @@
     "migrationsRun": true,
     "dropSchema": false,
     "logging": true,
-    "batchChunkSize": 50
+    "batchChunkSize": 50,
+    "cacheEnabled": true,
+    "cacheHost": "localhost",
+    "cacheDatabase": 3
   },
   "fileUploads": {
     "sizeLimit": 8388608,

--- a/api/config/development.json
+++ b/api/config/development.json
@@ -12,14 +12,8 @@
   "auth": {
     "requireUserAccountActivation": false,
     "jwt": {
-      "expiresIn": "1m",
       "secret": "myVeryBadJWTSecretForTests"
     }
-  },
-  "redis": {
-    "host": "localhost",
-    "port": 6379,
-    "importQueueName": "excel-import"
   },
   "map": {
     "distributed": true

--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -36,7 +36,7 @@ import { ContextualLayersModule } from 'modules/contextual-layers/contextual-lay
 import { CachedDataModule } from 'modules/cached-data/cached-data.module';
 import * as config from 'config';
 
-const redisConfig: any = config.get('redis');
+const queueConfig: any = config.get('queue');
 
 @Module({
   imports: [
@@ -44,8 +44,9 @@ const redisConfig: any = config.get('redis');
     TypeOrmModule.forRoot(typeOrmConfig),
     BullModule.forRoot({
       redis: {
-        host: redisConfig.host,
-        port: redisConfig.port,
+        host: queueConfig.host,
+        port: queueConfig.port,
+        db: queueConfig.database,
       },
       settings: { lockDuration: 10000000, maxStalledCount: 0 },
     }),

--- a/api/src/health.controller.ts
+++ b/api/src/health.controller.ts
@@ -10,7 +10,7 @@ import { HealthCheckResult } from '@nestjs/terminus/dist/health-check/health-che
 import { Public } from 'decorators/public.decorator';
 import * as config from 'config';
 
-const redisConfig: any = config.get('redis');
+const queueConfig: any = config.get('queue');
 
 @Controller('health')
 export class HealthController {
@@ -28,7 +28,7 @@ export class HealthController {
         this.microservice.pingCheck<RedisOptions>('redis', {
           transport: Transport.REDIS,
           options: {
-            url: `redis://${redisConfig.host}:${redisConfig.port}`,
+            url: `redis://${queueConfig.host}:${queueConfig.port}`,
           },
         }),
     ]);

--- a/api/src/modules/geo-coding/geo-coding.module.ts
+++ b/api/src/modules/geo-coding/geo-coding.module.ts
@@ -17,7 +17,6 @@ import { GoogleMapsGeocoder } from 'modules/geo-coding/geocoders/google-maps.geo
 import * as redisStore from 'cache-manager-redis-store';
 import * as config from 'config';
 
-const redisConfig: any = config.get('redis');
 const geocodingCacheConfig: any = config.get('geocodingCache');
 
 const geocodingCacheTTL: number = parseInt(
@@ -34,8 +33,9 @@ const geocodingCacheEnabled: boolean =
     SourcingLocationsModule,
     CacheModule.register({
       store: redisStore,
-      host: redisConfig.host,
-      port: redisConfig.port,
+      host: geocodingCacheConfig.host,
+      port: geocodingCacheConfig.port,
+      db: geocodingCacheConfig.database,
       ttl: geocodingCacheTTL,
     }),
   ],

--- a/api/src/modules/import-data/workers/import-queue.name.ts
+++ b/api/src/modules/import-data/workers/import-queue.name.ts
@@ -1,3 +1,3 @@
 import * as config from 'config';
 
-export const importQueueName: string = config.get('redis.importQueueName');
+export const importQueueName: string = config.get('queue.importQueueName');

--- a/api/src/modules/indicator-records/indicator-records.service.ts
+++ b/api/src/modules/indicator-records/indicator-records.service.ts
@@ -527,7 +527,7 @@ export class IndicatorRecordsService extends AppBaseService<
   }
 
   /**
-   * his functions calculates (or gets from the Cached Data if present) the indicator raw value
+   * This functions calculates (or gets from the Cached Data if present) the indicator raw value
    * for the given indicators, material and geoRegion, and puts the result on the cache if needed.
    * @param geoRegionId
    * @param indicatorType

--- a/api/src/typeorm.config.ts
+++ b/api/src/typeorm.config.ts
@@ -21,6 +21,17 @@ export const typeOrmConfig: TypeOrmModuleOptions = {
   cli: {
     migrationsDir: 'migrations',
   },
+  cache:
+    dbConfig.cacheEnabled === true || dbConfig.cacheEnabled === 'true'
+      ? {
+          type: 'redis',
+          options: {
+            host: dbConfig.cacheHost,
+            port: dbConfig.cachePort ? parseInt(dbConfig.cachePort) : 6379,
+            db: dbConfig.cacheDatabase ? parseInt(dbConfig.cacheDatabase) : 1,
+          },
+        }
+      : false,
   uuidExtension: 'pgcrypto',
   entities: [ImpactMaterializedView],
 };

--- a/infrastructure/kubernetes/modules/api/main.tf
+++ b/infrastructure/kubernetes/modules/api/main.tf
@@ -119,7 +119,7 @@ resource "kubernetes_deployment" "api_deployment" {
           }
 
           env {
-            name = "REDIS_HOST"
+            name = "QUEUE_HOST"
             value_from {
               secret_key_ref {
                 name = "db"
@@ -129,11 +129,21 @@ resource "kubernetes_deployment" "api_deployment" {
           }
 
           env {
-            name = "REDIS_IMPORT_QUEUE_NAME"
+            name = "GEOCODING_CACHE_HOST"
             value_from {
               secret_key_ref {
                 name = "db"
-                key  = "REDIS_IMPORT_QUEUE_NAME"
+                key  = "REDIS_HOST"
+              }
+            }
+          }
+
+          env {
+            name = "DB_CACHE_HOST"
+            value_from {
+              secret_key_ref {
+                name = "db"
+                key  = "REDIS_HOST"
               }
             }
           }

--- a/infrastructure/kubernetes/modules/secrets/main.tf
+++ b/infrastructure/kubernetes/modules/secrets/main.tf
@@ -102,7 +102,6 @@ resource "kubernetes_secret" "db_secret" {
     DB_DATABASE             = sensitive(local.postgres_secret_json.database)
     DB_SYNCHRONIZE          = "true"
     REDIS_HOST              = "redis-master.${var.namespace}.svc.cluster.local"
-    REDIS_IMPORT_QUEUE_NAME = "excel-import-${var.namespace}"
   }
 }
 


### PR DESCRIPTION
### General description

This PR adds the possibility to enable Redis as a TypeORM query cache.
Since this is the 3rd different usage of Redis we make, I also modified the config value structure to no longer assume all 3 different usages actually use a single Redis server - that is the case now, but may not be in the future.
I also added separate Redis databases for each usage, in case we do want to use a single Redis server, but still keep things separated