### PR TITLE
Feature LANDGRIF-899 ranking include scenario data

### DIFF
--- a/api/src/modules/impact/comparison/actual-vs-scenario.service.ts
+++ b/api/src/modules/impact/comparison/actual-vs-scenario.service.ts
@@ -1,8 +1,8 @@
 import { Injectable, Logger } from '@nestjs/common';
 import {
-  GetActualVsScenarioImpactTabledto,
+  GetActualVsScenarioImpactTableDto,
   GetImpactTableDto,
-} from 'modules/impact/dto/get-impact-table.dto';
+} from 'modules/impact/dto/impact-table.dto';
 import { IndicatorsService } from 'modules/indicators/indicators.service';
 import { SourcingRecordsService } from 'modules/sourcing-records/sourcing-records.service';
 import {
@@ -47,7 +47,7 @@ export class ActualVsScenarioImpactService {
   ) {}
 
   async getActualVsScenarioImpactTable(
-    actualVsScenarioImpactTableDto: GetActualVsScenarioImpactTabledto,
+    actualVsScenarioImpactTableDto: GetActualVsScenarioImpactTableDto,
     fetchSpecification: FetchSpecification,
   ): Promise<PaginatedImpactTable> {
     const indicators: Indicator[] =
@@ -101,7 +101,7 @@ export class ActualVsScenarioImpactService {
   }
 
   /**
-   * Modifies the ImpactTabledto such that, for each entityIds that is populated,
+   * @description: Modifies the ImpactTabledto such that, for each entityIds that is populated,
    * the ids of their descendants are added, in-place
    * @param impactTableDto
    * @private
@@ -135,7 +135,7 @@ export class ActualVsScenarioImpactService {
    * @private
    */
   private async getScenarioAndActualEntityTrees(
-    getActualVsScenarioImpactTableDto: GetActualVsScenarioImpactTabledto,
+    getActualVsScenarioImpactTableDto: GetActualVsScenarioImpactTableDto,
   ): Promise<ImpactTableEntityType[]> {
     const treeOptions: GetMaterialTreeWithOptionsDto = {
       ...(getActualVsScenarioImpactTableDto.materialIds && {
@@ -217,7 +217,7 @@ export class ActualVsScenarioImpactService {
   }
 
   private getDataForActualVsScenarioImpactTable(
-    actualVsScenarioImpactTableDto: GetActualVsScenarioImpactTabledto,
+    actualVsScenarioImpactTableDto: GetActualVsScenarioImpactTableDto,
     entities: ImpactTableEntityType[],
   ): Promise<ActualVsScenarioImpactTableData[]> {
     return entities.length > 0
@@ -228,7 +228,7 @@ export class ActualVsScenarioImpactService {
   }
 
   private buildActualVsScenarioImpactTable(
-    queryDto: GetActualVsScenarioImpactTabledto,
+    queryDto: GetActualVsScenarioImpactTableDto,
     indicators: Indicator[],
     dataForActualVsScenarioImpactTable: ActualVsScenarioImpactTableData[],
     entities: ImpactTableRows[],

--- a/api/src/modules/impact/dto/impact-table.dto.ts
+++ b/api/src/modules/impact/dto/impact-table.dto.ts
@@ -18,7 +18,7 @@ import {
 } from 'modules/sourcing-locations/sourcing-location.entity';
 import { transformLocationType } from 'utils/transform-location-type.util';
 
-export class GetImpactTableDto {
+export class BaseImpactTableDto {
   @ApiProperty({
     name: 'indicatorIds[]',
   })
@@ -88,14 +88,24 @@ export class GetImpactTableDto {
   locationTypes?: LOCATION_TYPES_PARAMS[];
 }
 
-export class GetActualVsScenarioImpactTabledto extends GetImpactTableDto {
-  @ApiPropertyOptional()
-  @IsOptional()
+export class GetActualVsScenarioImpactTableDto extends BaseImpactTableDto {
+  @ApiProperty()
+  @IsNotEmpty()
   @IsUUID(4)
   scenarioId: string;
 }
 
-export class GetRankedImpactTableDto extends GetImpactTableDto {
+export class GetImpactTableDto extends BaseImpactTableDto {
+  @ApiPropertyOptional({
+    description:
+      'Include in the response elements that are being intervened in a Scenario,',
+  })
+  @IsOptional()
+  @IsUUID(4)
+  scenarioId?: string;
+}
+
+export class GetRankedImpactTableDto extends BaseImpactTableDto {
   @ApiProperty({
     description:
       'The maximum number of entities to show in the Impact Table. If the result includes more than that, they will be' +
@@ -116,5 +126,13 @@ export class GetRankedImpactTableDto extends GetImpactTableDto {
   @IsIn(['ASC', 'DES'], {
     message: `sort property must be either 'ASC' (Ascendant) or 'DES' (Descendent)`,
   })
-  sort?: string; // ASC or DESC, will be DESC by default
+  sort?: string;
+
+  @ApiPropertyOptional({
+    description:
+      'Include in the response elements that are being intervened in a Scenario,',
+  })
+  @IsOptional()
+  @IsUUID(4)
+  scenarioId?: string;
 }

--- a/api/src/modules/impact/impact.controller.ts
+++ b/api/src/modules/impact/impact.controller.ts
@@ -1,9 +1,9 @@
 import { Controller, Get, Query, ValidationPipe } from '@nestjs/common';
 import {
-  GetActualVsScenarioImpactTabledto,
+  GetActualVsScenarioImpactTableDto,
   GetImpactTableDto,
   GetRankedImpactTableDto,
-} from 'modules/impact/dto/get-impact-table.dto';
+} from 'modules/impact/dto/impact-table.dto';
 import { ImpactService } from 'modules/impact/impact.service';
 import {
   ApiBearerAuth,
@@ -20,7 +20,7 @@ import {
   ProcessFetchSpecification,
 } from 'nestjs-base-service';
 import { JSONAPIPaginationQueryParams } from 'decorators/json-api-parameters.decorator';
-import { ActualVsScenarioImpactService } from './actual-vs-scenario.service';
+import { ActualVsScenarioImpactService } from 'modules/impact/comparison/actual-vs-scenario.service';
 
 @Controller('/api/v1/impact')
 @ApiTags('Impact')
@@ -28,7 +28,7 @@ import { ActualVsScenarioImpactService } from './actual-vs-scenario.service';
 export class ImpactController {
   constructor(
     private readonly impactService: ImpactService,
-    private readonly actualVsScenarioiImpactService: ActualVsScenarioImpactService,
+    private readonly actualVsScenarioImpactService: ActualVsScenarioImpactService,
   ) {}
 
   @ApiOperation({
@@ -61,9 +61,9 @@ export class ImpactController {
   async getActualVsScenarioImpactTable(
     @ProcessFetchSpecification() fetchSpecification: FetchSpecification,
     @Query(ValidationPipe)
-    actualvsScenarioImpactTableDto: GetActualVsScenarioImpactTabledto,
+    actualvsScenarioImpactTableDto: GetActualVsScenarioImpactTableDto,
   ): Promise<PaginatedImpactTable> {
-    return await this.actualVsScenarioiImpactService.getActualVsScenarioImpactTable(
+    return await this.actualVsScenarioImpactService.getActualVsScenarioImpactTable(
       actualvsScenarioImpactTableDto,
       fetchSpecification,
     );

--- a/api/src/modules/impact/impact.module.ts
+++ b/api/src/modules/impact/impact.module.ts
@@ -7,7 +7,7 @@ import { BusinessUnitsModule } from 'modules/business-units/business-units.modul
 import { AdminRegionsModule } from 'modules/admin-regions/admin-regions.module';
 import { SuppliersModule } from 'modules/suppliers/suppliers.module';
 import { MaterialsModule } from 'modules/materials/materials.module';
-import { ActualVsScenarioImpactService } from './actual-vs-scenario.service';
+import { ActualVsScenarioImpactService } from 'modules/impact/comparison/actual-vs-scenario.service';
 
 @Module({
   imports: [

--- a/api/src/modules/impact/impact.repository.ts
+++ b/api/src/modules/impact/impact.repository.ts
@@ -1,0 +1,80 @@
+import { Repository, getManager, SelectQueryBuilder } from 'typeorm';
+import {
+  BaseImpactTableDto,
+  GetActualVsScenarioImpactTableDto,
+} from 'modules/impact/dto/impact-table.dto';
+import { SourcingRecord } from 'modules/sourcing-records/sourcing-record.entity';
+import { SourcingLocation } from 'modules/sourcing-locations/sourcing-location.entity';
+import { IndicatorRecord } from 'modules/indicator-records/indicator-record.entity';
+import { Indicator } from 'modules/indicators/indicator.entity';
+import { Material } from 'modules/materials/material.entity';
+import { AdminRegion } from 'modules/admin-regions/admin-region.entity';
+import { Supplier } from 'modules/suppliers/supplier.entity';
+import { BusinessUnit } from 'modules/business-units/business-unit.entity';
+
+/**
+ * @description: Even to Impact is not a mapped entity in our codebase, we will use
+ * this repository to centralise all data layer access regarding Impact
+ * It is not included in the module
+ */
+
+// TODO: Refactor tu use this repository for all Impact Related data retrieval (Currently using Sourcing Records repo for this purpose)
+
+export class ImpactRepository extends Repository<any> {
+  private createBasicSelectQuery(
+    impactDataDto: GetActualVsScenarioImpactTableDto | BaseImpactTableDto,
+  ): SelectQueryBuilder<SourcingRecord> {
+    return getManager()
+      .createQueryBuilder()
+      .select('sourcingRecords.year', 'year')
+      .addSelect('sum(sourcingRecords.tonnage)', 'tonnes')
+      .addSelect('sum(indicatorRecord.value)', 'impact')
+      .addSelect('indicator.id', 'indicatorId')
+      .addSelect('sourcingLocation.interventionType', 'typeByIntervention')
+      .from(SourcingRecord, 'sourcingRecords')
+      .leftJoin(
+        SourcingLocation,
+        'sourcingLocation',
+        'sourcingLocation.id = sourcingRecords.sourcingLocationId',
+      )
+      .leftJoin(
+        IndicatorRecord,
+        'indicatorRecord',
+        'indicatorRecord.sourcingRecordId = sourcingRecords.id',
+      )
+      .leftJoin(
+        Indicator,
+        'indicator',
+        'indicator.id = indicatorRecord.indicatorId',
+      )
+      .leftJoin(
+        Material,
+        'material',
+        'material.id = sourcingLocation.materialId',
+      )
+      .leftJoin(
+        AdminRegion,
+        'adminRegion',
+        'sourcingLocation.adminRegionId = adminRegion.id ',
+      )
+      .leftJoin(
+        Supplier,
+        'supplier',
+        'sourcingLocation.producerId = supplier.id or sourcingLocation.t1SupplierId = supplier.id',
+      )
+      .leftJoin(
+        BusinessUnit,
+        'businessUnit',
+        'sourcingLocation.businessUnitId = businessUnit.id',
+      )
+
+      .where('sourcingRecords.year BETWEEN :startYear and :endYear', {
+        startYear: impactDataDto.startYear,
+        endYear: impactDataDto.endYear,
+      })
+      .andWhere('indicator.id IN (:...indicatorIds)', {
+        indicatorIds: impactDataDto.indicatorIds,
+      });
+  }
+  // use getManager() from typeorm to perform queries
+}

--- a/api/src/modules/impact/impact.service.ts
+++ b/api/src/modules/impact/impact.service.ts
@@ -2,7 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import {
   GetImpactTableDto,
   GetRankedImpactTableDto,
-} from 'modules/impact/dto/get-impact-table.dto';
+} from 'modules/impact/dto/impact-table.dto';
 import { IndicatorsService } from 'modules/indicators/indicators.service';
 import { SourcingRecordsService } from 'modules/sourcing-records/sourcing-records.service';
 import { ImpactTableData } from 'modules/sourcing-records/sourcing-record.repository';
@@ -27,7 +27,6 @@ import { DEFAULT_PAGINATION, FetchSpecification } from 'nestjs-base-service';
 import { PaginatedEntitiesDto } from 'modules/impact/dto/paginated-entities.dto';
 import { GetMaterialTreeWithOptionsDto } from 'modules/materials/dto/get-material-tree-with-options.dto';
 import { LOCATION_TYPES } from 'modules/sourcing-locations/sourcing-location.entity';
-import { SOURCING_LOCATION_TYPE_BY_INTERVENTION } from 'modules/sourcing-locations/sourcing-location.entity';
 import { PaginationMeta } from 'utils/app-base.service';
 
 @Injectable()
@@ -73,7 +72,7 @@ export class ImpactService {
       paginatedEntities.entities,
     );
 
-    let dataForImpactTable: ImpactTableData[] =
+    const dataForImpactTable: ImpactTableData[] =
       await this.getDataForImpactTable(
         impactTableDto,
         paginatedEntities.entities,
@@ -233,7 +232,7 @@ export class ImpactService {
   }
 
   /**
-   * Returns an array of ImpactTable Entities, determined by the grouBy field and properties
+   * @description Returns an array of ImpactTable Entities, determined by the groupBy field and properties
    * of the GetImpactTableDto
    * @param impactTableDto
    * @private
@@ -250,6 +249,9 @@ export class ImpactService {
       }),
       ...(impactTableDto.supplierIds && {
         supplierIds: impactTableDto.supplierIds,
+      }),
+      ...(impactTableDto.scenarioId && {
+        scenarioId: impactTableDto.scenarioId,
       }),
     };
     switch (impactTableDto.groupBy) {
@@ -409,7 +411,7 @@ export class ImpactService {
           0,
         );
 
-        let totalInterventionSumByYear: number | null = null;
+        const totalInterventionSumByYear: number | null = null;
 
         impactTable[indicatorValuesIndex].yearSum.push({
           year,

--- a/api/src/modules/sourcing-records/sourcing-records.service.ts
+++ b/api/src/modules/sourcing-records/sourcing-records.service.ts
@@ -17,9 +17,9 @@ import {
 import { CreateSourcingRecordDto } from 'modules/sourcing-records/dto/create.sourcing-record.dto';
 import { UpdateSourcingRecordDto } from 'modules/sourcing-records/dto/update.sourcing-record.dto';
 import {
-  GetActualVsScenarioImpactTabledto,
-  GetImpactTableDto,
-} from 'modules/impact/dto/get-impact-table.dto';
+  GetActualVsScenarioImpactTableDto,
+  BaseImpactTableDto,
+} from 'modules/impact/dto/impact-table.dto';
 import { SourcingLocation } from 'modules/sourcing-locations/sourcing-location.entity';
 import { GeoRegion } from 'modules/geo-regions/geo-region.entity';
 
@@ -90,10 +90,12 @@ export class SourcingRecordsService extends AppBaseService<
 
   /**
    * @description Retrieve raw data from DB required to build (on the fly) a Impact Table/Chart
+   * @deprecated: Will be removed to impact repository
    */
 
+  // TODO: Add a repository in Impact Module to get this data
   async getDataForImpactTable(
-    getImpactTableDto: GetImpactTableDto,
+    getImpactTableDto: BaseImpactTableDto,
   ): Promise<ImpactTableData[]> {
     return this.sourcingRecordRepository.getDataForImpactTable(
       getImpactTableDto,
@@ -101,7 +103,7 @@ export class SourcingRecordsService extends AppBaseService<
   }
 
   async getDataForActualVsScebarioImpactTable(
-    getActualVsScenarioImpactTableDto: GetActualVsScenarioImpactTabledto,
+    getActualVsScenarioImpactTableDto: GetActualVsScenarioImpactTableDto,
   ): Promise<ActualVsScenarioImpactTableData[]> {
     return this.sourcingRecordRepository.getDataForActualVsScenarioImpactTable(
       getActualVsScenarioImpactTableDto,

--- a/api/test/e2e/impact/chart.spec.ts
+++ b/api/test/e2e/impact/chart.spec.ts
@@ -1,0 +1,473 @@
+import { HttpStatus, INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import * as request from 'supertest';
+import { v4 as uuidv4 } from 'uuid';
+import { AppModule } from '../../../src/app.module';
+import { ImpactModule } from '../../../src/modules/impact/impact.module';
+import { getApp } from '../../utils/getApp';
+import { saveUserAndGetToken } from '../../utils/userAuth';
+import { clearEntityTables } from '../../utils/database-test-helper';
+import { IndicatorRecord } from '../../../src/modules/indicator-records/indicator-record.entity';
+import { MaterialToH3 } from '../../../src/modules/materials/material-to-h3.entity';
+import { H3Data } from '../../../src/modules/h3-data/h3-data.entity';
+import { Material } from '../../../src/modules/materials/material.entity';
+import {
+  Indicator,
+  INDICATOR_TYPES,
+} from '../../../src/modules/indicators/indicator.entity';
+import { Unit } from '../../../src/modules/units/unit.entity';
+import { BusinessUnit } from '../../../src/modules/business-units/business-unit.entity';
+import { AdminRegion } from '../../../src/modules/admin-regions/admin-region.entity';
+import { GeoRegion } from '../../../src/modules/geo-regions/geo-region.entity';
+import { Supplier } from '../../../src/modules/suppliers/supplier.entity';
+import { SourcingRecord } from '../../../src/modules/sourcing-records/sourcing-record.entity';
+import { SourcingLocation } from '../../../src/modules/sourcing-locations/sourcing-location.entity';
+import { SourcingLocationGroup } from '../../../src/modules/sourcing-location-groups/sourcing-location-group.entity';
+import {
+  ImpactTableDataAggregatedValue,
+  ImpactTableDataAggregationInfo,
+} from 'modules/impact/dto/response-impact-table.dto';
+import {
+  createAdminRegion,
+  createBusinessUnit,
+  createIndicator,
+  createIndicatorRecordV2,
+  createMaterial,
+  createSourcingLocation,
+  createSourcingRecord,
+  createSupplier,
+  createUnit,
+} from '../../entity-mocks';
+import { range } from 'lodash';
+import { createNewMaterialInterventionPreconditions } from './scenario-impact-preconditions/new-material-intervention.preconditions';
+
+describe('Impact Chart (Ranking) Test Suite (e2e)', () => {
+  let app: INestApplication;
+  let jwtToken: string;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule, ImpactModule],
+    }).compile();
+
+    app = getApp(moduleFixture);
+    await app.init();
+    jwtToken = await saveUserAndGetToken(moduleFixture, app);
+  });
+
+  afterEach(async () => {
+    await clearEntityTables([
+      IndicatorRecord,
+      MaterialToH3,
+      H3Data,
+      Material,
+      Indicator,
+      Unit,
+      BusinessUnit,
+      AdminRegion,
+      GeoRegion,
+      Supplier,
+      SourcingRecord,
+      SourcingLocation,
+      SourcingLocationGroup,
+    ]);
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  test('When I query the API for an Impact Table Ranking with an invalid sort order, a proper validation error should be returned', async () => {
+    const invalidResponse = await request(app.getHttpServer())
+      .get('/api/v1/impact/ranking')
+      .set('Authorization', `Bearer ${jwtToken}`)
+      .query({
+        'indicatorIds[]': [uuidv4()],
+        startYear: 2010,
+        endYear: 2012,
+        groupBy: 'material',
+        maxRankingEntities: 420,
+        sort: 'Condescending',
+      })
+      //ASSERT
+      .expect(HttpStatus.BAD_REQUEST);
+
+    //ASSERT
+    expect(
+      invalidResponse.body.errors[0].meta.rawError.response.message,
+    ).toContain(
+      `sort property must be either 'ASC' (Ascendant) or 'DES' (Descendent)`,
+    );
+  });
+
+  test('When I query the API for an Impact Table Ranking with an invalid maxRankingEntities (missing or non positive), a proper validation error should be returned', async () => {
+    // ARRANGE / ACT
+    const missingResponse = await request(app.getHttpServer())
+      .get('/api/v1/impact/ranking')
+      .set('Authorization', `Bearer ${jwtToken}`)
+      .query({
+        'indicatorIds[]': [uuidv4()],
+        startYear: 2010,
+        groupBy: 'material',
+      })
+      //ASSERT
+      .expect(HttpStatus.BAD_REQUEST);
+
+    const nonPositivegResponse = await request(app.getHttpServer())
+      .get('/api/v1/impact/ranking')
+      .set('Authorization', `Bearer ${jwtToken}`)
+      .query({
+        'indicatorIds[]': [uuidv4()],
+        startYear: 2010,
+        groupBy: 'material',
+        maxRankingEntities: 0,
+      })
+      //ASSERT
+      .expect(HttpStatus.BAD_REQUEST);
+
+    //ASSERT
+    expect(
+      missingResponse.body.errors[0].meta.rawError.response.message,
+    ).toContain('maxRankingEntities should not be empty');
+    expect(
+      nonPositivegResponse.body.errors[0].meta.rawError.response.message,
+    ).toContain('maxRankingEntities must be a positive number');
+  });
+
+  test('When I query the API for a Impact Table Ranking, then I should see all the data grouped by the requested entity and properly ordered, up to a MAX amount, with the rest being aggregated per year', async () => {
+    //////////// ARRANGE
+    const adminRegion: AdminRegion = await createAdminRegion({
+      name: 'Fake AdminRegion',
+    });
+    const unit: Unit = await createUnit({ shortName: 'fakeUnit' });
+    const indicator: Indicator = await createIndicator({
+      name: 'Fake Indicator',
+      unit,
+      nameCode: INDICATOR_TYPES.DEFORESTATION,
+    });
+
+    const indicator2: Indicator = await createIndicator({
+      name: 'Fake Indicator 2',
+      unit,
+      nameCode: INDICATOR_TYPES.CARBON_EMISSIONS,
+    });
+
+    const businessUnit: BusinessUnit = await createBusinessUnit({
+      name: 'Fake Business Unit',
+    });
+
+    const supplier: Supplier = await createSupplier({
+      name: 'Fake Supplier',
+    });
+    const supplierDescendant: Supplier = await createSupplier({
+      name: 'Fake Supplier Descendant',
+      parent: supplier,
+    });
+
+    // Create a small tree of Materials and their childs
+    const numberOfTopMaterials = 4;
+    const materialParents = await Promise.all(
+      range(numberOfTopMaterials).map(
+        async (index: number) =>
+          await createMaterial({ name: `Fake Material ${index}` }),
+      ),
+    );
+    for (const materialParent of materialParents) {
+      materialParent.children = await Promise.all(
+        range(2).map(
+          async (index: number) =>
+            await createMaterial({
+              name: `${materialParent.name} - Child ${index}`,
+              parent: materialParent,
+            }),
+        ),
+      );
+    }
+
+    //Helper function to create sourcing location and related entities (indicator and sourcing records)
+    //with behaviour specific to this test
+    const buildSourcingLocation = async (
+      material: Material,
+      baseImpactValue: number,
+      baseImpactValue2: number,
+    ): Promise<SourcingLocation> => {
+      const sourcingRecords: SourcingRecord[] = await Promise.all(
+        range(2010, 2013).map(async (year: number) => {
+          const sourcingRecord = await createSourcingRecord({
+            year,
+            tonnage: 100 + 10 * (year - 2010),
+          });
+
+          await createIndicatorRecordV2({
+            indicator,
+            value: baseImpactValue + 50 * (year - 2010),
+            sourcingRecord,
+          });
+
+          await createIndicatorRecordV2({
+            indicator: indicator2,
+            value: baseImpactValue2 + 20 * (year - 2010),
+            sourcingRecord,
+          });
+
+          return sourcingRecord;
+        }),
+      );
+
+      return await createSourcingLocation({
+        material: material,
+        businessUnit,
+        t1Supplier: supplierDescendant,
+        adminRegion,
+        sourcingRecords,
+      });
+    };
+
+    await buildSourcingLocation(materialParents[0], 100, 90);
+    await buildSourcingLocation(materialParents[0].children[0], 30, 80);
+    await buildSourcingLocation(materialParents[1].children[0], 100, 45);
+    await buildSourcingLocation(materialParents[1].children[1], 70, 90);
+    await buildSourcingLocation(materialParents[2].children[0], 1000, 200);
+    await buildSourcingLocation(materialParents[3], 40, 500);
+
+    const maxRankingEntities = 2;
+
+    //////////// ACT
+    const response1 = await request(app.getHttpServer())
+      .get('/api/v1/impact/ranking')
+      .set('Authorization', `Bearer ${jwtToken}`)
+      .query({
+        'indicatorIds[]': [indicator.id, indicator2.id],
+        endYear: 2012,
+        startYear: 2010,
+        groupBy: 'material',
+        maxRankingEntities: maxRankingEntities,
+        sort: 'DES',
+      })
+      .expect(HttpStatus.OK);
+
+    //////////// ASSERT
+    // Check aggregation for each indicator
+    //Number of aggregated entities should be 2 because it's the top level entities, not counting children
+    checkAggregatedInformation(
+      response1.body.impactTable[0].others,
+      numberOfTopMaterials - maxRankingEntities,
+      [
+        {
+          value: 170,
+          year: 2010,
+        },
+        {
+          value: 320,
+          year: 2011,
+        },
+        {
+          value: 470,
+          year: 2012,
+        },
+      ],
+      'DES',
+    );
+
+    checkAggregatedInformation(
+      response1.body.impactTable[1].others,
+      numberOfTopMaterials - maxRankingEntities,
+      [
+        {
+          value: 305,
+          year: 2010,
+        },
+        {
+          value: 385,
+          year: 2011,
+        },
+        {
+          value: 465,
+          year: 2012,
+        },
+      ],
+      'DES',
+    );
+
+    // Check that each indicator only has the expected number of maxRankingEntities and sorted appropriately
+    expect(response1.body.impactTable[0].rows).toHaveLength(maxRankingEntities);
+    expect(response1.body.impactTable[1].rows).toHaveLength(maxRankingEntities);
+
+    //Check order and values of ranked entities  for each indicator
+    //Inidicator1
+    expect(response1.body.impactTable[0].rows[0].name).toEqual(
+      materialParents[2].name,
+    );
+    expect(response1.body.impactTable[0].rows[1].name).toEqual(
+      materialParents[1].name,
+    );
+    expect(response1.body.impactTable[0].rows[0].values[0]).toEqual({
+      year: 2010,
+      value: 1000,
+      isProjected: false,
+    });
+    expect(response1.body.impactTable[0].rows[1].values[0]).toEqual({
+      year: 2010,
+      value: 170,
+      isProjected: false,
+    });
+
+    //Inidicator2
+    expect(response1.body.impactTable[1].rows[0].name).toEqual(
+      materialParents[3].name,
+    );
+    expect(response1.body.impactTable[1].rows[1].name).toEqual(
+      materialParents[2].name,
+    );
+    expect(response1.body.impactTable[1].rows[0].values[0]).toEqual({
+      year: 2010,
+      value: 500,
+      isProjected: false,
+    });
+    expect(response1.body.impactTable[1].rows[1].values[0]).toEqual({
+      year: 2010,
+      value: 200,
+      isProjected: false,
+    });
+  });
+
+  test('When I query the API for a Impact Table Ranking, and there is not enough entities to exceed the maxRankingEntities, then the aggregated value and number of entities should be 0', async () => {
+    //ARRANGE
+    const adminRegion: AdminRegion = await createAdminRegion({
+      name: 'Fake AdminRegion',
+    });
+    const unit: Unit = await createUnit({ shortName: 'fakeUnit' });
+    const indicator: Indicator = await createIndicator({
+      name: 'Fake Indicator',
+      unit,
+      nameCode: INDICATOR_TYPES.DEFORESTATION,
+    });
+
+    const businessUnit: BusinessUnit = await createBusinessUnit({
+      name: 'Fake Business Unit',
+    });
+
+    const supplier: Supplier = await createSupplier({
+      name: 'Fake Supplier',
+    });
+    const supplierDescendant: Supplier = await createSupplier({
+      name: 'Fake Supplier Descendant',
+      parent: supplier,
+    });
+
+    const material = await createMaterial({ name: `Fake Material ` });
+
+    const sourcingRecord = await createSourcingRecord({
+      year: 2010,
+      tonnage: 100,
+    });
+
+    await createIndicatorRecordV2({
+      indicator,
+      value: 50,
+      sourcingRecord,
+    });
+
+    await createSourcingLocation({
+      material: material,
+      businessUnit,
+      t1Supplier: supplierDescendant,
+      adminRegion,
+      sourcingRecords: [sourcingRecord],
+    });
+
+    const maxRankingEntities = 5;
+
+    //ACT
+    const response1 = await request(app.getHttpServer())
+      .get('/api/v1/impact/ranking')
+      .set('Authorization', `Bearer ${jwtToken}`)
+      .query({
+        'indicatorIds[]': [indicator.id],
+        endYear: 2012,
+        startYear: 2010,
+        groupBy: 'material',
+        maxRankingEntities: maxRankingEntities,
+        sort: 'DES',
+      })
+      .expect(HttpStatus.OK);
+
+    //ASSERT
+    // Number of aggregated entities and aggregated value should be 0 because there's not enough entities
+    // that result the current data/criteria that go over the maxRankingEntities
+    checkAggregatedInformation(
+      response1.body.impactTable[0].others,
+      0,
+      [
+        {
+          value: 0,
+          year: 2010,
+        },
+        {
+          value: 0,
+          year: 2011,
+        },
+        {
+          value: 0,
+          year: 2012,
+        },
+      ],
+      'DES',
+    );
+
+    // Check that each indicator has the expected number of entities
+    expect(response1.body.impactTable[0].rows).toHaveLength(1);
+  });
+
+  function checkAggregatedInformation(
+    others: ImpactTableDataAggregationInfo,
+    numberAggregatedEntities: number,
+    aggregatedValues: ImpactTableDataAggregatedValue[],
+    sort: string,
+  ): void {
+    expect(others).toBeTruthy();
+    expect(others.numberOfAggregatedEntities).toEqual(numberAggregatedEntities);
+    expect(others.aggregatedValues).toEqual(aggregatedValues);
+    expect(others.sort).toEqual(sort);
+  }
+
+  describe('Chart Table including Scenario Tests', () => {
+    test(
+      'When I query a Impact Chart' +
+        'And I include a Scenario Id' +
+        'Then I should see the elements included in that Scenario among the actual data',
+      async () => {
+        const {
+          replacedMaterials,
+          replacingMaterials,
+          scenarioIntervention,
+          indicator,
+        } = await createNewMaterialInterventionPreconditions();
+
+        const response = await request(app.getHttpServer())
+          .get('/api/v1/impact/ranking')
+          .set('Authorization', `Bearer ${jwtToken}`)
+          .query({
+            'indicatorIds[]': [indicator.id],
+            endYear: 2022,
+            startYear: 2019,
+            groupBy: 'material',
+            scenarioId: scenarioIntervention.scenarioId,
+            maxRankingEntities: 5,
+          });
+
+        expect(
+          response.body.impactTable[0].rows[0].children.some(
+            (child: Material) => child.id === replacedMaterials['cotton'].id,
+          ),
+        );
+
+        expect(
+          response.body.impactTable[0].rows[0].children.some(
+            (child: Material) => child.id === replacingMaterials['linen'].id,
+          ),
+        );
+      },
+    );
+  });
+});

--- a/api/test/e2e/impact/impact.spec.ts
+++ b/api/test/e2e/impact/impact.spec.ts
@@ -7,7 +7,6 @@ import {
   createBusinessUnit,
   createIndicator,
   createIndicatorRecord,
-  createIndicatorRecordV2,
   createMaterial,
   createSourcingLocation,
   createSourcingRecord,
@@ -46,15 +45,11 @@ import {
 import { PaginationMeta } from 'utils/app-base.service';
 import { MaterialToH3 } from 'modules/materials/material-to-h3.entity';
 import { clearEntityTables } from '../../utils/database-test-helper';
-import { range } from 'lodash';
-import {
-  ImpactTableDataAggregatedValue,
-  ImpactTableDataAggregationInfo,
-} from '../../../src/modules/impact/dto/response-impact-table.dto';
 import { H3Data } from 'modules/h3-data/h3-data.entity';
 import { GeoRegion } from 'modules/geo-regions/geo-region.entity';
 import { SourcingRecord } from 'modules/sourcing-records/sourcing-record.entity';
 import { SourcingLocationGroup } from 'modules/sourcing-location-groups/sourcing-location-group.entity';
+import { createNewMaterialInterventionPreconditions } from './scenario-impact-preconditions/new-material-intervention.preconditions';
 
 describe('Impact Table and Charts test suite (e2e)', () => {
   let app: INestApplication;
@@ -360,368 +355,6 @@ describe('Impact Table and Charts test suite (e2e)', () => {
     expect(response.body.data.purchasedTonnes[1].value).toEqual(
       previousNonProjectedValue + (previousNonProjectedValue * 1.5) / 100,
     );
-  });
-
-  describe('Ranking', () => {
-    test('When I query the API for an Impact Table Ranking with an invalid sort order, a proper validation error should be returned', async () => {
-      const invalidResponse = await request(app.getHttpServer())
-        .get('/api/v1/impact/ranking')
-        .set('Authorization', `Bearer ${jwtToken}`)
-        .query({
-          'indicatorIds[]': [uuidv4()],
-          startYear: 2010,
-          endYear: 2012,
-          groupBy: 'material',
-          maxRankingEntities: 420,
-          sort: 'Condescending',
-        })
-        //ASSERT
-        .expect(HttpStatus.BAD_REQUEST);
-
-      //ASSERT
-      expect(
-        invalidResponse.body.errors[0].meta.rawError.response.message,
-      ).toContain(
-        `sort property must be either 'ASC' (Ascendant) or 'DES' (Descendent)`,
-      );
-    });
-
-    test('When I query the API for an Impact Table Ranking with an invalid maxRankingEntities (missing or non positive), a proper validation error should be returned', async () => {
-      // ARRANGE / ACT
-      const missingResponse = await request(app.getHttpServer())
-        .get('/api/v1/impact/ranking')
-        .set('Authorization', `Bearer ${jwtToken}`)
-        .query({
-          'indicatorIds[]': [uuidv4()],
-          startYear: 2010,
-          groupBy: 'material',
-        })
-        //ASSERT
-        .expect(HttpStatus.BAD_REQUEST);
-
-      const nonPositivegResponse = await request(app.getHttpServer())
-        .get('/api/v1/impact/ranking')
-        .set('Authorization', `Bearer ${jwtToken}`)
-        .query({
-          'indicatorIds[]': [uuidv4()],
-          startYear: 2010,
-          groupBy: 'material',
-          maxRankingEntities: 0,
-        })
-        //ASSERT
-        .expect(HttpStatus.BAD_REQUEST);
-
-      //ASSERT
-      expect(
-        missingResponse.body.errors[0].meta.rawError.response.message,
-      ).toContain('maxRankingEntities should not be empty');
-      expect(
-        nonPositivegResponse.body.errors[0].meta.rawError.response.message,
-      ).toContain('maxRankingEntities must be a positive number');
-    });
-
-    test('When I query the API for a Impact Table Ranking, then I should see all the data grouped by the requested entity and properly ordered, up to a MAX amount, with the rest being aggregated per year', async () => {
-      //////////// ARRANGE
-      const adminRegion: AdminRegion = await createAdminRegion({
-        name: 'Fake AdminRegion',
-      });
-      const unit: Unit = await createUnit({ shortName: 'fakeUnit' });
-      const indicator: Indicator = await createIndicator({
-        name: 'Fake Indicator',
-        unit,
-        nameCode: INDICATOR_TYPES.DEFORESTATION,
-      });
-
-      const indicator2: Indicator = await createIndicator({
-        name: 'Fake Indicator 2',
-        unit,
-        nameCode: INDICATOR_TYPES.CARBON_EMISSIONS,
-      });
-
-      const businessUnit: BusinessUnit = await createBusinessUnit({
-        name: 'Fake Business Unit',
-      });
-
-      const supplier: Supplier = await createSupplier({
-        name: 'Fake Supplier',
-      });
-      const supplierDescendant: Supplier = await createSupplier({
-        name: 'Fake Supplier Descendant',
-        parent: supplier,
-      });
-
-      // Create a small tree of Materials and their childs
-      const numberOfTopMaterials = 4;
-      const materialParents = await Promise.all(
-        range(numberOfTopMaterials).map(
-          async (index: number) =>
-            await createMaterial({ name: `Fake Material ${index}` }),
-        ),
-      );
-      for (const materialParent of materialParents) {
-        materialParent.children = await Promise.all(
-          range(2).map(
-            async (index: number) =>
-              await createMaterial({
-                name: `${materialParent.name} - Child ${index}`,
-                parent: materialParent,
-              }),
-          ),
-        );
-      }
-
-      //Helper function to create sourcing location and related entities (indicator and sourcing records)
-      //with behaviour specific to this test
-      const buildSourcingLocation = async (
-        material: Material,
-        baseImpactValue: number,
-        baseImpactValue2: number,
-      ): Promise<SourcingLocation> => {
-        const sourcingRecords: SourcingRecord[] = await Promise.all(
-          range(2010, 2013).map(async (year: number) => {
-            const sourcingRecord = await createSourcingRecord({
-              year,
-              tonnage: 100 + 10 * (year - 2010),
-            });
-
-            await createIndicatorRecordV2({
-              indicator,
-              value: baseImpactValue + 50 * (year - 2010),
-              sourcingRecord,
-            });
-
-            await createIndicatorRecordV2({
-              indicator: indicator2,
-              value: baseImpactValue2 + 20 * (year - 2010),
-              sourcingRecord,
-            });
-
-            return sourcingRecord;
-          }),
-        );
-
-        return await createSourcingLocation({
-          material: material,
-          businessUnit,
-          t1Supplier: supplierDescendant,
-          adminRegion,
-          sourcingRecords,
-        });
-      };
-
-      await buildSourcingLocation(materialParents[0], 100, 90);
-      await buildSourcingLocation(materialParents[0].children[0], 30, 80);
-      await buildSourcingLocation(materialParents[1].children[0], 100, 45);
-      await buildSourcingLocation(materialParents[1].children[1], 70, 90);
-      await buildSourcingLocation(materialParents[2].children[0], 1000, 200);
-      await buildSourcingLocation(materialParents[3], 40, 500);
-
-      const maxRankingEntities = 2;
-
-      //////////// ACT
-      const response1 = await request(app.getHttpServer())
-        .get('/api/v1/impact/ranking')
-        .set('Authorization', `Bearer ${jwtToken}`)
-        .query({
-          'indicatorIds[]': [indicator.id, indicator2.id],
-          endYear: 2012,
-          startYear: 2010,
-          groupBy: 'material',
-          maxRankingEntities: maxRankingEntities,
-          sort: 'DES',
-        })
-        .expect(HttpStatus.OK);
-
-      //////////// ASSERT
-      // Check aggregation for each indicator
-      //Number of aggregated entities should be 2 because it's the top level entities, not counting children
-      checkAggregatedInformation(
-        response1.body.impactTable[0].others,
-        numberOfTopMaterials - maxRankingEntities,
-        [
-          {
-            value: 170,
-            year: 2010,
-          },
-          {
-            value: 320,
-            year: 2011,
-          },
-          {
-            value: 470,
-            year: 2012,
-          },
-        ],
-        'DES',
-      );
-
-      checkAggregatedInformation(
-        response1.body.impactTable[1].others,
-        numberOfTopMaterials - maxRankingEntities,
-        [
-          {
-            value: 305,
-            year: 2010,
-          },
-          {
-            value: 385,
-            year: 2011,
-          },
-          {
-            value: 465,
-            year: 2012,
-          },
-        ],
-        'DES',
-      );
-
-      // Check that each indicator only has the expected number of maxRankingEntities and sorted appropriately
-      expect(response1.body.impactTable[0].rows).toHaveLength(
-        maxRankingEntities,
-      );
-      expect(response1.body.impactTable[1].rows).toHaveLength(
-        maxRankingEntities,
-      );
-
-      //Check order and values of ranked entities  for each indicator
-      //Inidicator1
-      expect(response1.body.impactTable[0].rows[0].name).toEqual(
-        materialParents[2].name,
-      );
-      expect(response1.body.impactTable[0].rows[1].name).toEqual(
-        materialParents[1].name,
-      );
-      expect(response1.body.impactTable[0].rows[0].values[0]).toEqual({
-        year: 2010,
-        value: 1000,
-        isProjected: false,
-      });
-      expect(response1.body.impactTable[0].rows[1].values[0]).toEqual({
-        year: 2010,
-        value: 170,
-        isProjected: false,
-      });
-
-      //Inidicator2
-      expect(response1.body.impactTable[1].rows[0].name).toEqual(
-        materialParents[3].name,
-      );
-      expect(response1.body.impactTable[1].rows[1].name).toEqual(
-        materialParents[2].name,
-      );
-      expect(response1.body.impactTable[1].rows[0].values[0]).toEqual({
-        year: 2010,
-        value: 500,
-        isProjected: false,
-      });
-      expect(response1.body.impactTable[1].rows[1].values[0]).toEqual({
-        year: 2010,
-        value: 200,
-        isProjected: false,
-      });
-    });
-
-    test('When I query the API for a Impact Table Ranking, and there is not enough entities to exceed the maxRankingEntities, then the aggregated value and number of entities should be 0', async () => {
-      //ARRANGE
-      const adminRegion: AdminRegion = await createAdminRegion({
-        name: 'Fake AdminRegion',
-      });
-      const unit: Unit = await createUnit({ shortName: 'fakeUnit' });
-      const indicator: Indicator = await createIndicator({
-        name: 'Fake Indicator',
-        unit,
-        nameCode: INDICATOR_TYPES.DEFORESTATION,
-      });
-
-      const businessUnit: BusinessUnit = await createBusinessUnit({
-        name: 'Fake Business Unit',
-      });
-
-      const supplier: Supplier = await createSupplier({
-        name: 'Fake Supplier',
-      });
-      const supplierDescendant: Supplier = await createSupplier({
-        name: 'Fake Supplier Descendant',
-        parent: supplier,
-      });
-
-      const material = await createMaterial({ name: `Fake Material ` });
-
-      const sourcingRecord = await createSourcingRecord({
-        year: 2010,
-        tonnage: 100,
-      });
-
-      await createIndicatorRecordV2({
-        indicator,
-        value: 50,
-        sourcingRecord,
-      });
-
-      await createSourcingLocation({
-        material: material,
-        businessUnit,
-        t1Supplier: supplierDescendant,
-        adminRegion,
-        sourcingRecords: [sourcingRecord],
-      });
-
-      const maxRankingEntities = 5;
-
-      //ACT
-      const response1 = await request(app.getHttpServer())
-        .get('/api/v1/impact/ranking')
-        .set('Authorization', `Bearer ${jwtToken}`)
-        .query({
-          'indicatorIds[]': [indicator.id],
-          endYear: 2012,
-          startYear: 2010,
-          groupBy: 'material',
-          maxRankingEntities: maxRankingEntities,
-          sort: 'DES',
-        })
-        .expect(HttpStatus.OK);
-
-      //ASSERT
-      // Number of aggregated entities and aggregated value should be 0 because there's not enough entities
-      // that result the current data/criteria that go over the maxRankingEntities
-      checkAggregatedInformation(
-        response1.body.impactTable[0].others,
-        0,
-        [
-          {
-            value: 0,
-            year: 2010,
-          },
-          {
-            value: 0,
-            year: 2011,
-          },
-          {
-            value: 0,
-            year: 2012,
-          },
-        ],
-        'DES',
-      );
-
-      // Check that each indicator has the expected number of entities
-      expect(response1.body.impactTable[0].rows).toHaveLength(1);
-    });
-
-    function checkAggregatedInformation(
-      others: ImpactTableDataAggregationInfo,
-      numberAggregatedEntities: number,
-      aggregatedValues: ImpactTableDataAggregatedValue[],
-      sort: string,
-    ): void {
-      expect(others).toBeTruthy();
-      expect(others.numberOfAggregatedEntities).toEqual(
-        numberAggregatedEntities,
-      );
-      expect(others.aggregatedValues).toEqual(aggregatedValues);
-      expect(others.sort).toEqual(sort);
-    }
   });
 
   describe('Group By tests', () => {
@@ -1554,5 +1187,44 @@ describe('Impact Table and Charts test suite (e2e)', () => {
         expect.arrayContaining(filteredByLocationTypeResponseData.yearSum),
       );
     });
+  });
+
+  describe('Impact Table including Scenario Tests', () => {
+    test(
+      'When I query a Impact Table' +
+        'And I include a Scenario Id' +
+        'Then I should see the elements included in that Scenario among the actual data',
+      async () => {
+        const {
+          replacedMaterials,
+          replacingMaterials,
+          scenarioIntervention,
+          indicator,
+        } = await createNewMaterialInterventionPreconditions();
+
+        const response = await request(app.getHttpServer())
+          .get('/api/v1/impact/table')
+          .set('Authorization', `Bearer ${jwtToken}`)
+          .query({
+            'indicatorIds[]': [indicator.id],
+            endYear: 2022,
+            startYear: 2019,
+            groupBy: 'material',
+            scenarioId: scenarioIntervention.scenarioId,
+          });
+
+        expect(
+          response.body.data.impactTable[0].rows[0].children.some(
+            (child: Material) => child.id === replacedMaterials['cotton'].id,
+          ),
+        );
+
+        expect(
+          response.body.data.impactTable[0].rows[0].children.some(
+            (child: Material) => child.id === replacingMaterials['linen'].id,
+          ),
+        );
+      },
+    );
   });
 });

--- a/api/test/e2e/impact/scenario-impact-preconditions/new-material-intervention.preconditions.ts
+++ b/api/test/e2e/impact/scenario-impact-preconditions/new-material-intervention.preconditions.ts
@@ -27,6 +27,8 @@ import { INDICATOR_TYPES } from '../../../../src/modules/indicators/indicator.en
 export async function createNewMaterialInterventionPreconditions(): Promise<{
   indicator: Indicator;
   scenarioIntervention: ScenarioIntervention;
+  replacingMaterials: Record<string, Material>;
+  replacedMaterials: Record<string, Material>;
 }> {
   const adminRegion: AdminRegion = await createAdminRegion({
     name: 'India',
@@ -184,5 +186,10 @@ export async function createNewMaterialInterventionPreconditions(): Promise<{
     sourcingLocation: linenSourcingLocationReplacing,
   });
 
-  return { indicator, scenarioIntervention };
+  return {
+    indicator,
+    scenarioIntervention,
+    replacedMaterials: { wool, cotton },
+    replacingMaterials: { linen },
+  };
 }

--- a/api/test/e2e/impact/scenario-impact.spec.ts
+++ b/api/test/e2e/impact/scenario-impact.spec.ts
@@ -49,6 +49,7 @@ describe('Impact Table and Charts test suite (e2e)', () => {
 
   afterEach(async () => {
     await clearEntityTables([
+      Scenario,
       IndicatorRecord,
       MaterialToH3,
       H3Data,

--- a/client/src/containers/analysis-chart/impact-chart/component.tsx
+++ b/client/src/containers/analysis-chart/impact-chart/component.tsx
@@ -14,7 +14,7 @@ import {
 } from 'recharts';
 
 import { filtersForTabularAPI } from 'store/features/analysis/selector';
-import { useImpactRanking } from 'hooks/impact';
+import { useImpactRanking } from 'hooks/impact/ranking';
 
 import Loading from 'components/loading';
 import { NUMBER_FORMAT } from 'utils/number-format';

--- a/client/src/containers/analysis-visualization/analysis-table/comparison-cell/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-table/comparison-cell/component.tsx
@@ -1,10 +1,7 @@
 import classNames from 'classnames';
-import { format } from 'd3-format';
 import { useAppSelector } from 'store/hooks';
 import { scenarios } from 'store/features/analysis/scenarios';
 import { NUMBER_FORMAT, BIG_NUMBER_FORMAT } from 'utils/number-format';
-
-const PERCENTAGE_FORMAT = format(',.2%');
 
 export interface ComparisonCellProps {
   value: number;
@@ -39,7 +36,7 @@ const ComparisonCell: React.FC<ComparisonCellProps> = ({
             },
           )}
         >
-          {comparisonMode === 'relative' && `${PERCENTAGE_FORMAT(percentageDifference)}%`}
+          {comparisonMode === 'relative' && `${NUMBER_FORMAT(percentageDifference)}%`}
           {comparisonMode === 'absolute' && (
             <>
               {absoluteDifference > 0 && '+'}
@@ -48,7 +45,7 @@ const ComparisonCell: React.FC<ComparisonCellProps> = ({
           )}
         </div>
       </div>
-      <div className="my-auto text-xs text-left text-gray-400">
+      <div className="my-auto text-xs text-left text-gray-400 whitespace-nowrap">
         Actual data: {NUMBER_FORMAT(value)}
       </div>
     </div>

--- a/client/src/containers/analysis-visualization/analysis-table/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-table/component.tsx
@@ -1,24 +1,26 @@
-import LinkButton from 'components/button';
-import AnalysisDynamicMetadata from 'containers/analysis-visualization/analysis-dynamic-metadata';
-import { useImpactData } from 'hooks/impact';
-import { uniq } from 'lodash';
 import { useCallback, useMemo, useState } from 'react';
+import classNames from 'classnames';
+import { DownloadIcon } from '@heroicons/react/outline';
+import { getSortedRowModel } from '@tanstack/react-table';
+import { uniq } from 'lodash';
+
+import { useImpactData } from 'hooks/impact';
+import { useImpactComparison } from 'hooks/impact/comparison';
 import { scenarios } from 'store/features/analysis/scenarios';
 import { useAppSelector } from 'store/hooks';
 
-import { DownloadIcon } from '@heroicons/react/outline';
-import type { TableProps } from 'components/table/component';
+import AnalysisDynamicMetadata from 'containers/analysis-visualization/analysis-dynamic-metadata';
+import LinkButton from 'components/button';
 import Table from 'components/table/component';
-import { getSortedRowModel } from '@tanstack/react-table';
-import type { PaginationState, SortingState } from '@tanstack/react-table';
-import type { ColumnDefinition } from 'components/table/column';
 import LineChart from 'components/chart/line';
-import type { LinesConfig } from 'components/chart/line/types';
 import { BIG_NUMBER_FORMAT } from 'utils/number-format';
-
-import type { ImpactTableData } from 'types';
 import ComparisonCell from './comparison-cell/component';
-import classNames from 'classnames';
+
+import type { PaginationState, SortingState } from '@tanstack/react-table';
+import type { TableProps } from 'components/table/component';
+import type { ColumnDefinition } from 'components/table/column';
+import type { LinesConfig } from 'components/chart/line/types';
+import type { ImpactTableData } from 'types';
 
 type TableDataType = ImpactTableData['rows'][0];
 

--- a/client/src/hooks/analysis/index.ts
+++ b/client/src/hooks/analysis/index.ts
@@ -6,7 +6,7 @@ import compact from 'lodash/compact';
 import chroma from 'chroma-js';
 
 import { useAppSelector } from 'store/hooks';
-import { useImpactRanking } from 'hooks/impact';
+import { useImpactRanking } from 'hooks/impact/ranking';
 import { analysisFilters } from 'store/features/analysis/filters';
 
 import type { AnalysisChart } from './types';

--- a/client/src/hooks/impact/index.ts
+++ b/client/src/hooks/impact/index.ts
@@ -10,10 +10,9 @@ import { scenarios } from 'store/features/analysis/scenarios';
 import { apiRawService } from 'services/api';
 import { useIndicators } from 'hooks/indicators';
 
-import type { ImpactData, ImpactRanking, APIpaginationRequest } from 'types';
+import type { ImpactData, APIpaginationRequest } from 'types';
 import { useStore } from 'react-redux';
 
-import type { ImpactTabularAPIParams } from 'types';
 import type { Store } from 'store';
 
 const DEFAULT_QUERY_OPTIONS: UseQueryOptions = {
@@ -25,16 +24,6 @@ const DEFAULT_QUERY_OPTIONS: UseQueryOptions = {
     metadata: {
       unit: null,
     },
-  },
-  retry: false,
-  keepPreviousData: true,
-  refetchOnWindowFocus: false,
-};
-
-const DEFAULT_QUERY_RANKING_OPTIONS: UseQueryOptions<ImpactRanking> = {
-  placeholderData: {
-    impactTable: [],
-    purchasedTonnes: [],
   },
   retry: false,
   keepPreviousData: true,
@@ -84,10 +73,7 @@ export const useImpactData: (pagination?: APIpaginationRequest) => ImpactDataRes
 
   const query = useQuery(
     ['impact-data', layer, params],
-    () =>
-      apiRawService
-        .get('/impact/compare/scenario/vs/actual', { params })
-        .then((response) => response.data),
+    () => apiRawService.get('/impact/table', { params }).then((response) => response.data),
     {
       ...DEFAULT_QUERY_OPTIONS,
       enabled: layer === 'impact' && isEnable,
@@ -105,31 +91,3 @@ export const useImpactData: (pagination?: APIpaginationRequest) => ImpactDataRes
     [query, isError, data],
   );
 };
-
-type ImpactRankingParams = ImpactTabularAPIParams & {
-  maxRankingEntities: number;
-  sort: string;
-};
-
-export function useImpactRanking(
-  params: Partial<ImpactRankingParams> = { maxRankingEntities: 5, sort: 'ASC' },
-  options: UseQueryOptions<ImpactRanking> = {},
-): UseQueryResult<ImpactRanking, unknown> {
-  const query = useQuery<ImpactRanking>(
-    ['impact-ranking', params],
-    () =>
-      apiRawService
-        .get('/impact/ranking', {
-          params,
-        })
-        .then((response) => {
-          return response.data;
-        }),
-    {
-      ...DEFAULT_QUERY_RANKING_OPTIONS,
-      ...options,
-    },
-  );
-
-  return query;
-}

--- a/client/src/hooks/impact/ranking.ts
+++ b/client/src/hooks/impact/ranking.ts
@@ -1,0 +1,45 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { apiRawService } from 'services/api';
+
+import type { UseQueryOptions, UseQueryResult } from '@tanstack/react-query';
+import type { ImpactRanking } from 'types';
+import type { ImpactTabularAPIParams } from 'types';
+
+const DEFAULT_QUERY_OPTIONS: UseQueryOptions<ImpactRanking> = {
+  placeholderData: {
+    impactTable: [],
+    purchasedTonnes: [],
+  },
+  retry: false,
+  keepPreviousData: true,
+  refetchOnWindowFocus: false,
+};
+
+type ImpactRankingParams = ImpactTabularAPIParams & {
+  maxRankingEntities: number;
+  sort: string;
+};
+
+export function useImpactRanking(
+  params: Partial<ImpactRankingParams> = { maxRankingEntities: 5, sort: 'ASC' },
+  options: UseQueryOptions<ImpactRanking> = {},
+): UseQueryResult<ImpactRanking, unknown> {
+  const query = useQuery<ImpactRanking>(
+    ['impact-ranking', params],
+    () =>
+      apiRawService
+        .get('/impact/ranking', {
+          params,
+        })
+        .then((response) => {
+          return response.data;
+        }),
+    {
+      ...DEFAULT_QUERY_OPTIONS,
+      ...options,
+    },
+  );
+
+  return query;
+}

--- a/client/src/types.d.ts
+++ b/client/src/types.d.ts
@@ -208,6 +208,7 @@ export type PaginationMetadata = {
 export type ImpactData = {
   data: {
     impactTable: ImpactTableData[];
+    purchasedTonnes?: PurchasedTonnesData[];
   };
   metadata: PaginationMetadata;
 };


### PR DESCRIPTION
### General description

This PR adds a conditional scenarioId for both Impact Table and Impact Chart, so that elements present in a scenario can be retrieved mixed with the actual data in both cases

Adds a little refactor for sanitising some DTO and minor fixes 
Deprecates some methods in sourcing record servide and repository, and adds a impact repository
as first step to refactoring all data layer access regarding impact data retrieval to that repository

### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

Create an Intervention replacing some noticeable stuff (Material, Supplier, Region..). 
Then GET the impact map adding the scenarioId (the FE is not ready to show this stuff properly)
Then you should see the elements you replaced (depending on the groupBy) being retrieved in the response
with a populated value property, in case your specific intervention has had any impact

- Apart from the added feature / bug fix, check overall performance, styling...

## Checklist before merging

- [x] Branch name / PR includes the related Jira ticket Id.
- [x] Tests to check core implementation / bug fix added.
- [x] All checks in Continuous Integration workflow pass.
- [x] Feature functionally tested by reviewer(s).
- [x] Code reviewed by reviewer(s).
- [ ] Documentation updated (README, CHANGELOG...) (if required)
