### PR TITLE
Showing comparison line chart when is enabled

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 - Readded material layer to the map as a contextual layer [LANDGRIF-827](https://vizzuality.atlassian.net/browse/LANDGRIF-827)
 - Add map preview to legend settings modal [LANDGRIF-827](https://vizzuality.atlassian.net/browse/LANDGRIF-827)
+- In chart view, when a comparison is enabled the chart changes to line chart [LANDGRIF-807](https://vizzuality.atlassian.net/browse/LANDGRIF-807)
 
 ### Changed
 

--- a/client/src/containers/analysis-chart/comparison-chart/component.tsx
+++ b/client/src/containers/analysis-chart/comparison-chart/component.tsx
@@ -19,7 +19,8 @@ import { useImpactComparison } from 'hooks/impact/comparison';
 
 import Loading from 'components/loading';
 import { NUMBER_FORMAT } from 'utils/number-format';
-import LegendChart from './legend';
+import CustomLegend from './legend';
+import CustomTooltip from './tooltip';
 
 import type { Store } from 'store';
 import type { Indicator } from 'types';
@@ -70,8 +71,12 @@ const StackedAreaChart: React.FC<StackedAreaChartProps> = ({ indicator }) => {
     };
   }, [data]);
 
-  const renderLegend = useCallback((props) => {
-    return <LegendChart {...props} />;
+  const renderLegend = useCallback((props) => <CustomLegend {...props} />, []);
+
+  const renderTooltip = useCallback((props) => {
+    if (props && props.active && props.payload && props.payload.length) {
+      return <CustomTooltip {...props} />;
+    }
   }, []);
 
   return (
@@ -96,10 +101,10 @@ const StackedAreaChart: React.FC<StackedAreaChartProps> = ({ indicator }) => {
                 >
                   <Legend verticalAlign="top" content={renderLegend} height={70} />
                   <CartesianGrid
-                    vertical={false}
                     stroke="#15181F"
                     strokeWidth={1}
                     strokeOpacity={0.15}
+                    vertical={false}
                   />
                   <XAxis
                     dataKey="date"
@@ -110,32 +115,31 @@ const StackedAreaChart: React.FC<StackedAreaChartProps> = ({ indicator }) => {
                   />
                   <YAxis
                     axisLine={false}
+                    domain={['auto', 'auto']}
                     label={{ value: chartData.unit, angle: -90, position: 'insideLeft' }}
                     tick={{ fill: '#15181F', fontWeight: 300 }}
                     tickLine={false}
                     tickFormatter={NUMBER_FORMAT}
                   />
-                  <Tooltip
-                    formatter={NUMBER_FORMAT}
-                    animationDuration={500}
-                    itemStyle={{ color: '#15181F' }}
-                  />
+                  <Tooltip animationDuration={500} content={renderTooltip} />
+                  {/* Actual data */}
                   <Line
-                    type="monotone"
-                    dataKey="scenarioValue"
-                    stroke="#078A3C"
-                    strokeWidth={1}
-                    fillOpacity={0.9}
                     animationEasing="ease"
                     animationDuration={500}
-                  />
-                  <Line
-                    type="monotone"
                     dataKey="value"
-                    stroke="#3F59E0"
-                    strokeWidth={1}
+                    stroke="#AEB1B5"
+                    strokeWidth={2}
+                    type="linear"
+                  />
+                  {/* Scenario */}
+                  <Line
                     animationEasing="ease"
                     animationDuration={500}
+                    dataKey="scenarioValue"
+                    fillOpacity={0.9}
+                    stroke="#3F59E0"
+                    strokeWidth={2}
+                    type="linear"
                   />
                 </LineChart>
               </ResponsiveContainer>

--- a/client/src/containers/analysis-chart/comparison-chart/component.tsx
+++ b/client/src/containers/analysis-chart/comparison-chart/component.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useMemo } from 'react';
-import chroma from 'chroma-js';
+import { useStore } from 'react-redux';
+import omit from 'lodash/omit';
 import {
   LineChart,
   Line,
@@ -11,50 +12,61 @@ import {
   ResponsiveContainer,
 } from 'recharts';
 
+import { useAppSelector } from 'store/hooks';
+import { scenarios } from 'store/features/analysis/scenarios';
+import { filtersForTabularAPI } from 'store/features/analysis/selector';
+import { useImpactComparison } from 'hooks/impact/comparison';
+
+import Loading from 'components/loading';
 import { NUMBER_FORMAT } from 'utils/number-format';
 import LegendChart from './legend';
 
-import type { ImpactRanking } from 'types';
+import type { Store } from 'store';
+import type { Indicator } from 'types';
 
-type ComparisonChartProps = {
-  data: ImpactRanking;
+type StackedAreaChartProps = {
+  indicator: Indicator;
 };
 
-const COLOR_SCALE = chroma.scale(['#2D7A5B', '#39A163', '#9AC864', '#D9E77F', '#FFF9C7']);
+type ChartData = {
+  name: string;
+  unit: string;
+  values: {
+    year: number;
+    value: number;
+    scenarioValue: number;
+    absoluteDifference: number;
+    percentageDifference: number;
+  }[];
+};
 
-const ComparisonChart: React.FC<ComparisonChartProps> = ({ data }) => {
-  const chartData = useMemo(() => {
-    const { indicatorShortName, rows, yearSum, metadata } = data?.impactTable?.[0] || {};
-    const result = [];
-    const keys = [];
+const StackedAreaChart: React.FC<StackedAreaChartProps> = ({ indicator }) => {
+  const store: Store = useStore();
+  const { scenarioToCompare } = useAppSelector(scenarios);
+  const filters = filtersForTabularAPI(store.getState());
 
-    yearSum?.forEach(({ year }) => {
-      const items = {};
-      rows?.forEach((row) => {
-        const yearValues = row?.values.find((rowValues) => rowValues?.year === year);
-        items[row.name] = yearValues?.value;
-      });
-      result.push({ date: year, ...items });
-    });
+  const params = {
+    ...omit(filters, 'indicatorId'),
+    indicatorIds: [indicator.id],
+    scenarioId: scenarioToCompare,
+    disabledPagination: true,
+  };
 
-    if (result?.[0]) {
-      Object.keys(result[0]).forEach((key) => key !== 'date' && keys.push(key));
-    }
+  const enabled =
+    !!filters?.indicatorId &&
+    !!filters.startYear &&
+    !!filters.endYear &&
+    filters.endYear !== filters.startYear;
 
-    const colorScale = COLOR_SCALE.colors(keys.length);
+  const { data, isFetched, isLoading } = useImpactComparison(params, { enabled });
+
+  const chartData = useMemo<ChartData>(() => {
+    const { indicatorShortName, yearSum, metadata } = data?.data?.impactTable?.[0] || {};
 
     return {
-      values: result,
-      keys,
+      values: yearSum,
       name: indicatorShortName,
       unit: metadata?.unit,
-      colors: keys.reduce(
-        (acc, k, i) => ({
-          ...acc,
-          [k]: k === 'Other' || k === 'Others' ? '#E4E4E4' : colorScale[i],
-        }),
-        {},
-      ),
     };
   }, [data]);
 
@@ -63,67 +75,76 @@ const ComparisonChart: React.FC<ComparisonChartProps> = ({ data }) => {
   }, []);
 
   return (
-    <div>
-      <h2 className="flex-shrink-0 text-base">
-        {chartData.name} ({chartData.unit})
-      </h2>
-      <div className="relative flex-grow mt-3">
-        <div className="h-[370px] text-xs">
-          <ResponsiveContainer width="100%" height="100%">
-            <LineChart
-              data={chartData.values}
-              margin={{
-                top: 0,
-                right: 0,
-                left: 0,
-                bottom: 0,
-              }}
-            >
-              <Legend verticalAlign="top" content={renderLegend} height={70} />
-              <CartesianGrid
-                vertical={false}
-                stroke="#15181F"
-                strokeWidth={1}
-                strokeOpacity={0.15}
-              />
-              <XAxis
-                dataKey="date"
-                axisLine={false}
-                tick={{ fill: '#15181F', fontWeight: 300 }}
-                tickLine={false}
-              />
-              <YAxis
-                axisLine={false}
-                label={{ value: chartData.unit, angle: -90, position: 'insideLeft' }}
-                tick={{ fill: '#15181F', fontWeight: 300 }}
-                tickLine={false}
-                tickFormatter={NUMBER_FORMAT}
-              />
-              <Tooltip
-                formatter={NUMBER_FORMAT}
-                animationDuration={500}
-                itemStyle={{ color: '#15181F' }}
-              />
-              {chartData.keys.map((key) => (
-                <Line
-                  key={key}
-                  type="monotone"
-                  dataKey={key}
-                  dot={false}
-                  stroke={chartData.colors[key]}
-                  strokeWidth={2}
-                  fill={chartData.colors[key]}
-                  fillOpacity={0.9}
-                  animationEasing="ease"
-                  animationDuration={500}
-                />
-              ))}
-            </LineChart>
-          </ResponsiveContainer>
+    <div className="p-6 bg-white rounded-md shadow-sm">
+      {isLoading && <Loading className="w-5 h-5 m-auto text-primary" />}
+      {!isLoading && isFetched && data && (
+        <div>
+          <h2 className="flex-shrink-0 text-base">
+            {chartData.name} ({chartData.unit})
+          </h2>
+          <div className="relative flex-grow mt-3">
+            <div className="h-[370px] text-xs">
+              <ResponsiveContainer width="100%" height="100%">
+                <LineChart
+                  data={chartData.values}
+                  margin={{
+                    top: 0,
+                    right: 20,
+                    left: 0,
+                    bottom: 0,
+                  }}
+                >
+                  <Legend verticalAlign="top" content={renderLegend} height={70} />
+                  <CartesianGrid
+                    vertical={false}
+                    stroke="#15181F"
+                    strokeWidth={1}
+                    strokeOpacity={0.15}
+                  />
+                  <XAxis
+                    dataKey="date"
+                    axisLine={false}
+                    tick={{ fill: '#15181F', fontWeight: 300 }}
+                    tickLine={false}
+                    tickMargin={8}
+                  />
+                  <YAxis
+                    axisLine={false}
+                    label={{ value: chartData.unit, angle: -90, position: 'insideLeft' }}
+                    tick={{ fill: '#15181F', fontWeight: 300 }}
+                    tickLine={false}
+                    tickFormatter={NUMBER_FORMAT}
+                  />
+                  <Tooltip
+                    formatter={NUMBER_FORMAT}
+                    animationDuration={500}
+                    itemStyle={{ color: '#15181F' }}
+                  />
+                  <Line
+                    type="monotone"
+                    dataKey="scenarioValue"
+                    stroke="#078A3C"
+                    strokeWidth={1}
+                    fillOpacity={0.9}
+                    animationEasing="ease"
+                    animationDuration={500}
+                  />
+                  <Line
+                    type="monotone"
+                    dataKey="value"
+                    stroke="#3F59E0"
+                    strokeWidth={1}
+                    animationEasing="ease"
+                    animationDuration={500}
+                  />
+                </LineChart>
+              </ResponsiveContainer>
+            </div>
+          </div>
         </div>
-      </div>
+      )}
     </div>
   );
 };
 
-export default ComparisonChart;
+export default StackedAreaChart;

--- a/client/src/containers/analysis-chart/comparison-chart/component.tsx
+++ b/client/src/containers/analysis-chart/comparison-chart/component.tsx
@@ -107,7 +107,7 @@ const StackedAreaChart: React.FC<StackedAreaChartProps> = ({ indicator }) => {
                     vertical={false}
                   />
                   <XAxis
-                    dataKey="date"
+                    dataKey="year"
                     axisLine={false}
                     tick={{ fill: '#15181F', fontWeight: 300 }}
                     tickLine={false}

--- a/client/src/containers/analysis-chart/comparison-chart/legend/component.tsx
+++ b/client/src/containers/analysis-chart/comparison-chart/legend/component.tsx
@@ -1,5 +1,3 @@
-import ProjectedDataIcon from 'components/icons/projected-data';
-
 type LegendChartProps = {
   payload: {
     value: string;
@@ -10,20 +8,18 @@ type LegendChartProps = {
 const LegendChart: React.FC<LegendChartProps> = ({ payload }) => (
   <div className="flex justify-between">
     <ul className="flex flex-wrap">
-      {payload.map((item) => (
+      {payload.reverse().map((item) => (
         <li key={item.value} className="flex items-center mr-2 space-x-1">
-          <div
-            className="w-2 h-3 rounded shrink-0 grow-0"
-            style={{ backgroundColor: `${item.color}` }}
-          />
-          <div className="overflow-hidden text-xs whitespace-nowrap text-ellipsis max-w-[100px]">
-            {item.value}
+          <div className="w-[16px] h-[1px] border-b-2" style={{ borderColor: `${item.color}` }} />
+          <div className="overflow-hidden text-xs whitespace-nowrap text-ellipsis max-w-[150px]">
+            {item.value === 'scenarioValue' && 'Scenario'}
+            {item.value === 'value' && 'Actual data'}
           </div>
         </li>
       ))}
     </ul>
     <div className="flex items-center space-x-1">
-      <ProjectedDataIcon />
+      <div className="w-[16px] h-[1px] border-b-2 border-dashed border-gray-900" />
       <div className="text-xs whitespace-nowrap">Projected data</div>
     </div>
   </div>

--- a/client/src/containers/analysis-chart/comparison-chart/tooltip/component.tsx
+++ b/client/src/containers/analysis-chart/comparison-chart/tooltip/component.tsx
@@ -1,0 +1,41 @@
+import classNames from 'classnames';
+import { NUMBER_FORMAT } from 'utils/number-format';
+
+type CustomTooltipProps = {
+  payload: {
+    value: number;
+    payload: {
+      absoluteDifference: number;
+    };
+  }[];
+};
+
+const CustomTooltip: React.FC<CustomTooltipProps> = ({ payload }) => {
+  // We will assume that actual-data is the first item and the scenario is the second one
+  const actualDataValue = payload[0].value;
+  const scenarioValue = payload[1].value;
+  const absoluteDifference = payload[1].payload.absoluteDifference;
+
+  return (
+    <div className="p-4 text-gray-900 bg-white border rounded-md">
+      <div className="flex items-center space-x-2">
+        <div>{NUMBER_FORMAT(scenarioValue)}</div>
+        <div
+          className={classNames(
+            'rounded-sm px-1 text-xs',
+            absoluteDifference > 0
+              ? 'text-[#DC3C51] bg-[#DC3C51]/10'
+              : 'text-[#078A3C] bg-[#078A3C]/10',
+          )}
+        >
+          {absoluteDifference > 0 && '+'}
+          {absoluteDifference < 0 && '-'}
+          {NUMBER_FORMAT(absoluteDifference)}
+        </div>
+      </div>
+      <div className="text-gray-400">Actual data: {NUMBER_FORMAT(actualDataValue)}</div>
+    </div>
+  );
+};
+
+export default CustomTooltip;

--- a/client/src/containers/analysis-chart/comparison-chart/tooltip/index.ts
+++ b/client/src/containers/analysis-chart/comparison-chart/tooltip/index.ts
@@ -1,0 +1,1 @@
+export { default } from './component';

--- a/client/src/containers/analysis-chart/component.tsx
+++ b/client/src/containers/analysis-chart/component.tsx
@@ -1,12 +1,21 @@
 import ImpactChart from './impact-chart';
+import ComparisonChart from './comparison-chart';
+
+import { useAppSelector } from 'store/hooks';
+import { scenarios } from 'store/features/analysis/scenarios';
+
 import type { Indicator } from 'types';
 
 type AnalysisChartProps = {
   indicator: Indicator;
 };
 
-const AnalysisChart: React.FC<AnalysisChartProps> = ({ indicator }) => (
-  <ImpactChart indicator={indicator} />
-);
+const AnalysisChart: React.FC<AnalysisChartProps> = ({ indicator }) => {
+  const { scenarioToCompare } = useAppSelector(scenarios);
+
+  if (scenarioToCompare) return <ComparisonChart indicator={indicator} />;
+
+  return <ImpactChart indicator={indicator} />;
+};
 
 export default AnalysisChart;

--- a/client/src/containers/analysis-chart/component.tsx
+++ b/client/src/containers/analysis-chart/component.tsx
@@ -11,9 +11,9 @@ type AnalysisChartProps = {
 };
 
 const AnalysisChart: React.FC<AnalysisChartProps> = ({ indicator }) => {
-  const { scenarioToCompare } = useAppSelector(scenarios);
+  const { isComparisonEnabled } = useAppSelector(scenarios);
 
-  if (scenarioToCompare) return <ComparisonChart indicator={indicator} />;
+  if (isComparisonEnabled) return <ComparisonChart indicator={indicator} />;
 
   return <ImpactChart indicator={indicator} />;
 };

--- a/client/src/containers/analysis-chart/impact-chart/component.tsx
+++ b/client/src/containers/analysis-chart/impact-chart/component.tsx
@@ -158,8 +158,9 @@ const StackedAreaChart: React.FC<StackedAreaChartProps> = ({ indicator }) => {
                     tickFormatter={NUMBER_FORMAT}
                   />
                   <Tooltip
-                    formatter={NUMBER_FORMAT}
                     animationDuration={500}
+                    contentStyle={{ borderRadius: '8px', borderColor: '#D1D5DB' }}
+                    formatter={NUMBER_FORMAT}
                     itemStyle={{ color: '#15181F' }}
                   />
                   {chartData.keys.map((key) => (

--- a/client/src/containers/scenarios/item/index.tsx
+++ b/client/src/containers/scenarios/item/index.tsx
@@ -9,7 +9,7 @@ const ScenarioItemContainer = (props) => {
     isSelected: false,
     isComparisonEnabled: false,
     ...props,
-    isComparisonAvailable: visualizationMode === 'table',
+    isComparisonAvailable: visualizationMode !== 'map',
   };
 
   return <Component {...componentProps} />;

--- a/client/src/hooks/impact/comparison.ts
+++ b/client/src/hooks/impact/comparison.ts
@@ -1,0 +1,52 @@
+import type { UseQueryOptions, UseQueryResult } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
+
+import { apiRawService } from 'services/api';
+
+import type { ImpactData } from 'types';
+
+import type { ImpactTabularAPIParams } from 'types';
+
+const DEFAULT_QUERY_OPTIONS: UseQueryOptions<ImpactData> = {
+  placeholderData: {
+    data: {
+      impactTable: [],
+    },
+    metadata: {
+      page: 1,
+      size: 1,
+      totalItems: 1,
+      totalPages: 1,
+    },
+  },
+  retry: false,
+  keepPreviousData: true,
+  refetchOnWindowFocus: false,
+};
+
+type ImpactComparisonParams = ImpactTabularAPIParams & {
+  scenarioId: string;
+};
+
+export function useImpactComparison(
+  params: Partial<ImpactComparisonParams> = {},
+  options: UseQueryOptions<ImpactData> = {},
+): UseQueryResult<ImpactData> {
+  const query = useQuery<ImpactData>(
+    ['impact-ranking', params],
+    () =>
+      apiRawService
+        .get('/impact/compare/scenario/vs/actual', {
+          params,
+        })
+        .then((response) => response.data),
+    {
+      ...DEFAULT_QUERY_OPTIONS,
+      ...options,
+    },
+  );
+
+  return query;
+}
+
+export default useImpactComparison;

--- a/client/src/pages/analysis/chart.tsx
+++ b/client/src/pages/analysis/chart.tsx
@@ -9,6 +9,7 @@ import useEffectOnce from 'hooks/once';
 import ApplicationLayout from 'layouts/application';
 import AnalysisLayout from 'layouts/analysis';
 import AnalysisChart from 'containers/analysis-chart';
+import AnalysisDynamicMetadata from 'containers/analysis-visualization/analysis-dynamic-metadata';
 import Loading from 'components/loading';
 import TitleTemplate from 'utils/titleTemplate';
 
@@ -45,16 +46,21 @@ const ChartPage: NextPageWithLayout = () => {
         </div>
       )}
       {!isLoading && activeIndicators?.length > 0 && (
-        <div
-          className={classNames('grid gap-6', {
-            'grid-cols-1': activeIndicators?.length === 1,
-            'grid-cols-1 2xl:grid-cols-2': activeIndicators?.length > 1,
-          })}
-        >
-          {activeIndicators.map((indicator) => (
-            <AnalysisChart key={`analysis-chart-${indicator.id}`} indicator={indicator} />
-          ))}
-        </div>
+        <>
+          <div className="mb-6">
+            <AnalysisDynamicMetadata />
+          </div>
+          <div
+            className={classNames('grid gap-6', {
+              'grid-cols-1': activeIndicators?.length === 1,
+              'grid-cols-1 2xl:grid-cols-2': activeIndicators?.length > 1,
+            })}
+          >
+            {activeIndicators.map((indicator) => (
+              <AnalysisChart key={`analysis-chart-${indicator.id}`} indicator={indicator} />
+            ))}
+          </div>
+        </>
       )}
     </div>
   );

--- a/client/src/types.d.ts
+++ b/client/src/types.d.ts
@@ -186,6 +186,9 @@ export type ImpactTableData = {
   yearSum: {
     year: number;
     value: number;
+    scenarioValue: number;
+    absoluteDifference: number;
+    percentageDifference: number;
   }[];
 };
 


### PR DESCRIPTION
### General description

Added comparison line chart when the comparison is enabled in the chart view
![image](https://user-images.githubusercontent.com/674179/192999786-2db1215e-6d9a-436f-bee7-142244859947.png)

### Designs

[Figma](https://www.figma.com/file/7bmF29CIXDJwCpuloW5Nt6/%F0%9F%94%B5-Landgriffon---Redesign_BLUE?node-id=1870%3A171530)

### Missing
- [ ] Show scenario name in the legend
- [ ] Projected data should be dashed line in the chart
- [ ] Allow to switch between relative and absolute and change the tooltip according to this