### PR TITLE
Table doesn't load until params are manually changed

### DIFF
--- a/client/src/components/tree-select/component.stories.tsx
+++ b/client/src/components/tree-select/component.stories.tsx
@@ -15,7 +15,7 @@ export default {
     },
     options: { table: { disable: true } },
     checkedStrategy: {
-      options: ['ALL', 'CHILDREN', 'PARENT'],
+      options: ['ALL', 'CHILD', 'PARENT'],
       control: { type: 'radio' },
     },
   },
@@ -36,6 +36,13 @@ Default.args = {
   label: 'Label',
   options: [
     {
+      value: 'deep',
+      label: 'Deep',
+      children: [
+        { value: 'deeper', label: 'Deeper', children: [{ value: 'deepest', label: 'Deepest' }] },
+      ],
+    },
+    {
       value: 'ocean',
       label: 'Ocean',
       color: '#00B8D9',
@@ -43,7 +50,16 @@ Default.args = {
       children: [
         { value: 'blue2', label: 'Blue2', color: '#0052CC', isDisabled: true },
         { value: 'purple2', label: 'Purple2', color: '#5243AA' },
-        { value: 'red2', label: 'Red2', color: '#FF5630', isFixed: true },
+        {
+          value: 'red2',
+          label: 'Red2',
+          color: '#FF5630',
+          isFixed: true,
+          children: [
+            { value: 'blue3', label: 'Blue3', color: '#0052CC' },
+            { value: 'purple3', label: 'Purple3', color: '#5243AA' },
+          ],
+        },
       ],
     },
     { value: 'blue', label: 'Blue', color: '#0052CC', isDisabled: true },

--- a/client/src/components/tree-select/types.d.ts
+++ b/client/src/components/tree-select/types.d.ts
@@ -1,3 +1,5 @@
+import type { CHECKED_STRATEGIES } from './utils';
+
 export type TreeSelectOption = {
   label: string;
   value: string | number;
@@ -24,30 +26,9 @@ interface CommonTreeProps {
    * - `CHILD`: if parent is selected and also all children are selected, only children ids are in the values
    * - `ONLY_CHILD`: only for styling purpose, only children ids are in the values and just the first child is shown
    */
-  checkedStrategy?: 'ALL' | 'PARENT' | 'CHILD';
+  checkedStrategy?: keyof typeof CHECKED_STRATEGIES;
   checkedStrategyDisplay?: 'ONLY_CHILD';
-
-  // multiple: Multi;
-  // current: Multi extends true ? TreeSelectOption[] : TreeSelectOption;
-  // onChange?: (selected: Multi extends true ? TreeSelectOption[] : TreeSelectOption) => void;
 }
-
-// interface MultipleTreeProps {
-//   multiple: true;
-//   current: TreeSelectOption[];
-//   onChange?: (selected: TreeSelectOption[]) => void;
-// }
-
-// interface SingleTreeProps {
-//   multiple?: false;
-//   current: TreeSelectOption;
-//   onChange?: (selected: TreeSelectOption) => void;
-// }
-
-// interface TreeSelectPropsWithoutMultiple<IsMulti extends boolean> extends CommonTreeProps {
-//   current: IsMulti extends true ? TreeSelectOption[] : TreeSelectOption;
-//   onChange?: (selected: IsMulti extends true ? TreeSelectOption[] : TreeSelectOption) => void;
-// }
 
 export interface TreeSelectProps<IsMulti extends boolean = false> extends CommonTreeProps {
   multiple?: IsMulti;

--- a/client/src/containers/analysis-chart/comparison-chart/component.tsx
+++ b/client/src/containers/analysis-chart/comparison-chart/component.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useMemo } from 'react';
-import { useStore } from 'react-redux';
 import omit from 'lodash/omit';
 import {
   LineChart,
@@ -22,7 +21,6 @@ import { NUMBER_FORMAT } from 'utils/number-format';
 import CustomLegend from './legend';
 import CustomTooltip from './tooltip';
 
-import type { Store } from 'store';
 import type { Indicator } from 'types';
 
 type StackedAreaChartProps = {
@@ -42,9 +40,8 @@ type ChartData = {
 };
 
 const StackedAreaChart: React.FC<StackedAreaChartProps> = ({ indicator }) => {
-  const store: Store = useStore();
   const { scenarioToCompare } = useAppSelector(scenarios);
-  const filters = filtersForTabularAPI(store.getState());
+  const filters = useAppSelector(filtersForTabularAPI);
 
   const params = {
     ...omit(filters, 'indicatorId'),

--- a/client/src/containers/analysis-chart/impact-chart/component.tsx
+++ b/client/src/containers/analysis-chart/impact-chart/component.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useMemo } from 'react';
-import { useStore } from 'react-redux';
 import omit from 'lodash/omit';
 import chroma from 'chroma-js';
 import {
@@ -20,8 +19,8 @@ import Loading from 'components/loading';
 import { NUMBER_FORMAT } from 'utils/number-format';
 import LegendChart from './legend';
 
-import type { Store } from 'store';
 import type { Indicator } from 'types';
+import { useAppSelector } from 'store/hooks';
 
 type StackedAreaChartProps = {
   indicator: Indicator;
@@ -30,8 +29,7 @@ type StackedAreaChartProps = {
 const COLOR_SCALE = chroma.scale(['#2D7A5B', '#39A163', '#9AC864', '#D9E77F', '#FFF9C7']);
 
 const StackedAreaChart: React.FC<StackedAreaChartProps> = ({ indicator }) => {
-  const store: Store = useStore();
-  const filters = filtersForTabularAPI(store.getState());
+  const filters = useAppSelector(filtersForTabularAPI);
 
   const params = {
     maxRankingEntities: 5,

--- a/client/src/containers/analysis-visualization/analysis-table/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-table/component.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useMemo, useState } from 'react';
-import { useStore } from 'react-redux';
 import classNames from 'classnames';
 import { DownloadIcon } from '@heroicons/react/outline';
 import { getSortedRowModel } from '@tanstack/react-table';
@@ -19,7 +18,6 @@ import LineChart from 'components/chart/line';
 import { BIG_NUMBER_FORMAT } from 'utils/number-format';
 import ComparisonCell from './comparison-cell/component';
 
-import type { Store } from 'store';
 import type { PaginationState, SortingState } from '@tanstack/react-table';
 import type { TableProps } from 'components/table/component';
 import type { ColumnDefinition } from 'components/table/column';
@@ -64,11 +62,9 @@ const AnalysisTable: React.FC = () => {
     [paginationState, sortingState],
   );
 
-  // data from redux
-  const store = useStore() as Store;
   const { scenarioToCompare, isComparisonEnabled, currentScenario } = useAppSelector(scenarios);
   const { data: indicators } = useIndicators({ select: (data) => data.data });
-  const filters = filtersForTabularAPI(store.getState());
+  const filters = useAppSelector(filtersForTabularAPI);
 
   const showComparison = useMemo(
     () => isComparisonEnabled && !!scenarioToCompare,


### PR DESCRIPTION
### General description

This PR fixes some selectors not being reactive, causing issues like the table data not being rendered on navigation until the filters were manually changed.

As a bonus, it also fixes a bug with the `checkedStrategy` prop of the Tree Select. It allowed a `CHILD` instead of `CHILDREN` value. With the power of TypeScript, only valid values are allowed now, and an error will occur if the available ones change.

## Checklist before merging

- [x] Branch name / PR includes the related Jira ticket Id.
- [ ] Tests to check core implementation / bug fix added.
- [ ] All checks in Continuous Integration workflow pass.
- [ ] Feature functionally tested by reviewer(s).
- [ ] Code reviewed by reviewer(s).
- [ ] Documentation updated (README, CHANGELOG...) (if required)
