### PR TITLE
Bugfix/landgrif 931 supplier join refactor

### DIFF
--- a/api/src/modules/sourcing-records/sourcing-record.repository.ts
+++ b/api/src/modules/sourcing-records/sourcing-record.repository.ts
@@ -189,35 +189,56 @@ export class SourcingRecordRepository extends Repository<SourcingRecord> {
           Indicator,
           'indicator',
           'indicator.id = indicatorRecord.indicatorId',
-        )
-        .leftJoin(
+        );
+
+    switch (impactDataDto.groupBy) {
+      case GROUP_BY_VALUES.MATERIAL:
+        basicSelectQuery.leftJoin(
           Material,
           'material',
           'material.id = sourcingLocation.materialId',
-        )
-        .leftJoin(
+        );
+        break;
+      case GROUP_BY_VALUES.REGION:
+        basicSelectQuery.leftJoin(
           AdminRegion,
           'adminRegion',
           'sourcingLocation.adminRegionId = adminRegion.id ',
-        )
-        .leftJoin(
+        );
+        break;
+      case GROUP_BY_VALUES.SUPPLIER:
+        basicSelectQuery.leftJoin(
           Supplier,
           'supplier',
           'sourcingLocation.producerId = supplier.id or sourcingLocation.t1SupplierId = supplier.id',
-        )
-        .leftJoin(
+        );
+        break;
+      case GROUP_BY_VALUES.BUSINESS_UNIT:
+        basicSelectQuery.leftJoin(
           BusinessUnit,
           'businessUnit',
           'sourcingLocation.businessUnitId = businessUnit.id',
-        )
+        );
+        break;
 
-        .where('sourcingRecords.year BETWEEN :startYear and :endYear', {
-          startYear: impactDataDto.startYear,
-          endYear: impactDataDto.endYear,
-        })
-        .andWhere('indicator.id IN (:...indicatorIds)', {
-          indicatorIds: impactDataDto.indicatorIds,
-        });
+      default:
+        basicSelectQuery;
+    }
+
+    basicSelectQuery
+      .leftJoin(
+        BusinessUnit,
+        'businessUnit',
+        'sourcingLocation.businessUnitId = businessUnit.id',
+      )
+
+      .where('sourcingRecords.year BETWEEN :startYear and :endYear', {
+        startYear: impactDataDto.startYear,
+        endYear: impactDataDto.endYear,
+      })
+      .andWhere('indicator.id IN (:...indicatorIds)', {
+        indicatorIds: impactDataDto.indicatorIds,
+      });
 
     return basicSelectQuery;
   }

--- a/api/src/modules/sourcing-records/sourcing-record.repository.ts
+++ b/api/src/modules/sourcing-records/sourcing-record.repository.ts
@@ -226,12 +226,6 @@ export class SourcingRecordRepository extends Repository<SourcingRecord> {
     }
 
     basicSelectQuery
-      .leftJoin(
-        BusinessUnit,
-        'businessUnit',
-        'sourcingLocation.businessUnitId = businessUnit.id',
-      )
-
       .where('sourcingRecords.year BETWEEN :startYear and :endYear', {
         startYear: impactDataDto.startYear,
         endYear: impactDataDto.endYear,

--- a/api/test/e2e/impact/actual-vs-scenario-preconditions/mixed-interventions-scenario.preconditions.ts
+++ b/api/test/e2e/impact/actual-vs-scenario-preconditions/mixed-interventions-scenario.preconditions.ts
@@ -140,6 +140,7 @@ export async function createMultipleInterventionsPreconditions(): Promise<{
       material: wool,
       businessUnit,
       t1Supplier: supplierB,
+      producer: supplierA,
       adminRegion,
       scenarioInterventionId: scenarioIntervention1.id,
       interventionType: SOURCING_LOCATION_TYPE_BY_INTERVENTION.REPLACING,


### PR DESCRIPTION
### General description

This small fix makes the entity joins in the base select query for retrieving impact data fr analysis. Since the join is needed only to get 'name' of material, supplier, region y etc, there is no need to join all the entity tables, only the one specified in groupBy param.

In case of groupBy supplier, if location has both producer and supplier of different ids, response will contain impact data for both of them, even though leading to duplicated values in yearSum (approved by Science team). However, conditional join will avoid duplication in case other entity time is selected in groupBy (since supplier table will not be joined) 

### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

Test preconditions for mixed intervention scenarios case were updated - 1 location now has producer and supplier with different ids, and by requesting comparison grouped by material impact duplication is not happening.

- Apart from the added feature / bug fix, check overall performance, styling...

## Checklist before merging

- [ ] Branch name / PR includes the related Jira ticket Id.
- [ ] Tests to check core implementation / bug fix added.
- [ ] All checks in Continuous Integration workflow pass.
- [ ] Feature functionally tested by reviewer(s).
- [ ] Code reviewed by reviewer(s).
- [ ] Documentation updated (README, CHANGELOG...) (if required)
