### PR TITLE
Fix initial store state

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- `ACTUAL_DATA` was removed and a null scenario id is used in it's place
 - Send `scenarioId` param alongside analysis filters [LANDGRIF-891](https://vizzuality.atlassian.net/browse/LANDGRIF-891)
 - Same input for city, address and coordinates for intervention form [LANDGRIF-821](https://vizzuality.atlassian.net/browse/LANDGRIF-821)
 - Redesign the Legend [LANDGRIF_727](https://vizzuality.atlassian.net/browse/LANDGRIF-727)
@@ -26,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Navigating to another page with some query params now correctly override the state [LANDGRIF-911](https://vizzuality.atlassian.net/browse/LANDGRIF-911)
 - Smart filters not being persisted between pages
 - Showing errors in the sign-up form
 - Loading more consistent for the auth pages

--- a/client/src/components/button-group/link-group-item/component.tsx
+++ b/client/src/components/button-group/link-group-item/component.tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link';
 import classNames from 'classnames';
 
-import type { HTMLAttributes } from 'react';
+import type { ComponentProps, HTMLAttributes } from 'react';
 
 const CONTROL_ITEM_CLASS_NAMES =
   'relative inline-flex items-center px-4 py-1.5 border -ml-px first:ml-0';
@@ -10,7 +10,7 @@ const CONTROL_ITEM_DEFAULT_CLASS_NAMES =
 const CONTROL_ITEM_ACTIVE_CLASS_NAMES = 'z-10 text-primary bg-primary/20 pointer-events-none';
 
 type LinkGroupItemProps = HTMLAttributes<HTMLAnchorElement> & {
-  href: string;
+  href: ComponentProps<typeof Link>['href'];
   active?: boolean;
 };
 

--- a/client/src/containers/analysis-chart/comparison-chart/component.tsx
+++ b/client/src/containers/analysis-chart/comparison-chart/component.tsx
@@ -22,7 +22,6 @@ import CustomLegend from './legend';
 import CustomTooltip from './tooltip';
 
 import type { Indicator } from 'types';
-import { ACTUAL_DATA } from 'containers/scenarios/constants';
 
 type StackedAreaChartProps = {
   indicator: Indicator;
@@ -47,7 +46,7 @@ const StackedAreaChart: React.FC<StackedAreaChartProps> = ({ indicator }) => {
   const params = {
     ...omit(filters, 'indicatorId'),
     indicatorIds: [indicator.id],
-    scenarioId: scenarioToCompare === ACTUAL_DATA.id ? undefined : scenarioToCompare,
+    scenarioId: scenarioToCompare,
     disabledPagination: true,
   };
 

--- a/client/src/containers/analysis-chart/impact-chart/component.tsx
+++ b/client/src/containers/analysis-chart/impact-chart/component.tsx
@@ -22,7 +22,6 @@ import LegendChart from './legend';
 import type { Indicator } from 'types';
 import { useAppSelector } from 'store/hooks';
 import { scenarios } from 'store/features/analysis';
-import { ACTUAL_DATA } from 'containers/scenarios/constants';
 
 type StackedAreaChartProps = {
   indicator: Indicator;
@@ -39,7 +38,7 @@ const StackedAreaChart: React.FC<StackedAreaChartProps> = ({ indicator }) => {
     sort: 'DES',
     ...omit(filters, 'indicatorId'),
     indicatorIds: [indicator.id],
-    scenarioId: scenarioId === ACTUAL_DATA.id ? undefined : scenarioId,
+    scenarioId,
   };
 
   const enabled =

--- a/client/src/containers/analysis-visualization/analysis-dynamic-metadata/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-dynamic-metadata/component.tsx
@@ -40,12 +40,12 @@ const AnalysisDynamicMetadata: FC<AnalysisDynamicMetadataTypes> = ({
   const { data: scenarioB } = useScenario(scenarioToCompare);
 
   const scenario1 = useMemo(
-    () => (currentScenario !== 'actual-data' ? scenario?.title : 'Actual data'),
+    () => (currentScenario ? scenario?.title : 'Actual data'),
     [currentScenario, scenario?.title],
   );
 
   const scenario2 = useMemo(
-    () => (scenarioToCompare !== 'actual-data' ? scenarioB?.title : 'Actual data'),
+    () => (scenarioToCompare ? scenarioB?.title : 'Actual data'),
     [scenarioToCompare, scenarioB?.title],
   );
 
@@ -143,7 +143,7 @@ const AnalysisDynamicMetadata: FC<AnalysisDynamicMetadataTypes> = ({
   );
 
   const shouldDisplayComparePhrase = useMemo(
-    () => isComparisonEnabled && scenarioToCompare && scenarioToCompare !== 'actual-data',
+    () => isComparisonEnabled && scenarioToCompare,
     [isComparisonEnabled, scenarioToCompare],
   );
 

--- a/client/src/containers/analysis-visualization/analysis-filters/more-filters/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-filters/more-filters/component.tsx
@@ -22,7 +22,6 @@ import {
 } from '@floating-ui/react-dom-interactions';
 import { Transition } from '@headlessui/react';
 import { scenarios } from 'store/features/analysis';
-import { ACTUAL_DATA } from 'containers/scenarios/constants';
 
 type MoreFiltersState = {
   materials: AnalysisFiltersState['materials'];
@@ -42,8 +41,7 @@ const MoreFilters = () => {
   const dispatch = useAppDispatch();
   const { materials, origins, suppliers, locationTypes } = useAppSelector(analysisFilters);
 
-  const { currentScenario } = useAppSelector(scenarios);
-  const scenarioId = currentScenario === ACTUAL_DATA.id ? undefined : currentScenario;
+  const { currentScenario: scenarioId } = useAppSelector(scenarios);
 
   const moreFilters: MoreFiltersState = useMemo(
     () => ({ materials, origins, suppliers, locationTypes }),

--- a/client/src/containers/analysis-visualization/analysis-table/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-table/component.tsx
@@ -94,9 +94,7 @@ const AnalysisTable: React.FC = () => {
     endYear: filters.endYear,
     groupBy: filters.groupBy,
     ...restFilters,
-    ...(currentScenario && currentScenario !== 'actual-data'
-      ? { scenarioId: currentScenario }
-      : {}),
+    scenarioId: currentScenario,
     ...(isComparisonEnabled && scenarioToCompare ? { scenarioId: scenarioToCompare } : {}),
     'page[number]': paginationState.pageIndex,
     'page[size]': paginationState.pageSize,

--- a/client/src/containers/mode-control/component.tsx
+++ b/client/src/containers/mode-control/component.tsx
@@ -4,16 +4,22 @@ import { useAppSelector } from 'store/hooks';
 import { analysisUI } from 'store/features/analysis/ui';
 
 import ButtonGroup, { LinkGroupItem } from 'components/button-group';
+import { useRouter } from 'next/router';
 
 const MODES: string[] = ['map', 'table', 'chart'];
 
 const ModeControl: React.FC = () => {
   const { visualizationMode } = useAppSelector(analysisUI);
+  const { query } = useRouter();
 
   return (
     <ButtonGroup>
       {MODES.map((mode) => (
-        <LinkGroupItem key={mode} active={visualizationMode === mode} href={`/analysis/${mode}`}>
+        <LinkGroupItem
+          key={mode}
+          active={visualizationMode === mode}
+          href={{ pathname: `/analysis/${mode}`, query }}
+        >
           {mode === 'map' && <MapIcon className="w-6 h-6" aria-hidden="true" />}
           {mode === 'table' && <TableIcon className="w-6 h-6" aria-hidden="true" />}
           {mode === 'chart' && <ChartPieIcon className="w-6 h-6" aria-hidden="true" />}

--- a/client/src/containers/scenarios/comparison/component.tsx
+++ b/client/src/containers/scenarios/comparison/component.tsx
@@ -5,6 +5,7 @@ import { useScenarios } from 'hooks/scenarios';
 import { useAppDispatch, useAppSelector } from 'store/hooks';
 import {
   scenarios as scenariosSelector,
+  setComparisonEnabled,
   setScenarioToCompare,
 } from 'store/features/analysis/scenarios';
 
@@ -37,7 +38,8 @@ const ScenariosComparison: FC = () => {
 
   const handleOnChange = useCallback<Dispatch<SelectOption>>(
     (current) => {
-      dispatch(setScenarioToCompare(current?.value));
+      dispatch(setComparisonEnabled(!!current));
+      dispatch(setScenarioToCompare(current?.value || null));
     },
     [dispatch],
   );
@@ -46,12 +48,13 @@ const ScenariosComparison: FC = () => {
   useEffect(() => {
     if (selected?.value && scenarioToCompare !== selected?.value) {
       dispatch(setScenarioToCompare(null));
+      setComparisonEnabled(false);
     }
   }, [selected, dispatch, options, scenarioToCompare]);
 
   return (
     <div>
-      <div className="text-gray-900 text-sm">Compare with:</div>
+      <div className="text-sm text-gray-900">Compare with:</div>
       <Select
         showSearch
         current={selected}

--- a/client/src/containers/scenarios/constants.ts
+++ b/client/src/containers/scenarios/constants.ts
@@ -1,9 +1,0 @@
-import type { Scenario } from './types';
-
-/**
- * Actual data to the data response
- */
-export const ACTUAL_DATA: Scenario = {
-  id: 'actual-data', // reserved id only for actual-data
-  title: 'Actual data',
-};

--- a/client/src/containers/scenarios/item/component.tsx
+++ b/client/src/containers/scenarios/item/component.tsx
@@ -1,11 +1,7 @@
-import { Fragment, useEffect } from 'react';
 import { differenceInDays, format, formatDistanceToNowStrict } from 'date-fns';
 import { RadioGroup } from '@headlessui/react';
 import classNames from 'classnames';
 import Link from 'next/link';
-
-import { scenarios, setComparisonEnabled } from 'store/features/analysis/scenarios';
-import { useAppDispatch, useAppSelector } from 'store/hooks';
 
 import ScenariosComparison from 'containers/scenarios/comparison';
 
@@ -39,19 +35,6 @@ const formatTimeAgo = (date: Date) => {
 };
 
 const ScenarioItem = ({ scenario, isSelected }: ScenariosItemProps) => {
-  const dispatch = useAppDispatch();
-  const { currentScenario, scenarioToCompare } = useAppSelector(scenarios);
-
-  useEffect(() => {
-    // Disabling comparison when is not selected
-    if (!isSelected) dispatch(setComparisonEnabled(false));
-  }, [dispatch, isSelected]);
-
-  useEffect(() => {
-    // Disabling comparison when is not selected
-    dispatch(setComparisonEnabled(!!currentScenario && !!scenarioToCompare));
-  }, [dispatch, currentScenario, scenarioToCompare]);
-
   const updatedAt = useMemo(
     () => (scenario.updatedAt ? new Date(scenario.updatedAt) : null),
     [scenario.updatedAt],

--- a/client/src/containers/scenarios/item/component.tsx
+++ b/client/src/containers/scenarios/item/component.tsx
@@ -8,7 +8,6 @@ import { scenarios, setComparisonEnabled } from 'store/features/analysis/scenari
 import { useAppDispatch, useAppSelector } from 'store/hooks';
 
 import ScenariosComparison from 'containers/scenarios/comparison';
-import { ACTUAL_DATA } from '../constants';
 
 import type { Scenario } from '../types';
 import { DatabaseIcon } from '@heroicons/react/outline';
@@ -99,24 +98,22 @@ const ScenarioItem = ({ scenario, isSelected }: ScenariosItemProps) => {
                   >
                     {scenario.title}
                   </h2>
-                  {scenario.id !== ACTUAL_DATA.id && (
+                  {scenario.id ? (
                     <div className="flex">
                       <div className="px-2 text-xs rounded-full bg-yellow">
                         {scenario.scenarioInterventions.length} interventions
                       </div>
                     </div>
+                  ) : (
+                    <span className="flex flex-row text-sm text-gray-500 place-items-center">
+                      <span>
+                        <DatabaseIcon className="w-4 h-4" />
+                      </span>
+                      <span>Based on your uploaded data</span>
+                    </span>
                   )}
                   <div>
-                    {scenario.id === ACTUAL_DATA.id && (
-                      <span className="flex flex-row text-sm text-gray-500 place-items-center">
-                        <span>
-                          <DatabaseIcon className="w-4 h-4" />
-                        </span>
-                        <span>Based on your uploaded data</span>
-                      </span>
-                    )}
-
-                    {scenario.id !== ACTUAL_DATA.id && scenario.updatedAt && (
+                    {scenario.id && scenario.updatedAt && (
                       <div className="flex flex-row justify-between w-full min-w-0 gap-1 place-items-center">
                         <div className="text-xs text-gray-400" title={updatedAt?.toLocaleString()}>
                           Modified: {formattedUpdatedAgo}

--- a/client/src/containers/scenarios/list/component.tsx
+++ b/client/src/containers/scenarios/list/component.tsx
@@ -10,18 +10,19 @@ import {
 
 import ScenarioItem from 'containers/scenarios/item';
 
-import { ACTUAL_DATA } from '../constants';
-
 import type { Scenario } from '../types';
 
 type ScenariosListProps = {
   data: Scenario[];
 };
 
-const isScenarioSelected: (scenarioId: Scenario['id'], currentId: Scenario['id']) => boolean = (
-  scenarioId,
-  currentId,
-): boolean => scenarioId.toString() === currentId?.toString();
+/**
+ * Actual data to the data response
+ */
+const ACTUAL_DATA: Scenario = {
+  id: null, // reserved id only for actual-data
+  title: 'Actual data',
+};
 
 const ScenariosList = ({ data }: ScenariosListProps) => {
   const { currentScenario } = useAppSelector(scenarios);
@@ -37,26 +38,13 @@ const ScenariosList = ({ data }: ScenariosListProps) => {
     [dispatch],
   );
 
-  useEffect(() => {
-    if (data && !currentScenario) {
-      dispatch(setCurrentScenario(ACTUAL_DATA.id as string)); // first option of the list by default
-    }
-  }, [data, currentScenario, dispatch]);
-
   return (
     <RadioGroup value={currentScenario} onChange={handleOnChange}>
       <RadioGroup.Label className="sr-only">Scenarios</RadioGroup.Label>
       <ul className="relative grid grid-cols-1 gap-5 my-2 overflow-auto sm:gap-2 sm:grid-cols-2 lg:grid-cols-1">
-        <ScenarioItem
-          scenario={ACTUAL_DATA}
-          isSelected={isScenarioSelected(ACTUAL_DATA.id, currentScenario)}
-        />
+        <ScenarioItem scenario={ACTUAL_DATA} isSelected={!currentScenario} />
         {data.map((item) => (
-          <ScenarioItem
-            key={item.id}
-            scenario={item}
-            isSelected={isScenarioSelected(item.id, currentScenario)}
-          />
+          <ScenarioItem key={item.id} scenario={item} isSelected={currentScenario === item.id} />
         ))}
       </ul>
     </RadioGroup>

--- a/client/src/containers/scenarios/list/component.tsx
+++ b/client/src/containers/scenarios/list/component.tsx
@@ -1,9 +1,10 @@
-import { useEffect, useCallback } from 'react';
+import { useCallback } from 'react';
 import { RadioGroup } from '@headlessui/react';
 
 import { useAppSelector, useAppDispatch } from 'store/hooks';
 import {
   scenarios,
+  setComparisonEnabled,
   setCurrentScenario,
   setScenarioToCompare,
 } from 'store/features/analysis/scenarios';
@@ -30,10 +31,13 @@ const ScenariosList = ({ data }: ScenariosListProps) => {
 
   const handleOnChange = useCallback(
     (id: Scenario['id']) => {
-      dispatch(setCurrentScenario(id)).payload;
+      dispatch(setCurrentScenario(id));
+      dispatch(setComparisonEnabled(false));
+
+      // TODO: if done one after the other, the query middleware overrides the values stored in the query params
       setTimeout(() => {
         dispatch(setScenarioToCompare(null));
-      }, 10);
+      }, 0);
     },
     [dispatch],
   );

--- a/client/src/hooks/h3-data/impact/comparison.ts
+++ b/client/src/hooks/h3-data/impact/comparison.ts
@@ -1,6 +1,5 @@
 import type { UseQueryOptions } from '@tanstack/react-query';
 import { useQuery } from '@tanstack/react-query';
-import { ACTUAL_DATA } from 'containers/scenarios/constants';
 import type { Scenario } from 'containers/scenarios/types';
 import { apiRawService } from 'services/api';
 import type { ImpactH3APIParams } from 'types';
@@ -19,7 +18,7 @@ const useH3ComparisonData = <T = H3ImpactResponse>(
   { baseScenarioId, ...rawParams }: CompareH3ApiParams,
   options: UseQueryOptions<H3ImpactResponse, unknown, T>,
 ) => {
-  const vsActual = !baseScenarioId || baseScenarioId === ACTUAL_DATA.id;
+  const vsActual = !baseScenarioId;
   const colors = useColors('impact', COLOR_RAMPS);
   const params = { ...rawParams, ...(vsActual ? {} : { baseScenarioId }) };
 

--- a/client/src/hooks/h3-data/utils.ts
+++ b/client/src/hooks/h3-data/utils.ts
@@ -1,5 +1,4 @@
 import type { UseQueryResult } from '@tanstack/react-query';
-import { ACTUAL_DATA } from 'containers/scenarios/constants';
 import type { ScaleOrdinal, ScaleThreshold } from 'd3-scale';
 import { scaleOrdinal, scaleThreshold } from 'd3-scale';
 import type { AnalysisFiltersState } from 'store/features/analysis/filters';
@@ -32,7 +31,7 @@ export const storeToQueryParams = ({
     ...(suppliers?.length ? { supplierIds: suppliers?.map(({ value }) => value) } : {}),
     ...(origins?.length ? { originIds: origins?.map(({ value }) => value) } : {}),
     ...(locationTypes?.length ? { locationTypes: locationTypes?.map(({ value }) => value) } : {}),
-    ...(currentScenario !== ACTUAL_DATA.id ? { scenarioId: currentScenario } : {}),
+    scenarioId: currentScenario,
     resolution: origins?.length ? 6 : 4,
   };
 };

--- a/client/src/hooks/scenarios/index.ts
+++ b/client/src/hooks/scenarios/index.ts
@@ -123,7 +123,7 @@ export function useScenario(id: Scenario['id']): ResponseDataScenario {
           url: `/scenarios/${id}`,
         })
         .then(({ data: responseData }) => responseData.data),
-    { ...DEFAULT_QUERY_OPTIONS, enabled: !!id && id !== 'actual-data' },
+    { ...DEFAULT_QUERY_OPTIONS, enabled: !!id },
   );
 
   return useMemo<ResponseDataScenario>(() => response, [response]);

--- a/client/src/layouts/analysis/component.tsx
+++ b/client/src/layouts/analysis/component.tsx
@@ -61,7 +61,7 @@ const AnalysisLayout: React.FC<React.PropsWithChildren> = ({ children }) => {
             className={classNames(
               {
                 'absolute top-6 left-6 xl:left-12 right-6 z-10': visualizationMode === 'map',
-                'py-6 pr-6 pl-6 xl:pl-12': visualizationMode !== 'map',
+                'p-6 xl:pl-12': visualizationMode !== 'map',
               },
               'flex gap-2 flex-wrap justify-between',
             )}

--- a/client/src/pages/_app.tsx
+++ b/client/src/pages/_app.tsx
@@ -1,5 +1,5 @@
 import Head from 'next/head';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
 import { QueryClient, QueryClientProvider, Hydrate } from '@tanstack/react-query';
 import { OverlayProvider } from '@react-aria/overlays';
@@ -16,6 +16,7 @@ import type { DehydratedState } from '@tanstack/react-query';
 import type { Session } from 'next-auth';
 
 import 'styles/globals.css';
+import { useRouter } from 'next/router';
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 export type NextPageWithLayout<P = {}, IP = P> = NextPage<P, IP> & {
@@ -33,7 +34,25 @@ type AppPropsWithLayout = AppProps<PageProps> & {
 };
 
 function MyApp({ Component, pageProps }: AppPropsWithLayout) {
-  const [store] = useState(() => initStore(pageProps.query));
+  /* ?
+   * On navigation, the redux middleware doesn't run, so we must manually trigger it.
+   * The state is passed because otherwise it resets the store to the original state + the query params.
+   */
+  const router = useRouter();
+  const [store, setStore] = useState(() => initStore(pageProps.query));
+  useEffect(() => {
+    const onRouteChange = () => {
+      if (!router.isReady) return;
+      setStore(initStore(router.query, store.getState()));
+    };
+
+    router.events.on('routeChangeComplete', onRouteChange);
+
+    return () => {
+      router.events.off('routeChangeComplete', onRouteChange);
+    };
+  }, [router.events, router.isReady, router.query, store]);
+
   const [queryClient] = useState(() => new QueryClient());
   const getLayout = Component.Layout ?? ((page) => page);
 

--- a/client/src/store/features/analysis/scenarios.ts
+++ b/client/src/store/features/analysis/scenarios.ts
@@ -6,7 +6,11 @@ import type { Scenario } from 'containers/scenarios/types';
 export type ScenariosState = {
   isComparisonEnabled: boolean;
   comparisonMode: 'relative' | 'absolute';
-  currentScenario: Scenario['id'];
+  /**
+   * The current scenario id
+   * If the current scenario is the actual data, the id will be null
+   */
+  currentScenario: Scenario['id'] | null;
   scenarioToCompare: Scenario['id'];
   // To remove
   searchTerm: string;

--- a/client/src/store/index.ts
+++ b/client/src/store/index.ts
@@ -102,6 +102,7 @@ const getPreloadedState = (query = {}) => {
   const preloadedState = {
     'analysis/ui': { ...analysisUIInitialState },
     'analysis/map': { ...analysisMapInitialState },
+    'analysis/scenarios': { ...analysisScenariosInitialState },
   };
 
   Object.keys(QUERY_PARAMS_MAP).forEach((param) => {

--- a/client/src/store/index.ts
+++ b/client/src/store/index.ts
@@ -1,7 +1,7 @@
 import { configureStore, combineReducers } from '@reduxjs/toolkit';
 import type { ReducersMapObject, Middleware } from '@reduxjs/toolkit';
 import router from 'next/router';
-import { isObject } from 'lodash';
+import { cloneDeep, isObject } from 'lodash';
 
 import ui from 'store/features/ui';
 import analysisUI, {
@@ -103,13 +103,14 @@ const getPreloadedState = (
   query: Record<string, string>,
   // It seems like is needed to specify the whole root object
   // because it doesn't merge with the original initial state
-  previousState: AnalysisState = {
+  _previousStateOriginal: AnalysisState = {
     'analysis/ui': { ...analysisUIInitialState },
     'analysis/map': { ...analysisMapInitialState },
     'analysis/scenarios': { ...analysisScenariosInitialState },
     'analysis/filters': { ...analysisFiltersInitialState },
   },
 ) => {
+  const previousState = cloneDeep(_previousStateOriginal);
   Object.keys(QUERY_PARAMS_MAP).forEach((param) => {
     const { stateName, rootState } = QUERY_PARAMS_MAP[param];
     if (query[param]) {


### PR DESCRIPTION
### General description

This PR deletes `ACTUAL_DATA` in favour of a null scenario id.

#### Actual data

Rationale:
- The current scenario ID had a default value of `null`
- When showing the scenario selector, a effect automatically set it to `ACTUAL_DATA` if not set. Hence, there's no distinction between a null id and a `actual-data` id
- The difference in types caused a bunch of edge cases. For example, when calling some endpoints checks had to be performed to exclude the scenario id if it was `actual-data`.
  ```ts
  const vsActual = !baseScenarioId || baseScenarioId === ACTUAL_DATA.id;
  ```
  ```ts
  const params = {
    // snip
    ...(currentScenario !== ACTUAL_DATA.id ? { scenarioId: currentScenario } : {}),
  };
  ```
  
  This cases are now simplified.

The only difficulty I found implementing this was knowing when to enable comparison mode. Before, it was done trivially checking if both `baseScenarioId` and `scenarioToCompare` were set. Now, it is done in the change handler of the `scenarioToCompare` selector.

#### The bug itself

The bug was caused by a surprisingly large amount of factors (every one of this caused the bug on it's own):
- The store initialisation didn't use the current values, only the default ones. So whatever value was present in the past was overriden
- This wasn't noticed because the store didn't refresh at all after the first load. Hence, even when navigating around and clicking links with query params, those new params weren't stored.

## Checklist before merging

- [x] Branch name / PR includes the related Jira ticket Id.
- [ ] Tests to check core implementation / bug fix added.
- [ ] All checks in Continuous Integration workflow pass.
- [ ] Feature functionally tested by reviewer(s).
- [ ] Code reviewed by reviewer(s).
- [x] Documentation updated (README, CHANGELOG...) (if required)
