### PR TITLE
Add data processing for impact table for scenario

### DIFF
--- a/api/src/modules/impact/comparison/actual-vs-scenario.service.ts
+++ b/api/src/modules/impact/comparison/actual-vs-scenario.service.ts
@@ -578,6 +578,7 @@ export class ActualVsScenarioImpactService {
           if (
             scenarioData.name === realData.name &&
             scenarioData.year === realData.year &&
+            scenarioData.indicatorId === realData.indicatorId &&
             scenarioData.typeByIntervention !== null
           ) {
             realData.scenarioImpact = realData.scenarioImpact

--- a/api/src/modules/impact/comparison/scenario-vs-scenario.service.ts
+++ b/api/src/modules/impact/comparison/scenario-vs-scenario.service.ts
@@ -377,6 +377,13 @@ export class ScenarioVsScenarioImpactService {
           0,
         );
 
+        const yearData: ScenarioVsScenarioImpactTableRowsValues | undefined =
+          calculatedData[0].values.find(
+            (tableRowValue: ScenarioVsScenarioImpactTableRowsValues) => {
+              return tableRowValue.year === year;
+            },
+          );
+
         scenarioVsScenarioImpactTable[indicatorValuesIndex].yearSum.push({
           year,
           scenarioOneValue: scenarioOneTotalSumByYear,
@@ -388,6 +395,7 @@ export class ScenarioVsScenarioImpactService {
               ((scenarioOneTotalSumByYear || 0 + scenarioTwoTotalSumByYear) /
                 2)) *
             100,
+          isProjected: yearData?.isProjected,
         });
       });
       // copy and populate tree skeleton for each indicator

--- a/api/src/modules/impact/comparison/scenario-vs-scenario.service.ts
+++ b/api/src/modules/impact/comparison/scenario-vs-scenario.service.ts
@@ -613,6 +613,7 @@ export class ScenarioVsScenarioImpactService {
           if (
             scenarioData.name === realData.name &&
             scenarioData.year === realData.year &&
+            scenarioData.indicatorId === realData.indicatorId &&
             scenarioData.typeByIntervention !== null
           ) {
             realData.scenarioImpact = realData.scenarioImpact

--- a/api/src/modules/impact/dto/response-scenario-scenario.dto.ts
+++ b/api/src/modules/impact/dto/response-scenario-scenario.dto.ts
@@ -88,6 +88,8 @@ export class ScenarioVsScenarioYearSumData {
   absoluteDifference?: number;
   @ApiPropertyOptional()
   percentageDifference?: number;
+  @ApiPropertyOptional()
+  isProjected?: boolean;
 }
 
 export class ScenarioVsScenarioImpactTableRowsValues {

--- a/api/src/modules/impact/impact.service.ts
+++ b/api/src/modules/impact/impact.service.ts
@@ -631,6 +631,7 @@ export class ImpactService {
         if (
           scenarioData.name === realData.name &&
           scenarioData.year === realData.year &&
+          scenarioData.indicatorId === realData.indicatorId &&
           scenarioData.typeByIntervention !== null
         ) {
           realData.impact = realData.impact

--- a/api/test/e2e/impact/impact.spec.ts
+++ b/api/test/e2e/impact/impact.spec.ts
@@ -41,6 +41,7 @@ import {
   groupByMaterialResponseData,
   groupByOriginResponseData,
   groupBySupplierResponseData,
+  impactTableWithScenario,
 } from './response-mocks.impact';
 import { PaginationMeta } from 'utils/app-base.service';
 import { MaterialToH3 } from 'modules/materials/material-to-h3.entity';
@@ -1223,6 +1224,10 @@ describe('Impact Table and Charts test suite (e2e)', () => {
           response.body.data.impactTable[0].rows[0].children.some(
             (child: Material) => child.id === replacingMaterials['linen'].id,
           ),
+        );
+
+        expect(response.body.data.impactTable[0].rows).toEqual(
+          impactTableWithScenario.impactTable[0].rows,
         );
       },
     );

--- a/api/test/e2e/impact/response-mocks.impact.ts
+++ b/api/test/e2e/impact/response-mocks.impact.ts
@@ -483,11 +483,11 @@ export const filteredByLocationTypeResponseData = {
     { value: 406, year: 2013 },
   ],
 };
-export const scenarioInterventionComparisonTable = {
+export const impactTableWithScenario = {
   impactTable: [
     {
       indicatorShortName: null,
-      indicatorId: '8be70a63-58d6-4d3c-b724-ad0b0758c0a2',
+      indicatorId: '09dd65d9-dac0-481f-b5f5-7c099b005ce1',
       groupBy: 'material',
       rows: [
         {
@@ -498,36 +498,50 @@ export const scenarioInterventionComparisonTable = {
               children: [],
               values: [
                 {
+                  year: 2019,
+                  value: 0,
+                  isProjected: true,
+                },
+                {
                   year: 2020,
-                  value: 1200,
+                  value: 400,
                   isProjected: false,
-                  interventionValue: 1000,
-                  absoluteDifference: -200,
-                  percentageDifference: 83.33333333333334,
                 },
                 {
                   year: 2021,
-                  value: 1218,
+                  value: 406,
                   isProjected: true,
-                  interventionValue: 1015,
-                  absoluteDifference: -203,
-                  percentageDifference: 83.33333333333334,
                 },
                 {
                   year: 2022,
-                  value: 1236.27,
+                  value: 412.09,
                   isProjected: true,
-                  interventionValue: 1030.225,
-                  absoluteDifference: -206.04500000000007,
-                  percentageDifference: 83.33333333333333,
+                },
+              ],
+            },
+            {
+              name: 'Linen',
+              children: [],
+              values: [
+                {
+                  year: 2019,
+                  value: 0,
+                  isProjected: true,
                 },
                 {
-                  year: 2023,
-                  value: 1254.81405,
+                  year: 2020,
+                  value: 750,
+                  isProjected: false,
+                },
+                {
+                  year: 2021,
+                  value: 761.25,
                   isProjected: true,
-                  interventionValue: 1045.678375,
-                  absoluteDifference: -209.135675,
-                  percentageDifference: 83.33333333333334,
+                },
+                {
+                  year: 2022,
+                  value: 772.66875,
+                  isProjected: true,
                 },
               ],
             },
@@ -536,96 +550,68 @@ export const scenarioInterventionComparisonTable = {
               children: [],
               values: [
                 {
+                  year: 2019,
+                  value: 0,
+                  isProjected: true,
+                },
+                {
                   year: 2020,
-                  value: 1200,
+                  value: 500,
                   isProjected: false,
-                  interventionValue: 1000,
-                  absoluteDifference: -200,
-                  percentageDifference: 83.33333333333334,
                 },
                 {
                   year: 2021,
-                  value: 1218,
+                  value: 507.5,
                   isProjected: true,
-                  interventionValue: 1015,
-                  absoluteDifference: -203,
-                  percentageDifference: 83.33333333333334,
                 },
                 {
                   year: 2022,
-                  value: 1236.27,
+                  value: 515.1125,
                   isProjected: true,
-                  interventionValue: 1030.225,
-                  absoluteDifference: -206.04500000000007,
-                  percentageDifference: 83.33333333333333,
-                },
-                {
-                  year: 2023,
-                  value: 1254.81405,
-                  isProjected: true,
-                  interventionValue: 1045.678375,
-                  absoluteDifference: -209.135675,
-                  percentageDifference: 83.33333333333334,
                 },
               ],
             },
           ],
           values: [
             {
+              year: 2019,
+              value: 0,
+              isProjected: true,
+            },
+            {
               year: 2020,
-              value: 2400,
+              value: 1650,
               isProjected: false,
-              interventionValue: 2000,
-              absoluteDifference: -400,
-              percentageDifference: 83.33333333333334,
             },
             {
               year: 2021,
-              value: 2436,
+              value: 1674.75,
               isProjected: true,
-              interventionValue: 2030,
-              absoluteDifference: -406,
-              percentageDifference: 83.33333333333334,
             },
             {
               year: 2022,
-              value: 2472.54,
+              value: 1699.87125,
               isProjected: true,
-              interventionValue: 2060.45,
-              absoluteDifference: -412.09000000000015,
-              percentageDifference: 83.33333333333333,
-            },
-            {
-              year: 2023,
-              value: 2509.6281,
-              isProjected: true,
-              interventionValue: 2091.35675,
-              absoluteDifference: -418.27135,
-              percentageDifference: 83.33333333333334,
             },
           ],
         },
       ],
       yearSum: [
         {
+          year: 2019,
+          value: 0,
+        },
+        {
           year: 2020,
-          value: 2400,
-          interventionValue: 2000,
+          value: 1650,
         },
         {
           year: 2021,
-          value: 2436,
-          interventionValue: 2030,
+          value: 1674.75,
         },
         {
           year: 2022,
-          value: 2472.54,
-          interventionValue: 2060.45,
-        },
-        {
-          year: 2023,
-          value: 2509.6281,
-          interventionValue: 2091.35675,
+          value: 1699.87125,
         },
       ],
       metadata: {
@@ -633,26 +619,5 @@ export const scenarioInterventionComparisonTable = {
       },
     },
   ],
-  purchasedTonnes: [
-    {
-      year: 2020,
-      value: 2005.12,
-      isProjected: false,
-    },
-    {
-      year: 2021,
-      value: 1017.5984,
-      isProjected: true,
-    },
-    {
-      year: 2022,
-      value: 1017.5984,
-      isProjected: true,
-    },
-    {
-      year: 2023,
-      value: 1017.5984,
-      isProjected: true,
-    },
-  ],
+  purchasedTonnes: [],
 };

--- a/api/test/e2e/impact/scenario-vs-scenario-responses/same-materials-scenarios.reponse.ts
+++ b/api/test/e2e/impact/scenario-vs-scenario-responses/same-materials-scenarios.reponse.ts
@@ -105,6 +105,7 @@ export function getSameMaterialScenarioComparisonResponse(
             scenarioTwoValue: 1500,
             absoluteDifference: 500,
             percentageDifference: 200,
+            isProjected: false,
           },
           {
             year: 2021,
@@ -112,6 +113,7 @@ export function getSameMaterialScenarioComparisonResponse(
             scenarioTwoValue: 1522.5,
             absoluteDifference: 507.5,
             percentageDifference: 200,
+            isProjected: true,
           },
         ],
         metadata: {

--- a/api/test/e2e/impact/scenario-vs-scenario.spec.ts
+++ b/api/test/e2e/impact/scenario-vs-scenario.spec.ts
@@ -94,6 +94,15 @@ describe('Scenario comparison test suite (e2e)', () => {
         expectedScenariosTableMByMaterial.scenarioVsScenarioImpactTable[0].rows,
       ),
     );
+    expect(
+      responseGroupByMaterial.body.data.scenarioVsScenarioImpactTable[0]
+        .yearSum,
+    ).toEqual(
+      expect.arrayContaining(
+        expectedScenariosTableMByMaterial.scenarioVsScenarioImpactTable[0]
+          .yearSum,
+      ),
+    );
     expect(responseGroupByMaterial.body.data.purchasedTonnes).toEqual(
       expect.arrayContaining(expectedScenariosTableMByMaterial.purchasedTonnes),
     );


### PR DESCRIPTION
### General description

This fix adds a data processing method for correct calculation of simple non comparative impact for a scenario, in order for it to follow the formula:

Scenario impact = Actual impact - impact canceled by scenario + impact created by scenario

Additional bugfixes:
- Adding isProjected to yearSum of scenario-scenario analysis
- Fixing error in data processing for comparison (indicatorId was ignored in iteration)

Update of tests

### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

_Provide minimal instructions on how to test this PR._

- Apart from the added feature / bug fix, check overall performance, styling...

## Checklist before merging

- [ ] Branch name / PR includes the related Jira ticket Id.
- [ ] Tests to check core implementation / bug fix added.
- [ ] All checks in Continuous Integration workflow pass.
- [ ] Feature functionally tested by reviewer(s).
- [ ] Code reviewed by reviewer(s).
- [ ] Documentation updated (README, CHANGELOG...) (if required)
