### PR TITLE
Fix error in data processing for scenario-vs-scenario comparison

### DIFF
--- a/api/src/modules/impact/comparison/scenario-vs-scenario.service.ts
+++ b/api/src/modules/impact/comparison/scenario-vs-scenario.service.ts
@@ -715,7 +715,8 @@ export class ScenarioVsScenarioImpactService {
             accumulator.find((item: ScenarioVsScenarioImpactTableData) => {
               return (
                 item.name === currentValue.name &&
-                item.year === currentValue.year
+                item.year === currentValue.year &&
+                item.indicatorId === currentValue.indicatorId
               );
             });
 


### PR DESCRIPTION
### General description

Final reduce iteration for 2 scenario comparison data did not include indicatorId, which led to only one indicator being present in the results.

This PR adds a tiny fix for that issue.

### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

_Provide minimal instructions on how to test this PR._

- Apart from the added feature / bug fix, check overall performance, styling...

## Checklist before merging

- [ ] Branch name / PR includes the related Jira ticket Id.
- [ ] Tests to check core implementation / bug fix added.
- [ ] All checks in Continuous Integration workflow pass.
- [ ] Feature functionally tested by reviewer(s).
- [ ] Code reviewed by reviewer(s).
- [ ] Documentation updated (README, CHANGELOG...) (if required)
