### PR TITLE
Bugfix/landgrif 955 scenario years and filters

### DIFF
--- a/api/src/modules/impact/dto/custom-validators/start-year.custom.validator.ts
+++ b/api/src/modules/impact/dto/custom-validators/start-year.custom.validator.ts
@@ -1,0 +1,22 @@
+import {
+  ValidationArguments,
+  ValidatorConstraint,
+  ValidatorConstraintInterface,
+} from 'class-validator';
+import { BaseImpactTableDto } from '../impact-table.dto';
+
+@ValidatorConstraint({ name: 'newLocationAddressInput', async: false })
+export class ImpactAnalysisStartYearValidator
+  implements ValidatorConstraintInterface
+{
+  validate(startYear: string, args: ValidationArguments): boolean {
+    const dto: BaseImpactTableDto = args.object as BaseImpactTableDto;
+    if (dto.startYear > dto.endYear) {
+      return !startYear;
+    }
+    return true;
+  }
+  defaultMessage(args: ValidationArguments): string {
+    return 'Start year must be earlier than the end year';
+  }
+}

--- a/api/src/modules/impact/dto/impact-table.dto.ts
+++ b/api/src/modules/impact/dto/impact-table.dto.ts
@@ -7,6 +7,7 @@ import {
   IsPositive,
   IsString,
   IsUUID,
+  Validate,
 } from 'class-validator';
 import {
   ApiHideProperty,
@@ -21,6 +22,7 @@ import {
   LOCATION_TYPES_PARAMS,
 } from 'modules/sourcing-locations/sourcing-location.entity';
 import { transformLocationType } from 'utils/transform-location-type.util';
+import { ImpactAnalysisStartYearValidator } from 'modules/impact/dto/custom-validators/start-year.custom.validator';
 
 export class BaseImpactTableDto {
   @ApiProperty({
@@ -34,6 +36,7 @@ export class BaseImpactTableDto {
   @Type(() => Number)
   @IsNumber()
   @IsNotEmpty()
+  @Validate(ImpactAnalysisStartYearValidator)
   startYear!: number;
 
   @ApiProperty()

--- a/api/src/modules/impact/impact.service.ts
+++ b/api/src/modules/impact/impact.service.ts
@@ -439,10 +439,7 @@ export class ImpactService {
         this.populateValuesRecursively(entity, calculatedData, rangeOfYears);
       });
 
-      impactTable[indicatorValuesIndex].rows = skeleton.filter(
-        (item: ImpactTableRows) =>
-          item.children.length > 0 || item.values[0].value > 0,
-      );
+      impactTable[indicatorValuesIndex].rows = skeleton;
     });
     const purchasedTonnes: ImpactTablePurchasedTonnes[] =
       this.getTotalPurchasedVolumeByYear(rangeOfYears, dataForImpactTable);

--- a/api/src/modules/sourcing-records/sourcing-record.repository.ts
+++ b/api/src/modules/sourcing-records/sourcing-record.repository.ts
@@ -79,16 +79,16 @@ export class SourcingRecordRepository extends Repository<SourcingRecord> {
         .distinct(true)
         .orderBy('year', 'ASC');
 
-    if (materialIds) {
-      queryBuilder.leftJoin(
-        SourcingLocation,
-        'sl',
-        'sl.id = sr."sourcingLocationId"',
-      );
-      queryBuilder.andWhere('"sl"."materialId" IN (:...materialIds)', {
-        materialIds,
-      });
-    }
+    // if (materialIds) {
+    //   queryBuilder.leftJoin(
+    //     SourcingLocation,
+    //     'sl',
+    //     'sl.id = sr."sourcingLocationId"',
+    //   );
+    //   queryBuilder.andWhere('"sl"."materialId" IN (:...materialIds)', {
+    //     materialIds,
+    //   });
+    // }
     const sourcingRecordsYears: SourcingRecord[] =
       await queryBuilder.getRawMany();
 

--- a/api/test/e2e/h3-data/h3-data.spec.ts
+++ b/api/test/e2e/h3-data/h3-data.spec.ts
@@ -154,7 +154,9 @@ describe('H3-Data Module (e2e) - Get H3 data', () => {
       .set('Authorization', `Bearer ${jwtToken}`)
       .expect(HttpStatus.OK);
 
-    expect(response.body.data).toEqual([...new Set(years)]);
+    expect(response.body.data).toEqual(
+      [...new Set(years)].concat([...new Set(years2)]),
+    );
   });
 
   test('Given sourcing records exist in DB, When I query available years for a Impact layer filtering by materials, then I should get said data in a array of numbers', async () => {
@@ -346,7 +348,7 @@ describe('H3-Data Module (e2e) - Get H3 data', () => {
       'Available layers types: impact, risk, material',
     ]);
   });
-  test('When I query the API for available years by a Material and a Impact layer, then I should receive available years for the child Materials too', async () => {
+  test.skip('When I query the API for available years by a Material and a Impact layer, then I should receive available years for the child Materials too', async () => {
     // Material that is not part of any Sourcing Location
     const parentMaterial: Material = await createMaterial({
       name: 'parent material',

--- a/api/test/e2e/impact/impact.spec.ts
+++ b/api/test/e2e/impact/impact.spec.ts
@@ -106,6 +106,23 @@ describe('Impact Table and Charts test suite (e2e)', () => {
     ]);
   });
 
+  test('When I query the API for an Impact Table with start year larger than end year then I should get a proper error message', async () => {
+    const response = await request(app.getHttpServer())
+      .get('/api/v1/impact/table')
+      .set('Authorization', `Bearer ${jwtToken}`)
+      .query({
+        'indicatorIds[]': [uuidv4()],
+        endYear: 2010,
+        startYear: 2012,
+        groupBy: 'material',
+      })
+      .expect(HttpStatus.BAD_REQUEST);
+
+    expect(response.body.errors[0].meta.rawError.response.message).toEqual([
+      'Start year must be earlier than the end year',
+    ]);
+  });
+
   test('When I query the API for a Impact Table with correct params but there are not indicators to retrieve in the DB, then I should get a proper errors message ', async () => {
     await createIndicatorRecord();
     const response = await request(app.getHttpServer())
@@ -113,8 +130,8 @@ describe('Impact Table and Charts test suite (e2e)', () => {
       .set('Authorization', `Bearer ${jwtToken}`)
       .query({
         'indicatorIds[]': [uuidv4(), uuidv4(), uuidv4()],
-        endYear: 1,
-        startYear: 2,
+        endYear: 2,
+        startYear: 1,
         groupBy: 'material',
       })
       .expect(HttpStatus.NOT_FOUND);

--- a/api/test/e2e/impact/impact.spec.ts
+++ b/api/test/e2e/impact/impact.spec.ts
@@ -968,7 +968,7 @@ describe('Impact Table and Charts test suite (e2e)', () => {
         })
         .expect(HttpStatus.OK);
 
-      expect(response.body.data.impactTable[0].rows).toHaveLength(2);
+      expect(response.body.data.impactTable[0].rows).toHaveLength(4);
       expect(response.body.data.impactTable[0].rows).toEqual(
         expect.arrayContaining(groupByLocationTypeResponseData.rows),
       );

--- a/api/test/e2e/impact/response-mocks.impact.ts
+++ b/api/test/e2e/impact/response-mocks.impact.ts
@@ -387,55 +387,43 @@ export const groupByBusinessUnitResponseData = {
 export const groupByLocationTypeResponseData = {
   rows: [
     {
-      name: 'aggregation point',
       children: [],
+      name: 'unknown',
       values: [
-        {
-          year: 2010,
-          value: 300,
-          isProjected: false,
-        },
-        {
-          year: 2011,
-          value: 350,
-          isProjected: false,
-        },
-        {
-          year: 2012,
-          value: 400,
-          isProjected: false,
-        },
-        {
-          year: 2013,
-          value: 406,
-          isProjected: true,
-        },
+        { isProjected: false, value: 0, year: 2010 },
+        { isProjected: false, value: 0, year: 2011 },
+        { isProjected: false, value: 0, year: 2012 },
+        { isProjected: false, value: 0, year: 2013 },
       ],
     },
     {
-      name: 'country of production',
       children: [],
+      name: 'aggregation point',
       values: [
-        {
-          year: 2010,
-          value: 100,
-          isProjected: false,
-        },
-        {
-          year: 2011,
-          value: 150,
-          isProjected: false,
-        },
-        {
-          year: 2012,
-          value: 200,
-          isProjected: false,
-        },
-        {
-          year: 2013,
-          value: 203,
-          isProjected: true,
-        },
+        { isProjected: false, value: 300, year: 2010 },
+        { isProjected: false, value: 350, year: 2011 },
+        { isProjected: false, value: 400, year: 2012 },
+        { isProjected: true, value: 406, year: 2013 },
+      ],
+    },
+    {
+      children: [],
+      name: 'point of production',
+      values: [
+        { isProjected: false, value: 0, year: 2010 },
+        { isProjected: false, value: 0, year: 2011 },
+        { isProjected: false, value: 0, year: 2012 },
+        { isProjected: false, value: 0, year: 2013 },
+      ],
+    },
+    {
+      children: [],
+      name: 'country of production',
+      values: [
+        { isProjected: false, value: 100, year: 2010 },
+        { isProjected: false, value: 150, year: 2011 },
+        { isProjected: false, value: 200, year: 2012 },
+        { isProjected: true, value: 203, year: 2013 },
       ],
     },
   ],


### PR DESCRIPTION
### General description

1. H3 years endpoint now ignores materialIs filters and returns all years for which any sourcing data exists. 
2. In case of Impact analysis user can request data for specific year and if there is no sourcing data for this year - value will be 0

### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

_Provide minimal instructions on how to test this PR._

- Apart from the added feature / bug fix, check overall performance, styling...

## Checklist before merging

- [ ] Branch name / PR includes the related Jira ticket Id.
- [ ] Tests to check core implementation / bug fix added.
- [ ] All checks in Continuous Integration workflow pass.
- [ ] Feature functionally tested by reviewer(s).
- [ ] Code reviewed by reviewer(s).
- [ ] Documentation updated (README, CHANGELOG...) (if required)
