### PR TITLE
Fix filters between scenarios

### DIFF
--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -16,6 +16,7 @@ module.exports = {
     'import/extensions': ['.js', '.jsx', '.ts', '.tsx'],
   },
   rules: {
+    eqeqeq: ['warn'],
     'import/order': [
       'warn',
       {

--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Fix changing scenario keeping filters not valid for selection [LANDGRIF-958](https://vizzuality.atlassian.net/browse/LANDGRIF-958)
 - Navigating to another page with some query params now correctly override the state [LANDGRIF-911](https://vizzuality.atlassian.net/browse/LANDGRIF-911)
 - Zoom controls not working [LANDGRIF-928](https://vizzuality.atlassian.net/browse/LANDGRIF-928)
 - Smart filters not being persisted between pages

--- a/client/src/components/tree-select/types.d.ts
+++ b/client/src/components/tree-select/types.d.ts
@@ -31,7 +31,7 @@ interface CommonTreeProps {
 }
 
 export interface TreeSelectProps<IsMulti extends boolean = false> extends CommonTreeProps {
-  multiple?: IsMulti;
-  current: IsMulti extends true ? TreeSelectOption[] : TreeSelectOption | null;
+  multiple?: readonly IsMulti;
+  current: (IsMulti extends true ? TreeSelectOption[] : TreeSelectOption) | null;
   onChange?: (selected: IsMulti extends true ? TreeSelectOption[] : TreeSelectOption) => void;
 }

--- a/client/src/containers/analysis-sidebar/component.tsx
+++ b/client/src/containers/analysis-sidebar/component.tsx
@@ -2,6 +2,7 @@ import { useMemo, useCallback } from 'react';
 import { XCircleIcon, PlusIcon } from '@heroicons/react/solid';
 import { RadioGroup } from '@headlessui/react';
 import Link from 'next/link';
+import { useQueryClient } from '@tanstack/react-query';
 
 import { useAppSelector, useAppDispatch } from 'store/hooks';
 import {
@@ -16,6 +17,7 @@ import ScenariosFilters from 'containers/scenarios/filters';
 import { Anchor } from 'components/button';
 import Loading from 'components/loading';
 import ScenarioItem from 'containers/scenarios/item';
+import { useMaterialsTrees } from 'hooks/materials';
 
 import type { MutableRefObject } from 'react';
 import type { Scenario } from 'containers/scenarios/types';
@@ -44,10 +46,18 @@ const ScenariosComponent: React.FC<{ scrollref?: MutableRefObject<HTMLDivElement
     return pages?.reduce((acc, { data }) => acc.concat(data?.data), []);
   }, [data]);
 
+  const queryClient = useQueryClient();
+
   const handleOnChange = useCallback(
     (id: Scenario['id']) => {
       dispatch(setCurrentScenario(id));
       dispatch(setComparisonEnabled(false));
+
+      // const materials = queryClient.getQueryData(['materials-trees'], { exact: false });
+      // const origins = queryClient.getQueryData(['admin-regions-trees'], { exact: false });
+      // const suppliers = queryClient.getQueryData(['suppliers-trees'], { exact: false });
+      // const locationTypes = queryClient.getQueryData(['location-types'], { exact: false });
+      // console.log(materials, origins, suppliers, locationTypes);
 
       // TODO: if done one after the other, the query middleware overrides the values stored in the query params
       setTimeout(() => {

--- a/client/src/containers/analysis-sidebar/component.tsx
+++ b/client/src/containers/analysis-sidebar/component.tsx
@@ -2,7 +2,6 @@ import { useMemo, useCallback } from 'react';
 import { XCircleIcon, PlusIcon } from '@heroicons/react/solid';
 import { RadioGroup } from '@headlessui/react';
 import Link from 'next/link';
-import { useQueryClient } from '@tanstack/react-query';
 
 import { useAppSelector, useAppDispatch } from 'store/hooks';
 import {
@@ -17,7 +16,6 @@ import ScenariosFilters from 'containers/scenarios/filters';
 import { Anchor } from 'components/button';
 import Loading from 'components/loading';
 import ScenarioItem from 'containers/scenarios/item';
-import { useMaterialsTrees } from 'hooks/materials';
 
 import type { MutableRefObject } from 'react';
 import type { Scenario } from 'containers/scenarios/types';
@@ -46,18 +44,10 @@ const ScenariosComponent: React.FC<{ scrollref?: MutableRefObject<HTMLDivElement
     return pages?.reduce((acc, { data }) => acc.concat(data?.data), []);
   }, [data]);
 
-  const queryClient = useQueryClient();
-
   const handleOnChange = useCallback(
     (id: Scenario['id']) => {
       dispatch(setCurrentScenario(id));
       dispatch(setComparisonEnabled(false));
-
-      // const materials = queryClient.getQueryData(['materials-trees'], { exact: false });
-      // const origins = queryClient.getQueryData(['admin-regions-trees'], { exact: false });
-      // const suppliers = queryClient.getQueryData(['suppliers-trees'], { exact: false });
-      // const locationTypes = queryClient.getQueryData(['location-types'], { exact: false });
-      // console.log(materials, origins, suppliers, locationTypes);
 
       // TODO: if done one after the other, the query middleware overrides the values stored in the query params
       setTimeout(() => {

--- a/client/src/containers/analysis-visualization/analysis-filters/location-types/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-filters/location-types/component.tsx
@@ -5,35 +5,37 @@ import { sortBy } from 'lodash';
 import { useLocationTypes } from 'hooks/location-types';
 import TreeSelect from 'components/tree-select';
 
+import type { MakePropOptional } from 'types';
 import type { LocationTypesParams } from 'hooks/location-types';
 import type { TreeSelectProps } from 'components/tree-select/types';
 
-interface LocationTypeFilterProps
+interface LocationTypeFilterProps<IsMulti extends boolean>
   extends LocationTypesParams,
-    Pick<TreeSelectProps<true>, 'current' | 'onChange' | 'theme' | 'ellipsis' | 'fitContent'> {}
+    MakePropOptional<TreeSelectProps<IsMulti>, 'options'> {}
 
-const LocationTypesFilter: React.FC<LocationTypeFilterProps> = ({
-  current,
-  onChange,
-  theme,
-  ellipsis,
-  fitContent,
+const LocationTypesFilter = <IsMulti extends boolean = true>({
   materialIds,
   supplierIds,
   businessUnitIds,
   originIds,
   scenarioId,
-}) => {
-  const { data } = useLocationTypes({
-    materialIds,
-    supplierIds,
-    businessUnitIds,
-    originIds,
-    scenarioId,
-  });
+  options,
+  ...props
+}: LocationTypeFilterProps<IsMulti>) => {
+  const { data } = useLocationTypes(
+    {
+      materialIds,
+      supplierIds,
+      businessUnitIds,
+      originIds,
+      scenarioId,
+    },
+    { enabled: !options },
+  );
 
-  const options: TreeSelectProps<true>['options'] = useMemo(
+  const locationOptions: TreeSelectProps<IsMulti>['options'] = useMemo(
     () =>
+      options ??
       sortBy(
         data?.map(({ label, value }) => ({
           label,
@@ -41,20 +43,16 @@ const LocationTypesFilter: React.FC<LocationTypeFilterProps> = ({
         })),
         'label',
       ),
-    [data],
+    [data, options],
   );
 
   return (
     <TreeSelect
       multiple
       showSearch={false}
-      options={options}
+      options={locationOptions}
       placeholder="Location types"
-      onChange={onChange}
-      current={current}
-      theme={theme}
-      fitContent={fitContent}
-      ellipsis={ellipsis}
+      {...props}
     />
   );
 };

--- a/client/src/containers/analysis-visualization/analysis-filters/materials/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-filters/materials/component.tsx
@@ -4,18 +4,15 @@ import { sortBy } from 'lodash';
 import { useMaterialsTrees } from 'hooks/materials';
 import TreeSelect from 'components/tree-select';
 
+import type { MakePropOptional } from 'types';
 import type { MaterialsTreesParams } from 'hooks/materials';
 import type { TreeSelectProps } from 'components/tree-select/types';
 
 export interface MaterialsFilterProps<IsMulti extends boolean>
   extends MaterialsTreesParams,
-    Pick<
-      TreeSelectProps<IsMulti>,
-      'current' | 'multiple' | 'onChange' | 'theme' | 'ellipsis' | 'fitContent'
-    >,
-    Partial<Pick<TreeSelectProps<IsMulti>, 'options'>> {}
+    MakePropOptional<TreeSelectProps<IsMulti>, 'options'> {}
 
-const MaterialsFilter = <IsMulti extends boolean = false>({
+const MaterialsFilter = <IsMulti extends boolean>({
   depth = 1,
   supplierIds,
   businessUnitIds,

--- a/client/src/containers/analysis-visualization/analysis-filters/materials/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-filters/materials/component.tsx
@@ -7,7 +7,7 @@ import TreeSelect from 'components/tree-select';
 import type { MaterialsTreesParams } from 'hooks/materials';
 import type { TreeSelectProps } from 'components/tree-select/types';
 
-interface MaterialsFilterProps<IsMulti extends boolean>
+export interface MaterialsFilterProps<IsMulti extends boolean>
   extends MaterialsTreesParams,
     Pick<
       TreeSelectProps<IsMulti>,
@@ -39,6 +39,7 @@ const MaterialsFilter = <IsMulti extends boolean = false>({
     {
       // 2 minutes stale time
       staleTime: 2 * 60 * 1000,
+      enabled: !options,
     },
   );
 

--- a/client/src/containers/analysis-visualization/analysis-filters/materials/index.tsx
+++ b/client/src/containers/analysis-visualization/analysis-filters/materials/index.tsx
@@ -5,7 +5,9 @@ import Component from './component';
 import { useAppDispatch, useAppSelector } from 'store/hooks';
 import { analysisFilters, setFilter } from 'store/features/analysis/filters';
 
-const MaterialsFilter: React.FC<{ multiple?: boolean }> = ({ multiple = false }) => {
+import type { MaterialsFilterProps } from './component';
+
+const MaterialsFilter = <IsMulti extends boolean = false>(props: MaterialsFilterProps<IsMulti>) => {
   const dispatch = useAppDispatch();
   const { materials } = useAppSelector(analysisFilters);
   const handleChange = useCallback(
@@ -15,7 +17,7 @@ const MaterialsFilter: React.FC<{ multiple?: boolean }> = ({ multiple = false })
     [dispatch],
   );
 
-  return <Component current={materials} multiple={multiple} onChange={handleChange} />;
+  return <Component current={materials} onChange={handleChange} {...props} />;
 };
 
 export default MaterialsFilter;

--- a/client/src/containers/analysis-visualization/analysis-filters/more-filters/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-filters/more-filters/component.tsx
@@ -142,7 +142,7 @@ const MoreFilters = () => {
           <FilterIcon className="w-5 h-5 text-gray-900" aria-hidden="true" />
         </span>
         {counter !== 0 && (
-          <span className="flex items-center justify-center w-5 h-5 text-xs font-semibold text-white bg-green-700 rounded-full">
+          <span className="flex items-center justify-center w-5 h-5 text-xs font-semibold text-white bg-navy-400 rounded-full">
             {counter}
           </span>
         )}

--- a/client/src/containers/analysis-visualization/analysis-filters/more-filters/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-filters/more-filters/component.tsx
@@ -10,6 +10,7 @@ import {
   useInteractions,
 } from '@floating-ui/react-dom-interactions';
 import { Transition } from '@headlessui/react';
+import sortBy from 'lodash/sortBy';
 
 import Materials from '../materials/component';
 import OriginRegions from '../origin-regions/component';
@@ -42,10 +43,23 @@ const INITIAL_FILTERS: MoreFiltersState = {
   locationTypes: [],
 };
 
+interface ApiTreeResponse {
+  id: string;
+  name: string;
+  children?: this[];
+}
+
 const DEFAULT_QUERY_OPTIONS = {
   staleTime: 2 * 60 * 1000, // 2 minutes
-  select: (data: { id: string; name: string }[]) =>
-    data.map((item) => ({ value: item.id, label: item.name })),
+  select: (data: ApiTreeResponse[]) =>
+    sortBy(
+      data?.map(({ name, id, children }) => ({
+        label: name,
+        value: id,
+        children: children?.map(({ name, id }) => ({ label: name, value: id })),
+      })),
+      'label',
+    ),
 };
 
 const MoreFilters = () => {

--- a/client/src/containers/analysis-visualization/analysis-filters/origin-regions/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-filters/origin-regions/component.tsx
@@ -4,19 +4,15 @@ import { sortBy } from 'lodash';
 import TreeSelect from 'components/tree-select';
 import { useAdminRegionsTrees } from 'hooks/admin-regions';
 
+import type { MakePropOptional } from 'types';
 import type { AdminRegionsTreesParams } from 'hooks/admin-regions';
 import type { TreeSelectProps } from 'components/tree-select/types';
 
 interface OriginRegionsFilterProps<IsMulti extends boolean>
   extends AdminRegionsTreesParams,
-    Pick<
-      TreeSelectProps<IsMulti>,
-      'current' | 'multiple' | 'onChange' | 'theme' | 'ellipsis' | 'fitContent'
-    > {}
+    MakePropOptional<TreeSelectProps<IsMulti>, 'options'> {}
 
 const OriginRegionsFilter = <IsMulti extends boolean>({
-  multiple,
-  current,
   depth = 1,
   withSourcingLocations, // Do not a default; backend will override depth if this is set at all
   supplierIds,
@@ -24,10 +20,8 @@ const OriginRegionsFilter = <IsMulti extends boolean>({
   materialIds,
   locationTypes,
   scenarioId,
-  onChange,
-  theme,
-  ellipsis,
-  fitContent,
+  options,
+  ...props
 }: OriginRegionsFilterProps<IsMulti>) => {
   const { data, isFetching } = useAdminRegionsTrees(
     {
@@ -42,11 +36,13 @@ const OriginRegionsFilter = <IsMulti extends boolean>({
     {
       // 2 minutes stale time
       staleTime: 2 * 60 * 1000,
+      enabled: !options,
     },
   );
 
   const treeOptions = useMemo<TreeSelectProps<IsMulti>['options']>(
     () =>
+      options ??
       sortBy(
         data?.map(({ name, id, children }) => ({
           label: name,
@@ -59,21 +55,16 @@ const OriginRegionsFilter = <IsMulti extends boolean>({
         })),
         'label',
       ),
-    [data],
+    [data, options],
   );
 
   return (
     <TreeSelect
-      multiple={multiple}
       showSearch
       loading={isFetching}
       options={treeOptions}
       placeholder="Sourcing regions"
-      onChange={onChange}
-      current={current}
-      theme={theme}
-      ellipsis={ellipsis}
-      fitContent={fitContent}
+      {...props}
     />
   );
 };

--- a/client/src/containers/analysis-visualization/analysis-filters/suppliers/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-filters/suppliers/component.tsx
@@ -4,19 +4,16 @@ import { sortBy } from 'lodash';
 import TreeSelect from 'components/tree-select';
 import { useSuppliersTrees } from 'hooks/suppliers';
 
+import type { MakePropOptional } from 'types';
 import type { SuppliersTreesParams } from 'hooks/suppliers';
 import type { TreeSelectProps } from 'components/tree-select/types';
 
 interface SuppliersFilterProps<IsMulti extends boolean>
   extends SuppliersTreesParams,
-    Pick<
-      TreeSelectProps<IsMulti>,
-      'current' | 'multiple' | 'onChange' | 'theme' | 'ellipsis' | 'fitContent'
-    > {}
+    MakePropOptional<TreeSelectProps<IsMulti>, 'options'> {}
 
 const SuppliersFilter = <IsMulti extends boolean>({
-  multiple,
-  current,
+  options,
   depth = 1,
   withSourcingLocations, // Do not a default; backend will override depth if this is set at all
   originIds,
@@ -25,9 +22,7 @@ const SuppliersFilter = <IsMulti extends boolean>({
   locationTypes,
   scenarioId,
   onChange,
-  theme,
-  ellipsis,
-  fitContent,
+  ...props
 }: SuppliersFilterProps<IsMulti>) => {
   const { data, isFetching } = useSuppliersTrees(
     {
@@ -42,11 +37,13 @@ const SuppliersFilter = <IsMulti extends boolean>({
     {
       // 2 minutes stale time
       staleTime: 2 * 60 * 1000,
+      enabled: !options,
     },
   );
 
   const treeOptions: TreeSelectProps['options'] = useMemo(
     () =>
+      options ??
       sortBy(
         data?.map(({ name, id, children }) => ({
           label: name,
@@ -55,21 +52,17 @@ const SuppliersFilter = <IsMulti extends boolean>({
         })),
         'label',
       ),
-    [data],
+    [data, options],
   );
 
   return (
     <TreeSelect
-      multiple={multiple}
       showSearch
       loading={isFetching}
       options={treeOptions}
       placeholder="Suppliers"
       onChange={onChange}
-      current={current}
-      theme={theme}
-      ellipsis={ellipsis}
-      fitContent={fitContent}
+      {...props}
     />
   );
 };

--- a/client/src/containers/interventions/form/component.tsx
+++ b/client/src/containers/interventions/form/component.tsx
@@ -260,7 +260,7 @@ const InterventionForm: React.FC<InterventionFormProps> = ({
   });
   const optionsSuppliers = useMemo<SelectOption[]>(
     () =>
-      suppliers.map((supplier) => ({
+      suppliers?.map((supplier) => ({
         label: supplier.name,
         value: supplier.id,
       })),
@@ -273,7 +273,7 @@ const InterventionForm: React.FC<InterventionFormProps> = ({
   });
   const optionsProducers = useMemo<SelectOption[]>(
     () =>
-      producers.map((producer) => ({
+      producers?.map((producer) => ({
         label: producer.name,
         value: producer.id,
       })),

--- a/client/src/containers/interventions/form/component.tsx
+++ b/client/src/containers/interventions/form/component.tsx
@@ -283,7 +283,7 @@ const InterventionForm: React.FC<InterventionFormProps> = ({
   const { data: locationTypes } = useLocationTypes();
   const optionsLocationTypes: SelectOption<LocationTypes>[] = useMemo(
     () =>
-      locationTypes.map(({ label, value }) => ({
+      locationTypes?.map(({ label, value }) => ({
         label: `${label[0].toUpperCase()}${label.substring(1)}`,
         value,
       })),

--- a/client/src/hooks/location-types/index.ts
+++ b/client/src/hooks/location-types/index.ts
@@ -1,13 +1,12 @@
-import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 
 import { apiRawService } from 'services/api';
 
-import type { UseQueryResult, UseQueryOptions } from '@tanstack/react-query';
+import type { UseQueryOptions } from '@tanstack/react-query';
 import type { BaseTreeSearchParams } from 'containers/analysis-visualization/analysis-filters/more-filters/types';
 import type { LocationTypes } from 'containers/interventions/enums';
 
-const DEFAULT_QUERY_OPTIONS: UseQueryOptions = {
+const DEFAULT_QUERY_OPTIONS = {
   placeholderData: [],
   retry: false,
   keepPreviousData: true,
@@ -23,12 +22,10 @@ export type LocationType = {
   value: LocationTypes;
 };
 
-type ResponseData = UseQueryResult<LocationType[]>;
-
-export function useLocationTypes(
+export const useLocationTypes = <T = LocationType[]>(
   params: LocationTypesParams = {},
-  options: UseQueryOptions = {},
-): ResponseData {
+  options?: UseQueryOptions<LocationType[], unknown, T, ['location-types', typeof params]>,
+) => {
   const query = useQuery(
     ['location-types', params],
     () =>
@@ -45,14 +42,5 @@ export function useLocationTypes(
     },
   );
 
-  const { data, isError } = query;
-
-  return useMemo<ResponseData>(
-    () =>
-      ({
-        ...query,
-        data: (isError ? DEFAULT_QUERY_OPTIONS.placeholderData : data) as ResponseData,
-      } as ResponseData),
-    [query, isError, data],
-  );
-}
+  return query;
+};

--- a/client/src/hooks/scroll/index.ts
+++ b/client/src/hooks/scroll/index.ts
@@ -66,7 +66,7 @@ function useBottomScrollListener<T extends HTMLDivElement>(
   const noRef = useRef<T>(null);
   const containerRef = scrollref || noRef;
   const handleOnScroll = useCallback(() => {
-    if (containerRef.current != null) {
+    if (containerRef.current) {
       const scrollNode = containerRef.current;
       const scrollContainerBottomPosition = Math.round(
         scrollNode.scrollTop + scrollNode.clientHeight,
@@ -91,7 +91,7 @@ function useBottomScrollListener<T extends HTMLDivElement>(
   useEffect((): (() => void) => {
     const ref = containerRef.current;
 
-    if (ref != null) {
+    if (ref) {
       ref.addEventListener('scroll', handleOnScroll);
     } else {
       window.addEventListener('scroll', handleOnScroll);
@@ -102,7 +102,7 @@ function useBottomScrollListener<T extends HTMLDivElement>(
     }
 
     return () => {
-      if (ref != null) {
+      if (ref) {
         ref.removeEventListener('scroll', handleOnScroll);
       } else {
         window.removeEventListener('scroll', handleOnScroll);

--- a/client/src/hooks/suppliers/index.ts
+++ b/client/src/hooks/suppliers/index.ts
@@ -42,7 +42,7 @@ export const useSuppliers = <T = Supplier[]>(
 };
 
 export const useSuppliersTrees = <T = Supplier[]>(
-  params: SuppliersTreesParams,
+  params: SuppliersTreesParams = {},
   options?: UseQueryOptions<Supplier[], unknown, T, ['suppliers-trees', typeof params]>,
 ) => {
   const query = useQuery(

--- a/client/src/hooks/suppliers/index.ts
+++ b/client/src/hooks/suppliers/index.ts
@@ -1,27 +1,27 @@
-import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 
 import { apiService } from 'services/api';
 
-import type { UseQueryResult, UseQueryOptions } from '@tanstack/react-query';
+import type { UseQueryOptions } from '@tanstack/react-query';
 import type { Supplier } from 'types';
 import type { BaseTreeSearchParams } from 'containers/analysis-visualization/analysis-filters/more-filters/types';
 
-const DEFAULT_QUERY_OPTIONS: UseQueryOptions = {
+const DEFAULT_QUERY_OPTIONS = {
   placeholderData: [],
   retry: false,
   keepPreviousData: true,
   refetchOnWindowFocus: false,
 };
 
-type ResponseData = UseQueryResult<Supplier[]>;
-
 export interface SuppliersTreesParams extends BaseTreeSearchParams {
   withSourcingLocations?: boolean;
   locationTypes?: string[];
 }
 
-export function useSuppliers(params): ResponseData {
+export const useSuppliers = <T = Supplier[]>(
+  params,
+  options?: UseQueryOptions<Supplier[], unknown, T, ['suppliers', typeof params]>,
+) => {
   const query = useQuery(
     ['suppliers', params],
     () =>
@@ -34,30 +34,22 @@ export function useSuppliers(params): ResponseData {
         .then(({ data: responseData }) => responseData.data),
     {
       ...DEFAULT_QUERY_OPTIONS,
+      ...options,
     },
   );
 
-  const { data, isError } = query;
+  return query;
+};
 
-  return useMemo<ResponseData>(
-    () =>
-      ({
-        ...query,
-        data: (isError ? DEFAULT_QUERY_OPTIONS.placeholderData : data) as ResponseData,
-      } as ResponseData),
-    [query, isError, data],
-  );
-}
-
-export function useSuppliersTrees(
+export const useSuppliersTrees = <T = Supplier[]>(
   params: SuppliersTreesParams,
-  options: UseQueryOptions = {},
-): ResponseData {
+  options?: UseQueryOptions<Supplier[], unknown, T, ['suppliers-trees', typeof params]>,
+) => {
   const query = useQuery(
     ['suppliers-trees', params],
     () =>
       apiService
-        .request({
+        .request<{ data: Supplier[] }>({
           method: 'GET',
           url: '/suppliers/trees',
           params,
@@ -66,40 +58,25 @@ export function useSuppliersTrees(
     { ...DEFAULT_QUERY_OPTIONS, ...options },
   );
 
-  const { data, isError } = query;
+  return query;
+};
 
-  return useMemo<ResponseData>(
-    () =>
-      ({
-        ...query,
-        data: (isError ? DEFAULT_QUERY_OPTIONS.placeholderData : data) as ResponseData,
-      } as ResponseData),
-    [query, isError, data],
-  );
-}
-
-export function useSuppliersTypes(params: { type: 't1supplier' | 'producer' }): ResponseData {
+export const useSuppliersTypes = <T = Supplier[]>(
+  params: { type: 't1supplier' | 'producer' },
+  options?: UseQueryOptions<Supplier[], unknown, T, ['suppliers', typeof params]>,
+) => {
   const query = useQuery(
     ['suppliers', params],
     () =>
       apiService
-        .request({
+        .request<{ data: Supplier[] }>({
           method: 'GET',
           url: 'suppliers/types',
           params,
         })
         .then(({ data: responseData }) => responseData.data),
-    DEFAULT_QUERY_OPTIONS,
+    { ...DEFAULT_QUERY_OPTIONS, ...options },
   );
 
-  const { data, isError } = query;
-
-  return useMemo<ResponseData>(
-    () =>
-      ({
-        ...query,
-        data: (isError ? DEFAULT_QUERY_OPTIONS.placeholderData : data) as ResponseData,
-      } as ResponseData),
-    [query, isError, data],
-  );
-}
+  return query;
+};

--- a/client/src/types.d.ts
+++ b/client/src/types.d.ts
@@ -297,6 +297,8 @@ export type WithRequiredProperty<Type, Key extends keyof Type> = Type &
     [Property in Key]-?: Type[Property];
   };
 
+export type MakePropOptional<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
+
 export type Task = {
   id: string;
   type: string;


### PR DESCRIPTION
### General description

Intuitively, the solution to this is to unselect invalid filters when the scenario changes.

This turned out to be harder than expected, because the selectors fetch their own options.

The first (naive) solution I tried was to call the `onChange` callback on the selector component itself if one of the current values didn't match the available options. This didn't work because it only triggered when the selector was mounted. The data needs to be modified from the outside.

The only place that changes the scenario is the scenario selector. So I decided to add that logic there. I played around with react-query and couldn't find a way to subscribe to data WITHOUT specifying the parameters and query function. I wanted to do the equivalent of accessing a store but there's no way to do that (I have a `useQueryData` hook that uses some react-query internals that might do the trick in the oven).

In the end, I manually fetch the possible options for the filters from the parent 'More Filters' component and pass those options to each individual filter.

## Checklist before merging

- [x] Branch name / PR includes the related Jira ticket Id.
- [ ] Tests to check core implementation / bug fix added.
- [ ] All checks in Continuous Integration workflow pass.
- [ ] Feature functionally tested by reviewer(s).
- [ ] Code reviewed by reviewer(s).
- [x] Documentation updated (README, CHANGELOG...) (if required)
