### PR TITLE
Use last available year to fetch materials

### DIFF
--- a/client/src/containers/analysis-visualization/analysis-filters/years-range/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-filters/years-range/component.tsx
@@ -4,9 +4,7 @@ import { isFinite, toNumber, range } from 'lodash';
 import { useAppDispatch, useAppSelector } from 'store/hooks';
 import { analysisUI } from 'store/features/analysis/ui';
 import { analysisFilters, setFilters } from 'store/features/analysis/filters';
-
 import { useYears } from 'hooks/years';
-
 import YearsRangeFilter, { useYearsRange } from 'containers/filters/years-range';
 
 const YearsFilter: React.FC = () => {
@@ -16,7 +14,10 @@ const YearsFilter: React.FC = () => {
   const { visualizationMode } = useAppSelector(analysisUI);
   const filters = useAppSelector(analysisFilters);
   const { layer, materials, indicator } = filters;
-  const { data, isLoading } = useYears(layer, materials, indicator);
+
+  const materialIds = useMemo(() => materials.map((mat) => mat.value), [materials]);
+
+  const { data, isLoading } = useYears(layer, materialIds, indicator?.value);
 
   const { startYear, endYear, yearsGap, setYearsRange } = useYearsRange({
     years,

--- a/client/src/containers/analysis-visualization/analysis-filters/years/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-filters/years/component.tsx
@@ -1,19 +1,19 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { toNumber, range } from 'lodash';
 
 import { useAppDispatch, useAppSelector } from 'store/hooks';
 import { analysisFilters, setFilter, setFilters } from 'store/features/analysis/filters';
-
 import { useYears } from 'hooks/years';
+import Select from 'components/select';
 
 import type { SelectProps } from 'components/select';
-import Select from 'components/select';
-import { toNumber, range } from 'lodash';
 
 const YearsFilter: React.FC = () => {
   const dispatch = useAppDispatch();
   const filters = useAppSelector(analysisFilters);
   const { layer, materials, indicator, startYear } = filters;
-  const { data, isLoading } = useYears(layer, materials, indicator);
+  const materialsIds = useMemo(() => materials.map((mat) => mat.value), [materials]);
+  const { data, isLoading } = useYears(layer, materialsIds, indicator?.value);
 
   const [years, setYears] = useState(data);
 

--- a/client/src/containers/analysis-visualization/analysis-legend/settings/previewMap.tsx
+++ b/client/src/containers/analysis-visualization/analysis-legend/settings/previewMap.tsx
@@ -4,6 +4,7 @@ import { H3HexagonLayer } from '@deck.gl/geo-layers/typed';
 import Map from 'components/map';
 import { useH3Data } from 'hooks/h3-data';
 import PageLoading from 'containers/page-loading';
+import { useYears } from 'hooks/years';
 
 import type { Layer, Material } from 'types';
 
@@ -25,13 +26,21 @@ const INITIAL_PREVIEW_SETTINGS = {
 };
 
 const PreviewMap = ({ selectedLayerId, selectedMaterialId }: PreviewMapProps) => {
+  const { data: materialYear } = useYears('material', [selectedMaterialId], 'all', {
+    enabled: !!selectedMaterialId,
+    select: (data) => {
+      return data?.[data?.length - 1];
+    },
+  });
+
   const { data, isFetching } = useH3Data({
     id: selectedLayerId,
     params: {
       materialId: selectedMaterialId,
+      year: materialYear,
     },
     options: {
-      enabled: !!selectedLayerId,
+      enabled: !!selectedLayerId && (selectedLayerId !== 'material' || !!materialYear),
       select: (response) => response.data,
       keepPreviousData: true,
       staleTime: 10000,

--- a/client/src/hooks/h3-data/index.ts
+++ b/client/src/hooks/h3-data/index.ts
@@ -1,14 +1,15 @@
 import { useMemo } from 'react';
+
 import useH3MaterialData from './material';
 import useH3ImpactData from './impact';
 import useH3ContextualData from './contextual';
-
-import type { UseQueryOptions } from '@tanstack/react-query';
-import type { H3APIResponse } from 'types';
-import type { MaterialH3APIParams, ImpactH3APIParams, Layer } from 'types';
 import { storeToQueryParams } from './utils';
+
 import { useAppSelector } from 'store/hooks';
 import { analysisFilters, scenarios } from 'store/features/analysis';
+
+import type { UseQueryOptions } from '@tanstack/react-query';
+import type { H3APIResponse, MaterialH3APIParams, ImpactH3APIParams, Layer } from 'types';
 
 interface UseH3DataProps<T> {
   id: Layer['id'];
@@ -41,7 +42,7 @@ export const useH3Data = <T = H3APIResponse>({
     [currentScenario, filters, isComparisonEnabled, materialId, scenarioToCompare, year],
   );
 
-  const materialParams = useMemo(() => ({ materialId }), [materialId]);
+  const materialParams = useMemo(() => ({ materialId, year }), [materialId, year]);
   const materialOptions = useMemo(
     () => ({ ...options, enabled: enabled && isMaterial }),
     [enabled, isMaterial, options],

--- a/client/src/hooks/h3-data/material.ts
+++ b/client/src/hooks/h3-data/material.ts
@@ -1,13 +1,16 @@
-import type { UseQueryOptions } from '@tanstack/react-query';
 import { useQuery } from '@tanstack/react-query';
-import type { AxiosError } from 'axios';
 import { useCallback, useMemo } from 'react';
+
+import { DEFAULT_QUERY_OPTIONS, responseParser } from './utils';
+
 import { apiRawService } from 'services/api';
 import { analysisFilters } from 'store/features/analysis';
 import { useAppSelector } from 'store/hooks';
-import type { H3APIResponse, MaterialH3APIParams } from 'types';
 import { COLOR_RAMPS, useColors } from 'utils/colors';
-import { DEFAULT_QUERY_OPTIONS, responseParser } from './utils';
+
+import type { UseQueryOptions } from '@tanstack/react-query';
+import type { AxiosError } from 'axios';
+import type { H3APIResponse, MaterialH3APIParams } from 'types';
 
 const useH3MaterialData = <T = H3APIResponse>(
   params: Partial<MaterialH3APIParams> = {},
@@ -22,7 +25,6 @@ const useH3MaterialData = <T = H3APIResponse>(
       materialId,
       resolution: origins?.length ? 6 : 4,
       ...params,
-      year: 2010,
     }),
     [materialId, origins?.length, params],
   );

--- a/client/src/hooks/h3-data/material.ts
+++ b/client/src/hooks/h3-data/material.ts
@@ -7,6 +7,7 @@ import { apiRawService } from 'services/api';
 import { analysisFilters } from 'store/features/analysis';
 import { useAppSelector } from 'store/hooks';
 import { COLOR_RAMPS, useColors } from 'utils/colors';
+import { useYears } from 'hooks/years';
 
 import type { UseQueryOptions } from '@tanstack/react-query';
 import type { AxiosError } from 'axios';
@@ -20,13 +21,19 @@ const useH3MaterialData = <T = H3APIResponse>(
   const filters = useAppSelector(analysisFilters);
   const { materialId, origins } = filters;
 
+  const { data: year } = useYears('material', [materialId], 'all', {
+    enabled: !!materialId,
+    select: (years) => years?.[years?.length - 1],
+  });
+
   const urlParams = useMemo(
     () => ({
       materialId,
       resolution: origins?.length ? 6 : 4,
+      year,
       ...params,
     }),
-    [materialId, origins?.length, params],
+    [materialId, origins?.length, params, year],
   );
 
   const enabled = (options.enabled ?? true) && !!urlParams.year && !!urlParams.materialId;

--- a/client/src/hooks/years/index.ts
+++ b/client/src/hooks/years/index.ts
@@ -1,8 +1,10 @@
-import type { UseQueryOptions } from '@tanstack/react-query';
 import { useQuery } from '@tanstack/react-query';
 
 import { apiRawService } from 'services/api';
+
+import type { Indicator, Material } from 'types';
 import type { AnalysisState } from 'store/features/analysis';
+import type { UseQueryOptions } from '@tanstack/react-query';
 
 const DEFAULT_QUERY_OPTIONS = {
   placeholderData: [],
@@ -15,14 +17,14 @@ type YearsData = number[];
 
 export const useYears = <T = YearsData>(
   layer: AnalysisState['analysis/filters']['layer'],
-  materials: AnalysisState['analysis/filters']['materials'],
-  indicator: AnalysisState['analysis/filters']['indicator'],
+  materialIds: Material['id'][],
+  indicatorId: Indicator['id'],
   options: UseQueryOptions<YearsData, unknown, T> = {},
 ) => {
-  const enabled = (options.enabled ?? true) && !!indicator;
+  const enabled = (options.enabled ?? true) && !!indicatorId;
 
   const query = useQuery(
-    ['years', layer, materials, indicator],
+    ['years', layer, materialIds, indicatorId],
     () =>
       apiRawService
         .request<{ data: YearsData }>({
@@ -30,12 +32,8 @@ export const useYears = <T = YearsData>(
           url: '/h3/years',
           params: {
             layer,
-            ...(materials && materials.length
-              ? { materialIds: materials.map((material) => material.value) }
-              : {}),
-            ...(indicator && indicator.value && indicator.value !== 'all'
-              ? { indicatorId: indicator.value }
-              : {}),
+            materialIds,
+            indicatorId: indicatorId === 'all' ? undefined : indicatorId,
           },
         })
         .then((response) => response.data.data),

--- a/client/src/types.d.ts
+++ b/client/src/types.d.ts
@@ -36,7 +36,7 @@ export type CommonH3APIParams = {
   resolution: number;
 };
 
-export type MaterialH3APIParams = Omit<CommonH3APIParams, 'year'> & {
+export type MaterialH3APIParams = CommonH3APIParams & {
   materialId: string;
 };
 


### PR DESCRIPTION
### General description

The material data was assumed to come from MapSPAM, with the year for all materials being 2010. However, there are some materials whose dataset comes from EarthStat (dated 2000).

This PR fetches the available years for a material and uses that value to fetch them.

## Checklist before merging

- [ ] Branch name / PR includes the related Jira ticket Id.
- [ ] Tests to check core implementation / bug fix added.
- [ ] All checks in Continuous Integration workflow pass.
- [ ] Feature functionally tested by reviewer(s).
- [ ] Code reviewed by reviewer(s).
- [ ] Documentation updated (README, CHANGELOG...) (if required)
