### PR TITLE
Silent error on intervention creation

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Fixed
 
 - Fix changing scenario keeping filters not valid for selection [LANDGRIF-958](https://vizzuality.atlassian.net/browse/LANDGRIF-958)
+- Errors in intervention creation form not showing up [LANDGRIF-958](https://vizzuality.atlassian.net/browse/LANDGRIF-958)
 - Navigating to another page with some query params now correctly override the state [LANDGRIF-911](https://vizzuality.atlassian.net/browse/LANDGRIF-911)
 - Zoom controls not working [LANDGRIF-928](https://vizzuality.atlassian.net/browse/LANDGRIF-928)
 - Smart filters not being persisted between pages

--- a/client/src/components/alert/component.tsx
+++ b/client/src/components/alert/component.tsx
@@ -6,7 +6,7 @@ import type { ToasterProps } from 'react-hot-toast';
 
 export const ALERT_CLASSES = {
   success: {
-    iconColor: 'fill-green-600',
+    iconColor: 'fill-green-400',
     backgroundColor: 'bg-green-50',
     messagesColor: 'text-green-800',
   },

--- a/client/src/components/tree-select/component.tsx
+++ b/client/src/components/tree-select/component.tsx
@@ -284,6 +284,7 @@ const InnerTreeSelect = <IsMulti extends boolean>(
       <div className="inline-flex flex-row flex-grow h-min gap-x-1">
         <SearchIcon className="block w-4 h-4 my-auto text-gray-400" />
         <input
+          ref={ref}
           autoFocus
           type="search"
           value={searchTerm}
@@ -311,11 +312,19 @@ const InnerTreeSelect = <IsMulti extends boolean>(
       </div>
     );
     return Component;
-  }, [currentOptions.length, handleSearch, placeholder, resetSearch, searchTerm, selected, theme]);
+  }, [
+    currentOptions.length,
+    handleSearch,
+    placeholder,
+    ref,
+    resetSearch,
+    searchTerm,
+    selected,
+    theme,
+  ]);
 
   return (
     <div className="min-w-0 ">
-      <input ref={ref} className="hidden" />
       <div
         {...getReferenceProps({
           ref: reference,
@@ -479,7 +488,7 @@ const flattenKeys: (root: TreeSelectOption) => TreeSelectOption['value'][] = (ro
 
 const TreeSelect = React.forwardRef(InnerTreeSelect) as <IsMulti extends boolean = false>(
   props: TreeSelectProps<IsMulti> & {
-    ref?: Ref<HTMLDivElement>;
+    ref?: Ref<HTMLInputElement>;
   },
 ) => React.ReactElement;
 

--- a/client/src/containers/interventions/form/component.tsx
+++ b/client/src/containers/interventions/form/component.tsx
@@ -89,23 +89,23 @@ const schemaValidation = yup.object({
     otherwise: (schema) => schema.nullable(),
   }),
 
-  cityAddressCoordinates: yup
-    .string()
-    .test('is-coordinates', 'Coordinates should be valid (-90/90, -180/180)', (value) => {
-      if (!isCoordinates(value)) {
-        return false;
-      }
-      const [lat, lng] = value.split(',').map((coordinate) => parseFloat(coordinate));
-      return lat >= -90 && lat <= 90 && lng >= -180 && lng <= 180;
-    })
-    .when('newLocationType', {
-      is: (newLocationType) =>
-        [LocationTypes.aggregationPoint, LocationTypes.pointOfProduction].includes(
-          newLocationType?.value,
-        ),
-      then: (schema) => schema.required('Coordinates are required'),
-      otherwise: (schema) => schema.nullable(),
-    }),
+  cityAddressCoordinates: yup.string().when('newLocationType', {
+    is: (newLocationType) =>
+      [LocationTypes.aggregationPoint, LocationTypes.pointOfProduction].includes(
+        newLocationType?.value,
+      ),
+    then: (schema) =>
+      schema
+        .test('is-coordinates', 'Coordinates should be valid (-90/90, -180/180)', (value) => {
+          if (!isCoordinates(value)) {
+            return false;
+          }
+          const [lat, lng] = value.split(',').map((coordinate) => parseFloat(coordinate));
+          return lat >= -90 && lat <= 90 && lng >= -180 && lng <= 180;
+        })
+        .required('Coordinates are required'),
+    otherwise: (schema) => schema.nullable(),
+  }),
 
   // New material
   newMaterialId: yup

--- a/client/src/containers/interventions/form/component.tsx
+++ b/client/src/containers/interventions/form/component.tsx
@@ -141,7 +141,7 @@ const TYPES_OF_INTERVENTIONS = Object.values(InterventionTypes).map((interventio
   label: interventionType,
 }));
 
-type SubSchema = typeof schemaValidation['__outputType'];
+type SubSchema = yup.InferType<typeof schemaValidation>;
 
 const InterventionForm: React.FC<InterventionFormProps> = ({
   intervention,

--- a/client/src/containers/locations/select/component.tsx
+++ b/client/src/containers/locations/select/component.tsx
@@ -4,7 +4,7 @@ import { sortBy } from 'lodash';
 import TreeSelect from 'components/tree-select';
 import { useAdminRegionsTrees } from 'hooks/admin-regions';
 
-import type { Ref } from 'react';
+import type { Ref, ComponentRef } from 'react';
 import type { AdminRegionsTreesParams } from 'hooks/admin-regions';
 import type { TreeSelectOption, TreeSelectProps } from 'components/tree-select/types';
 
@@ -36,7 +36,7 @@ const InnerOriginRegionsFilter = <IsMulti extends boolean>(
     fitContent,
     ...props
   }: OriginRegionsFilterProps<IsMulti>,
-  ref: Ref<HTMLInputElement>,
+  ref: Ref<ComponentRef<typeof TreeSelect>>,
 ) => {
   const { data, isFetching } = useAdminRegionsTrees({
     depth,
@@ -99,7 +99,7 @@ const InnerOriginRegionsFilter = <IsMulti extends boolean>(
 };
 
 const OriginRegionsFilter = React.forwardRef(InnerOriginRegionsFilter) as <IsMulti extends boolean>(
-  props: OriginRegionsFilterProps<IsMulti> & { ref?: Ref<HTMLInputElement> },
+  props: OriginRegionsFilterProps<IsMulti> & { ref?: Ref<ComponentRef<typeof TreeSelect>> },
 ) => JSX.Element;
 
 export default OriginRegionsFilter;

--- a/client/src/containers/materials/select/component.tsx
+++ b/client/src/containers/materials/select/component.tsx
@@ -5,7 +5,7 @@ import { useMaterialsTrees } from 'hooks/materials';
 import TreeSelect from 'components/tree-select';
 
 import type { MaterialsTreesParams } from 'hooks/materials';
-import type { Ref } from 'react';
+import type { ComponentRef, Ref } from 'react';
 import type { TreeSelectProps } from 'components/tree-select/types';
 
 type MaterialsFilterProps<IsMulti extends boolean> = Omit<TreeSelectProps<IsMulti>, 'options'> & {
@@ -36,7 +36,7 @@ const InnerMaterialsFilter = <IsMulti extends boolean>(
     ellipsis,
     fitContent,
   }: MaterialsFilterProps<IsMulti>,
-  ref: Ref<HTMLInputElement>,
+  ref: Ref<ComponentRef<typeof TreeSelect>>,
 ) => {
   const { data, isFetching } = useMaterialsTrees(
     {
@@ -85,6 +85,6 @@ const InnerMaterialsFilter = <IsMulti extends boolean>(
 };
 
 const MaterialsFilter = React.forwardRef(InnerMaterialsFilter) as <IsMulti extends boolean>(
-  props: MaterialsFilterProps<IsMulti> & { ref?: Ref<HTMLInputElement> },
+  props: MaterialsFilterProps<IsMulti> & { ref?: Ref<ComponentRef<typeof TreeSelect>> },
 ) => React.ReactElement;
 export default MaterialsFilter;


### PR DESCRIPTION
### General description

This PR fixes errors not showing up when creating (and updating) interventions:
- Tree selects weren't focusable. If there's an error the user will be scrolled there now.
- An API call that returns multiple errors will correctly separate them by `.` (instead of joining them as-is)
- Due to yup implicit behaviour, some fields weren't detected as an error even if they were. Specifically, the fields that held a required option (label + value) were allowed even if they were not set. This is because yup obejcts are `{}` by default, and all fields optional. So a null or undefined object wouldn't fail. The solution was to set the inner object fields to required and adding a default undefined value. I shouldn't be that tricky, right? Or am I crazy?

### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

_Provide minimal instructions on how to test this PR._

- Apart from the added feature / bug fix, check overall performance, styling...

## Checklist before merging

- [x] Branch name / PR includes the related Jira ticket Id.
- [ ] Tests to check core implementation / bug fix added.
- [ ] All checks in Continuous Integration workflow pass.
- [ ] Feature functionally tested by reviewer(s).
- [ ] Code reviewed by reviewer(s).
- [x] Documentation updated (README, CHANGELOG...) (if required)
