### PR TITLE
Bugfix/landgrif 960 scenario impact chart

### DIFF
--- a/api/src/modules/impact/impact.controller.ts
+++ b/api/src/modules/impact/impact.controller.ts
@@ -111,6 +111,7 @@ export class ImpactController {
   })
   @UseInterceptors(SetScenarioIdsInterceptor)
   @JSONAPIPaginationQueryParams()
+  @UseInterceptors(SetScenarioIdsInterceptor)
   @Get('ranking')
   async getRankedImpactTable(
     @Query(ValidationPipe) rankedImpactTableDto: GetRankedImpactTableDto,

--- a/api/src/modules/impact/impact.service.ts
+++ b/api/src/modules/impact/impact.service.ts
@@ -439,10 +439,7 @@ export class ImpactService {
         this.populateValuesRecursively(entity, calculatedData, rangeOfYears);
       });
 
-      impactTable[indicatorValuesIndex].rows = skeleton.filter(
-        (item: ImpactTableRows) =>
-          item.children.length > 0 || item.values[0].value > 0,
-      );
+      impactTable[indicatorValuesIndex].rows = skeleton;
     });
     const purchasedTonnes: ImpactTablePurchasedTonnes[] =
       this.getTotalPurchasedVolumeByYear(rangeOfYears, dataForImpactTable);

--- a/api/test/e2e/impact/impact.spec.ts
+++ b/api/test/e2e/impact/impact.spec.ts
@@ -970,7 +970,7 @@ describe('Impact Table and Charts test suite (e2e)', () => {
         })
         .expect(HttpStatus.OK);
 
-      expect(response.body.data.impactTable[0].rows).toHaveLength(2);
+      expect(response.body.data.impactTable[0].rows).toHaveLength(4);
       expect(response.body.data.impactTable[0].rows).toEqual(
         expect.arrayContaining(groupByLocationTypeResponseData.rows),
       );


### PR DESCRIPTION
### General description

1. Add scenario Ids interceptor to /ranking endpoint - solves the bug of new materials/locations/suppliers created by intervention not being present in charts results
2. Remove discrimination of 0 values in the impact analysis result

### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

_Provide minimal instructions on how to test this PR._

- Apart from the added feature / bug fix, check overall performance, styling...

## Checklist before merging

- [ ] Branch name / PR includes the related Jira ticket Id.
- [ ] Tests to check core implementation / bug fix added.
- [ ] All checks in Continuous Integration workflow pass.
- [ ] Feature functionally tested by reviewer(s).
- [ ] Code reviewed by reviewer(s).
- [ ] Documentation updated (README, CHANGELOG...) (if required)
