### PR TITLE
Bigger table page sizes

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- Bigger table page size [LANDGRIF-922](https://vizzuality.atlassian.net/browse/LANDGRIF-922)
 - `ACTUAL_DATA` was removed and a null scenario id is used in it's place
 - Send `scenarioId` param alongside analysis filters [LANDGRIF-891](https://vizzuality.atlassian.net/browse/LANDGRIF-891)
 - Same input for city, address and coordinates for intervention form [LANDGRIF-821](https://vizzuality.atlassian.net/browse/LANDGRIF-821)

--- a/client/src/components/pagination/constants.ts
+++ b/client/src/components/pagination/constants.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_PAGE_SIZES = [50, 100, 200, 500];

--- a/client/src/components/pagination/pageSizeSelector.tsx
+++ b/client/src/components/pagination/pageSizeSelector.tsx
@@ -1,5 +1,7 @@
 import { useCallback, useMemo } from 'react';
 
+import { DEFAULT_PAGE_SIZES } from './constants';
+
 import Select from 'components/select';
 
 import type { SelectOption, SelectProps } from 'components/select';
@@ -12,7 +14,7 @@ interface PageSizeSelectorProps {
 
 const PageSizeSelector: React.FC<PageSizeSelectorProps> = ({
   onChange,
-  availableSizes,
+  availableSizes = DEFAULT_PAGE_SIZES,
   pageSize,
 }) => {
   const currentPageOption = useMemo<SelectOption<number>>(
@@ -20,7 +22,7 @@ const PageSizeSelector: React.FC<PageSizeSelectorProps> = ({
     [pageSize],
   );
   const sizeOptions = useMemo(
-    () => (availableSizes ?? [10, 20, 30]).map((size) => ({ label: `${size}`, value: size })),
+    () => availableSizes.map((size) => ({ label: `${size}`, value: size })),
     [availableSizes],
   );
 

--- a/client/src/components/select/component.tsx
+++ b/client/src/components/select/component.tsx
@@ -52,7 +52,7 @@ const getComponents = <
       <components.SelectContainer
         {...props}
         className={classNames(className, 'text-sm', {
-          'shadow-sm': theme == 'default',
+          'shadow-sm': theme === 'default',
         })}
       />
     ),
@@ -239,7 +239,7 @@ const InnerSelect = <OptionValue, IsMulti extends boolean = false>(
           <components.Menu
             className={classNames(
               className,
-              'static h-auto overflow-hidden border rounded-md shadow-md border-gray-50 min-w-[11rem]',
+              '!static h-auto overflow-hidden border rounded-md shadow-md border-gray-50 min-w-[11rem]',
             )}
             {...rest}
           />

--- a/client/src/components/table/component.tsx
+++ b/client/src/components/table/component.tsx
@@ -27,6 +27,7 @@ export interface TableProps<T>
     itemNumber: number;
     showSummary?: boolean;
     pageCount?: number;
+    pageSizes?: number[];
   };
 }
 
@@ -160,7 +161,11 @@ const Table = <T,>({
       <div className="flex flex-row">
         <div className="flex items-center space-x-2 basis-1/2">
           <span className="text-sm text-gray-500">Rows per page</span>
-          <PageSizeSelector onChange={onChangePageSize} pageSize={pagination.pageSize} />
+          <PageSizeSelector
+            availableSizes={pagination.pageSizes}
+            onChange={onChangePageSize}
+            pageSize={pagination.pageSize}
+          />
         </div>
 
         <div className="flex-1">

--- a/client/src/containers/analysis-visualization/analysis-table/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-table/component.tsx
@@ -17,6 +17,7 @@ import LinkButton from 'components/button';
 import Table from 'components/table/component';
 import LineChart from 'components/chart/line';
 import { NUMBER_FORMAT } from 'utils/number-format';
+import { DEFAULT_PAGE_SIZES } from 'components/pagination/constants';
 
 import type { PaginationState, SortingState } from '@tanstack/react-table';
 import type { TableProps } from 'components/table/component';
@@ -66,7 +67,7 @@ const dataToCsv = <Mode extends ComparisonMode>(tableData: AnalysisTableProps<Mo
 const AnalysisTable = () => {
   const [paginationState, setPaginationState] = useState<PaginationState>({
     pageIndex: 1,
-    pageSize: 10,
+    pageSize: DEFAULT_PAGE_SIZES[0],
   });
   const [sortingState, setSortingState] = useState<SortingState>([]);
   const tableState = useMemo(

--- a/client/src/hooks/tasks/index.ts
+++ b/client/src/hooks/tasks/index.ts
@@ -3,7 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import { apiService } from 'services/api';
 
 import type { UseQueryResult, UseQueryOptions } from '@tanstack/react-query';
-import type { APIMetadataPagination, Task } from 'types';
+import type { APIMetadataPagination, ErrorResponse, Task } from 'types';
 import type { LocationTypes } from 'containers/interventions/enums';
 
 type TaskAPIResponse = Task;
@@ -28,15 +28,15 @@ export type LocationType = {
     | LocationTypes.unknown;
 };
 
-export function useTasks(
+export const useTasks = <T = TasksAPIResponse>(
   params: Record<string, string | number | boolean> = {},
-  options: UseQueryOptions<TasksAPIResponse> = {},
-): UseQueryResult<TasksAPIResponse> {
-  const query = useQuery<TasksAPIResponse>(
-    ['tasks'],
+  options: UseQueryOptions<TasksAPIResponse, ErrorResponse, T, ['tasks', typeof params]> = {},
+) => {
+  const query = useQuery(
+    ['tasks', params],
     () =>
       apiService
-        .request({
+        .request<{ data: TasksAPIResponse }>({
           method: 'GET',
           url: '/tasks',
           params,
@@ -49,7 +49,7 @@ export function useTasks(
   );
 
   return query;
-}
+};
 
 export function useTask(
   id: Task['id'],

--- a/client/src/pages/data/constants.ts
+++ b/client/src/pages/data/constants.ts
@@ -1,1 +1,0 @@
-export const PAGE_SIZES = [50, 100, 200, 500];

--- a/client/src/pages/data/constants.ts
+++ b/client/src/pages/data/constants.ts
@@ -1,0 +1,1 @@
+export const PAGE_SIZES = [50, 100, 200, 500];

--- a/client/src/pages/data/index.tsx
+++ b/client/src/pages/data/index.tsx
@@ -6,8 +6,6 @@ import { useDebounce } from '@react-hook/debounce';
 import { format } from 'date-fns';
 import toast from 'react-hot-toast';
 
-import { PAGE_SIZES } from './constants';
-
 import useModal from 'hooks/modals';
 import { useSourcingLocations, useSourcingLocationsMaterials } from 'hooks/sourcing-locations';
 import { useTasks } from 'hooks/tasks';
@@ -21,6 +19,7 @@ import Search from 'components/search';
 import Modal from 'components/modal';
 import Table from 'components/table';
 import Loading from 'components/loading';
+import { DEFAULT_PAGE_SIZES } from 'components/pagination/constants';
 
 import type { PaginationState, SortingState } from '@tanstack/react-table';
 import type { ColumnDefinition } from 'components/table/column';
@@ -29,7 +28,7 @@ import type { SourcingLocation, Task } from 'types';
 const AdminDataPage: React.FC = () => {
   const [searchText, setSearchText] = useDebounce<string>('', 250);
   const [pagination, setPagination] = useState<PaginationState>({
-    pageSize: PAGE_SIZES[0],
+    pageSize: DEFAULT_PAGE_SIZES[0],
     pageIndex: 1,
   });
   const [sorting, setSorting] = useState<SortingState>([]);
@@ -268,7 +267,6 @@ const AdminDataPage: React.FC = () => {
                 sorting,
               }}
               paginationProps={{
-                pageSizes: PAGE_SIZES,
                 itemNumber: data.length,
                 totalItems: sourcingMetadata.totalItems,
                 pageCount: sourcingMetadata.totalPages,

--- a/client/src/pages/data/index.tsx
+++ b/client/src/pages/data/index.tsx
@@ -6,6 +6,8 @@ import { useDebounce } from '@react-hook/debounce';
 import { format } from 'date-fns';
 import toast from 'react-hot-toast';
 
+import { PAGE_SIZES } from './constants';
+
 import useModal from 'hooks/modals';
 import { useSourcingLocations, useSourcingLocationsMaterials } from 'hooks/sourcing-locations';
 import { useTasks } from 'hooks/tasks';
@@ -27,7 +29,7 @@ import type { SourcingLocation, Task } from 'types';
 const AdminDataPage: React.FC = () => {
   const [searchText, setSearchText] = useDebounce<string>('', 250);
   const [pagination, setPagination] = useState<PaginationState>({
-    pageSize: 10,
+    pageSize: PAGE_SIZES[0],
     pageIndex: 1,
   });
   const [sorting, setSorting] = useState<SortingState>([]);
@@ -266,6 +268,7 @@ const AdminDataPage: React.FC = () => {
                 sorting,
               }}
               paginationProps={{
+                pageSizes: PAGE_SIZES,
                 itemNumber: data.length,
                 totalItems: sourcingMetadata.totalItems,
                 pageCount: sourcingMetadata.totalPages,

--- a/client/src/pages/data/users.tsx
+++ b/client/src/pages/data/users.tsx
@@ -8,6 +8,7 @@ import AdminLayout from 'layouts/data';
 import Button from 'components/button';
 import Search from 'components/search';
 import Table from 'components/table';
+import { DEFAULT_PAGE_SIZES } from 'components/pagination/constants';
 
 import type { TableProps } from 'components/table/component';
 import type { PaginationState } from '@tanstack/react-table';
@@ -16,7 +17,7 @@ import type { User } from 'types';
 const AdminUsersPage: React.FC = () => {
   const [paginationState, setPaginationState] = useState<PaginationState>({
     pageIndex: 1,
-    pageSize: 10,
+    pageSize: DEFAULT_PAGE_SIZES[0],
   });
   const { data, isLoading } = useUsers({
     'page[size]': paginationState.pageSize,


### PR DESCRIPTION
### General description

This PR makes the table page size selector have default values of 50, 100, 200 and 500.

It also allows to override this values via prop.

During the development, I saw that the select was clipping out of the screen, so I added a fix that forced the floating element to have the size of the menu.

## Checklist before merging

- [x] Branch name / PR includes the related Jira ticket Id.
- [ ] Tests to check core implementation / bug fix added.
- [ ] All checks in Continuous Integration workflow pass.
- [ ] Feature functionally tested by reviewer(s).
- [ ] Code reviewed by reviewer(s).
- [x] Documentation updated (README, CHANGELOG...) (if required)
