### PR TITLE
Add original production value to cancelled impacts

### DIFF
--- a/api/src/modules/scenario-interventions/scenario-interventions.service.ts
+++ b/api/src/modules/scenario-interventions/scenario-interventions.service.ts
@@ -276,6 +276,7 @@ export class ScenarioInterventionsService extends AppBaseService<
             indicatorRecords: elem.indicatorRecords.map(
               (impact: IndicatorRecord) => ({
                 value: impact.value,
+                scaler: impact.scaler,
                 indicatorId: impact.indicatorId,
                 materialH3DataId: impact.materialH3DataId,
               }),

--- a/api/src/modules/sourcing-locations/sourcing-locations.service.ts
+++ b/api/src/modules/sourcing-locations/sourcing-locations.service.ts
@@ -138,6 +138,7 @@ export class SourcingLocationsService extends AppBaseService<
           'sr.year',
           'sr.tonnage',
           'ir.value',
+          'ir.scaler',
           'ir.indicatorId',
           'ir.materialH3DataId',
         ])


### PR DESCRIPTION
### General description

This PR fixes not adding the scaler (production) value to cancelled impacts, therefore resulting the map comparison equaling 0

NOTE:
We didn't realise this because the preconditions created to test this feature are setting the scaler value, we should try to locally test (at least critical implementation)

### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

Create an intervention. The impact related to the cancelled sourcing locations for that intervention should have a scaler value (equaling the value of the original impact)

- Apart from the added feature / bug fix, check overall performance, styling...

## Checklist before merging

- [x] Branch name / PR includes the related Jira ticket Id.
- [x] Tests to check core implementation / bug fix added.
- [x] All checks in Continuous Integration workflow pass.
- [ ] Feature functionally tested by reviewer(s).
- [ ] Code reviewed by reviewer(s).
- [ ] Documentation updated (README, CHANGELOG...) (if required)
