### PR TITLE
Bugfix/landgrif 975 scenario chart negative values

### DIFF
--- a/api/src/modules/impact/impact.service.ts
+++ b/api/src/modules/impact/impact.service.ts
@@ -136,6 +136,23 @@ export class ImpactService {
     const dataForImpactTable: ImpactTableData[] =
       await this.getDataForImpactTable(rankedImpactTableDto, entities);
 
+    if (rankedImpactTableDto.scenarioId) {
+      const dataForImpactTableWithScenario: ImpactTableData[] =
+        ImpactService.processImpactDataWithScenario(dataForImpactTable);
+
+      const impactTableWithScenario: ImpactTable = this.buildImpactTable(
+        rankedImpactTableDto,
+        indicators,
+        dataForImpactTableWithScenario,
+        this.buildImpactTableRowsSkeleton(entities),
+      );
+
+      return await this.applyRankingProcessing(
+        rankedImpactTableDto,
+        impactTableWithScenario,
+      );
+    }
+
     const impactTable: ImpactTable = this.buildImpactTable(
       rankedImpactTableDto,
       indicators,

--- a/api/test/e2e/impact/chart.spec.ts
+++ b/api/test/e2e/impact/chart.spec.ts
@@ -43,6 +43,7 @@ import {
 import { range } from 'lodash';
 import { createNewMaterialInterventionPreconditions } from './actual-vs-scenario-preconditions/new-material-intervention.preconditions';
 import { Scenario } from '../../../src/modules/scenarios/scenario.entity';
+import { rankingTableWithScenario } from './response-mocks.impact';
 
 describe('Impact Chart (Ranking) Test Suite (e2e)', () => {
   let app: INestApplication;
@@ -481,11 +482,13 @@ describe('Impact Chart (Ranking) Test Suite (e2e)', () => {
         expect(
           response.body.impactTable[0].rows[0].values.some(
             (value: ImpactTableRowsValues) =>
-              value.value === -1050 &&
-              !value.isProjected &&
-              value.year === 2020,
+              value.value === 1650 && !value.isProjected && value.year === 2020,
           ),
         ).toBeTruthy();
+
+        expect(response.body.impactTable[0].rows).toEqual(
+          rankingTableWithScenario.impactTable[0].rows,
+        );
       },
     );
   });

--- a/api/test/e2e/impact/response-mocks.impact.ts
+++ b/api/test/e2e/impact/response-mocks.impact.ts
@@ -621,3 +621,185 @@ export const impactTableWithScenario = {
   ],
   purchasedTonnes: [],
 };
+
+export const rankingTableWithScenario = {
+  impactTable: [
+    {
+      indicatorShortName: null,
+      indicatorId: '1b111521-5904-4e09-a7b1-7beeef3e0d2f',
+      groupBy: 'material',
+      rows: [
+        {
+          name: 'Textile',
+          children: [
+            {
+              name: 'Cotton',
+              children: [],
+              values: [
+                {
+                  year: 2019,
+                  value: 0,
+                  isProjected: true,
+                },
+                {
+                  year: 2020,
+                  value: 400,
+                  isProjected: false,
+                },
+                {
+                  year: 2021,
+                  value: 406,
+                  isProjected: true,
+                },
+                {
+                  year: 2022,
+                  value: 412.09,
+                  isProjected: true,
+                },
+              ],
+            },
+            {
+              name: 'Linen',
+              children: [],
+              values: [
+                {
+                  year: 2019,
+                  value: 0,
+                  isProjected: true,
+                },
+                {
+                  year: 2020,
+                  value: 750,
+                  isProjected: false,
+                },
+                {
+                  year: 2021,
+                  value: 761.25,
+                  isProjected: true,
+                },
+                {
+                  year: 2022,
+                  value: 772.66875,
+                  isProjected: true,
+                },
+              ],
+            },
+            {
+              name: 'Wool',
+              children: [],
+              values: [
+                {
+                  year: 2019,
+                  value: 0,
+                  isProjected: true,
+                },
+                {
+                  year: 2020,
+                  value: 500,
+                  isProjected: false,
+                },
+                {
+                  year: 2021,
+                  value: 507.5,
+                  isProjected: true,
+                },
+                {
+                  year: 2022,
+                  value: 515.1125,
+                  isProjected: true,
+                },
+              ],
+            },
+          ],
+          values: [
+            {
+              year: 2019,
+              value: 0,
+              isProjected: true,
+            },
+            {
+              year: 2020,
+              value: 1650,
+              isProjected: false,
+            },
+            {
+              year: 2021,
+              value: 1674.75,
+              isProjected: true,
+            },
+            {
+              year: 2022,
+              value: 1699.87125,
+              isProjected: true,
+            },
+          ],
+        },
+      ],
+      yearSum: [
+        {
+          year: 2019,
+          value: 0,
+        },
+        {
+          year: 2020,
+          value: 1650,
+        },
+        {
+          year: 2021,
+          value: 1674.75,
+        },
+        {
+          year: 2022,
+          value: 1699.87125,
+        },
+      ],
+      metadata: {
+        unit: 'm3/year',
+      },
+      others: {
+        aggregatedValues: [
+          {
+            year: 2019,
+            value: 0,
+          },
+          {
+            year: 2020,
+            value: 0,
+          },
+          {
+            year: 2021,
+            value: 0,
+          },
+          {
+            year: 2022,
+            value: 0,
+          },
+        ],
+        numberOfAggregatedEntities: 0,
+        sort: 'DES',
+      },
+    },
+  ],
+  purchasedTonnes: [
+    {
+      year: 2019,
+      value: 0,
+      isProjected: true,
+    },
+    {
+      year: 2020,
+      value: 3007.68,
+      isProjected: false,
+    },
+    {
+      year: 2021,
+      value: 3052.7952,
+      isProjected: true,
+    },
+    {
+      year: 2022,
+      value: 3098.587128,
+      isProjected: true,
+    },
+  ],
+};


### PR DESCRIPTION
### General description

Currently the ranking impact table with scenario (chart) does not have a data processing that calculates scenario impact as 'actual impact - canceled impact + new intervention impact', result only have canceled negative values.

This PR adds this data processing to ranking endpoint and updates the test accordingly with full expected result.

### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

_Provide minimal instructions on how to test this PR._

- Apart from the added feature / bug fix, check overall performance, styling...

## Checklist before merging

- [ ] Branch name / PR includes the related Jira ticket Id.
- [ ] Tests to check core implementation / bug fix added.
- [ ] All checks in Continuous Integration workflow pass.
- [ ] Feature functionally tested by reviewer(s).
- [ ] Code reviewed by reviewer(s).
- [ ] Documentation updated (README, CHANGELOG...) (if required)
