### PR TITLE
Map comparison mode selector

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- Comparison mode toggle for impact table H3 data [LANDGRIF-941](https://vizzuality.atlassian.net/browse/LANDGRIF-941)
 - Readded material layer to the map as a contextual layer [LANDGRIF-827](https://vizzuality.atlassian.net/browse/LANDGRIF-827)
 - Add map preview to legend settings modal [LANDGRIF-827](https://vizzuality.atlassian.net/browse/LANDGRIF-827)
 - In chart view, when a comparison is enabled the chart changes to line chart [LANDGRIF-807](https://vizzuality.atlassian.net/browse/LANDGRIF-807)

--- a/client/src/components/badge/component.tsx
+++ b/client/src/components/badge/component.tsx
@@ -1,5 +1,8 @@
+import { XIcon } from '@heroicons/react/solid';
 import classNames from 'classnames';
 import { useCallback } from 'react';
+
+import { THEME_CLASSNAMES } from './constants';
 
 import type { BadgeProps } from './types';
 
@@ -20,39 +23,27 @@ const Badge: React.FC<BadgeProps> = ({
     [data, onClick],
   );
 
-  const THEMES = {
-    default: {
-      wrapper: 'bg-green-50 rounded-xl',
-    },
-  };
-
   return (
     <span
       className={classNames(
-        'inline-flex items-center font-medium text-green-700 overflow-hidden shadow-sm px-2',
-        THEMES[theme]?.wrapper,
-        removable ? 'pr-1' : 'py-0',
+        'inline-flex items-center overflow-hidden shadow-sm px-2 py-px gap-x-0.5',
+        THEME_CLASSNAMES[theme]?.wrapper,
+        removable && 'pr-1',
         className,
       )}
     >
-      <span
-        className={classNames(
-          'truncate text-ellipsis text-green-700',
-          removable ? 'pr-0.5' : 'px-0.5',
-        )}
-      >
-        {children}
-      </span>
+      <span>{children}</span>
       {removable && (
         <button
           type="button"
-          className="flex-shrink-0 ml-0.5 h-4 w-4 rounded-full inline-flex items-center justify-center text-gray-900 hover:bg-green-200 hover:text-green-500 focus:outline-none focus:bg-green-500 focus:text-white"
+          className={classNames(
+            THEME_CLASSNAMES[theme].closeIcon,
+            'flex-shrink-0 h-4 w-4 rounded-full inline-flex items-center justify-center focus:outline-none',
+          )}
           onClick={handleClick}
+          aria-label="Remove"
         >
-          <span className="sr-only">Remove</span>
-          <svg className="h-2 w-2" stroke="currentColor" fill="none" viewBox="0 0 8 8">
-            <path strokeLinecap="round" strokeWidth="1.5" d="M1 1l6 6m0-6L1 7" />
-          </svg>
+          <XIcon className="h-3 w-3" />
         </button>
       )}
     </span>

--- a/client/src/components/badge/constants.ts
+++ b/client/src/components/badge/constants.ts
@@ -1,0 +1,6 @@
+export const THEME_CLASSNAMES = {
+  default: {
+    wrapper: 'bg-navy-50 border border-navy-200 rounded-md text-gray-900 text-xs',
+    closeIcon: 'hover:text-white hover:bg-navy-600 hover:ring-navy-200',
+  },
+};

--- a/client/src/components/badge/types.d.ts
+++ b/client/src/components/badge/types.d.ts
@@ -1,8 +1,10 @@
+import type { THEMES } from './constants';
+
 export type BadgeProps = {
   data?: unknown;
   children?: React.ReactNode;
   className?: string;
   removable?: boolean;
   onClick?: (data: BadgeProps['data']) => void;
-  theme?: string;
+  theme?: keyof typeof THEMES;
 };

--- a/client/src/components/legend/item/comparisonModeToggle.tsx
+++ b/client/src/components/legend/item/comparisonModeToggle.tsx
@@ -36,7 +36,7 @@ export const ComparisonToggle = () => {
         absolute
       </button>
       <button
-        type="submit"
+        type="button"
         className={classNames(
           COMMON_MODE_BUTTON_CLASSNAMES,
           'rounded-r-md',

--- a/client/src/components/legend/item/comparisonModeToggle.tsx
+++ b/client/src/components/legend/item/comparisonModeToggle.tsx
@@ -1,22 +1,22 @@
 import classNames from 'classnames';
 import { useCallback } from 'react';
 
-import type { Dispatch } from 'react';
-import type { ScenarioComparisonMode } from 'store/features/analysis/scenarios';
+import { scenarios, setComparisonMode } from 'store/features/analysis';
+import { useAppDispatch, useAppSelector } from 'store/hooks';
 
-interface ComaprisonToggleProps {
-  comparisonMode: ScenarioComparisonMode;
-  onChange: Dispatch<ScenarioComparisonMode>;
-}
+import type { ScenarioComparisonMode } from 'store/features/analysis/scenarios';
 
 const COMMON_MODE_BUTTON_CLASSNAMES = 'border px-1 p-0.5';
 const ACTIVE_BUTTON_CLASSNAMES = 'text-navy-400 border-navy-400 bg-navy-50';
 const DISABLED_BUTTON_CLASSNAMES = 'text-gray-400 border-gray-400';
 
-export const ComparisonToggle = ({ comparisonMode, onChange }: ComaprisonToggleProps) => {
+export const ComparisonToggle = () => {
+  const dispatch = useAppDispatch();
+  const { comparisonMode } = useAppSelector(scenarios);
+
   const getHandleChangeComparison = useCallback(
-    (mode: ScenarioComparisonMode) => () => onChange?.(mode),
-    [onChange],
+    (mode: ScenarioComparisonMode) => () => dispatch(setComparisonMode(mode)),
+    [dispatch],
   );
 
   return (

--- a/client/src/components/legend/item/comparisonModeToggle.tsx
+++ b/client/src/components/legend/item/comparisonModeToggle.tsx
@@ -1,0 +1,54 @@
+import classNames from 'classnames';
+import { useCallback } from 'react';
+
+import type { Dispatch } from 'react';
+import type { ScenarioComparisonMode } from 'store/features/analysis/scenarios';
+
+interface ComaprisonToggleProps {
+  comparisonMode: ScenarioComparisonMode;
+  onChange: Dispatch<ScenarioComparisonMode>;
+}
+
+const COMMON_MODE_BUTTON_CLASSNAMES = 'border px-1 p-0.5';
+const ACTIVE_BUTTON_CLASSNAMES = 'text-navy-400 border-navy-400 bg-navy-50';
+const DISABLED_BUTTON_CLASSNAMES = 'text-gray-400 border-gray-400';
+
+export const ComparisonToggle = ({ comparisonMode, onChange }: ComaprisonToggleProps) => {
+  const getHandleChangeComparison = useCallback(
+    (mode: ScenarioComparisonMode) => () => onChange?.(mode),
+    [onChange],
+  );
+
+  return (
+    <div className="flex flex-row text-sm w-fit">
+      <button
+        className={classNames(
+          COMMON_MODE_BUTTON_CLASSNAMES,
+          'rounded-l-md',
+          comparisonMode === 'absolute' ? ACTIVE_BUTTON_CLASSNAMES : DISABLED_BUTTON_CLASSNAMES,
+          {
+            'border-r-0': comparisonMode !== 'absolute',
+          },
+        )}
+        type="button"
+        onClick={getHandleChangeComparison('absolute')}
+      >
+        absolute
+      </button>
+      <button
+        type="submit"
+        className={classNames(
+          COMMON_MODE_BUTTON_CLASSNAMES,
+          'rounded-r-md',
+          comparisonMode === 'relative' ? ACTIVE_BUTTON_CLASSNAMES : DISABLED_BUTTON_CLASSNAMES,
+          {
+            'border-l-0': comparisonMode !== 'relative',
+          },
+        )}
+        onClick={getHandleChangeComparison('relative')}
+      >
+        relative
+      </button>
+    </div>
+  );
+};

--- a/client/src/components/legend/item/component.tsx
+++ b/client/src/components/legend/item/component.tsx
@@ -70,12 +70,16 @@ export const LegendItem = ({
             )}
           </div>
         )}
-        {showComparisonModeToggle && isComparisonEnabled && <ComparisonToggle />}
-        {!isLoading && children && (
-          <div className="flex flex-row gap-2 text-gray-500">
-            <div className="flex-grow min-w-0">{children}</div>
-            <div className="-mt-0.5 w-8 text-2xs">{unit && <>({unit})</>}</div>
-          </div>
+        {!isLoading && (
+          <>
+            {showComparisonModeToggle && isComparisonEnabled && <ComparisonToggle />}
+            {children && (
+              <div className="flex flex-row gap-2 text-gray-500">
+                <div className="flex-grow min-w-0">{children}</div>
+                <div className="-mt-0.5 w-8 text-2xs">{unit && <>({unit})</>}</div>
+              </div>
+            )}
+          </>
         )}
       </div>
     </div>

--- a/client/src/components/legend/item/component.tsx
+++ b/client/src/components/legend/item/component.tsx
@@ -6,9 +6,10 @@ import { ComparisonToggle } from './comparisonModeToggle';
 
 import InfoToolTip from 'components/info-tooltip/component';
 import Loading from 'components/loading';
+import { useAppSelector } from 'store/hooks';
+import { scenarios } from 'store/features/analysis';
 
 import type { Dispatch } from 'react';
-import type { ScenarioComparisonMode } from 'store/features/analysis/scenarios';
 
 export type LegendItemProps = {
   name: React.ReactNode;
@@ -22,8 +23,7 @@ export type LegendItemProps = {
   opacity: number;
   onChangeOpacity: Dispatch<number>;
   main?: boolean;
-  comparison?: ScenarioComparisonMode;
-  onChangeComparisonMode?: Dispatch<ScenarioComparisonMode>;
+  showComparisonModeToggle?: boolean;
 };
 
 export const LegendItem = ({
@@ -34,11 +34,12 @@ export const LegendItem = ({
   showToolbar = true,
   children,
   opacity,
-  comparison,
   onChangeOpacity,
-  onChangeComparisonMode,
   main = false,
+  showComparisonModeToggle = false,
 }: LegendItemProps) => {
+  const { isComparisonEnabled } = useAppSelector(scenarios);
+
   return (
     <div
       className={classNames('flex flex-row gap-1 relative group py-3 pl-1 pr-2', {
@@ -69,9 +70,7 @@ export const LegendItem = ({
             )}
           </div>
         )}
-        {comparison && (
-          <ComparisonToggle comparisonMode={comparison} onChange={onChangeComparisonMode} />
-        )}
+        {showComparisonModeToggle && isComparisonEnabled && <ComparisonToggle />}
         {!isLoading && children && (
           <div className="flex flex-row gap-2 text-gray-500">
             <div className="flex-grow min-w-0">{children}</div>

--- a/client/src/components/legend/item/component.tsx
+++ b/client/src/components/legend/item/component.tsx
@@ -25,6 +25,9 @@ export type LegendItemProps = {
   main?: boolean;
   comparison?: ScenarioComparisonMode;
 };
+const COMMON_MODE_BUTTON_CLASSNAMES = 'border px-1 p-0.5';
+const ACTIVE_BUTTON_CLASSNAMES = 'text-navy-400 border-navy-400 bg-navy-50';
+const DISABLED_BUTTON_CLASSNAMES = 'text-gray-400 border-gray-400';
 
 export const LegendItem = ({
   name,
@@ -75,11 +78,33 @@ export const LegendItem = ({
           </div>
         )}
         {comparison && (
-          <div className="flex flex-row text-xs">
-            <button type="button" onClick={handleChangeComparison('absolute')}>
+          <div className="flex flex-row text-sm w-fit">
+            <button
+              className={classNames(
+                COMMON_MODE_BUTTON_CLASSNAMES,
+                'rounded-l-md',
+                comparison === 'absolute' ? ACTIVE_BUTTON_CLASSNAMES : DISABLED_BUTTON_CLASSNAMES,
+                {
+                  'border-r-0': comparison !== 'absolute',
+                },
+              )}
+              type="button"
+              onClick={handleChangeComparison('absolute')}
+            >
               absolute
             </button>
-            <button type="submit" onClick={handleChangeComparison('relative')}>
+            <button
+              type="submit"
+              className={classNames(
+                COMMON_MODE_BUTTON_CLASSNAMES,
+                'rounded-r-md',
+                comparison === 'relative' ? ACTIVE_BUTTON_CLASSNAMES : DISABLED_BUTTON_CLASSNAMES,
+                {
+                  'border-l-0': comparison !== 'relative',
+                },
+              )}
+              onClick={handleChangeComparison('relative')}
+            >
               relative
             </button>
           </div>

--- a/client/src/components/legend/item/component.tsx
+++ b/client/src/components/legend/item/component.tsx
@@ -1,8 +1,8 @@
 import classNames from 'classnames';
-import { useCallback } from 'react';
 
 import OpacityControl from './opacityControl';
 import DragHandle from './dragHandle';
+import { ComparisonToggle } from './comparisonModeToggle';
 
 import InfoToolTip from 'components/info-tooltip/component';
 import Loading from 'components/loading';
@@ -21,13 +21,10 @@ export type LegendItemProps = {
   children?: React.ReactNode;
   opacity: number;
   onChangeOpacity: Dispatch<number>;
-  onChangeComparisonMode?: Dispatch<ScenarioComparisonMode>;
   main?: boolean;
   comparison?: ScenarioComparisonMode;
+  onChangeComparisonMode?: Dispatch<ScenarioComparisonMode>;
 };
-const COMMON_MODE_BUTTON_CLASSNAMES = 'border px-1 p-0.5';
-const ACTIVE_BUTTON_CLASSNAMES = 'text-navy-400 border-navy-400 bg-navy-50';
-const DISABLED_BUTTON_CLASSNAMES = 'text-gray-400 border-gray-400';
 
 export const LegendItem = ({
   name,
@@ -42,11 +39,6 @@ export const LegendItem = ({
   onChangeComparisonMode,
   main = false,
 }: LegendItemProps) => {
-  const handleChangeComparison = useCallback(
-    (mode: ScenarioComparisonMode) => () => onChangeComparisonMode?.(mode),
-    [onChangeComparisonMode],
-  );
-
   return (
     <div
       className={classNames('flex flex-row gap-1 relative group py-3 pl-1 pr-2', {
@@ -78,36 +70,7 @@ export const LegendItem = ({
           </div>
         )}
         {comparison && (
-          <div className="flex flex-row text-sm w-fit">
-            <button
-              className={classNames(
-                COMMON_MODE_BUTTON_CLASSNAMES,
-                'rounded-l-md',
-                comparison === 'absolute' ? ACTIVE_BUTTON_CLASSNAMES : DISABLED_BUTTON_CLASSNAMES,
-                {
-                  'border-r-0': comparison !== 'absolute',
-                },
-              )}
-              type="button"
-              onClick={handleChangeComparison('absolute')}
-            >
-              absolute
-            </button>
-            <button
-              type="submit"
-              className={classNames(
-                COMMON_MODE_BUTTON_CLASSNAMES,
-                'rounded-r-md',
-                comparison === 'relative' ? ACTIVE_BUTTON_CLASSNAMES : DISABLED_BUTTON_CLASSNAMES,
-                {
-                  'border-l-0': comparison !== 'relative',
-                },
-              )}
-              onClick={handleChangeComparison('relative')}
-            >
-              relative
-            </button>
-          </div>
+          <ComparisonToggle comparisonMode={comparison} onChange={onChangeComparisonMode} />
         )}
         {!isLoading && children && (
           <div className="flex flex-row gap-2 text-gray-500">

--- a/client/src/components/legend/item/component.tsx
+++ b/client/src/components/legend/item/component.tsx
@@ -1,4 +1,5 @@
 import classNames from 'classnames';
+import { useCallback } from 'react';
 
 import OpacityControl from './opacityControl';
 import DragHandle from './dragHandle';
@@ -6,8 +7,11 @@ import DragHandle from './dragHandle';
 import InfoToolTip from 'components/info-tooltip/component';
 import Loading from 'components/loading';
 
+import type { Dispatch } from 'react';
+import type { ScenarioComparisonMode } from 'store/features/analysis/scenarios';
+
 export type LegendItemProps = {
-  name: string | JSX.Element;
+  name: React.ReactNode;
   info?: string;
   unit?: string;
   id: string;
@@ -16,8 +20,10 @@ export type LegendItemProps = {
   showToolbar?: boolean;
   children?: React.ReactNode;
   opacity: number;
-  onChangeOpacity: (opacity: number) => void;
+  onChangeOpacity: Dispatch<number>;
+  onChangeComparisonMode?: Dispatch<ScenarioComparisonMode>;
   main?: boolean;
+  comparison?: ScenarioComparisonMode;
 };
 
 export const LegendItem = ({
@@ -28,9 +34,16 @@ export const LegendItem = ({
   showToolbar = true,
   children,
   opacity,
+  comparison,
   onChangeOpacity,
+  onChangeComparisonMode,
   main = false,
 }: LegendItemProps) => {
+  const handleChangeComparison = useCallback(
+    (mode: ScenarioComparisonMode) => () => onChangeComparisonMode?.(mode),
+    [onChangeComparisonMode],
+  );
+
   return (
     <div
       className={classNames('flex flex-row gap-1 relative group py-3 pl-1 pr-2', {
@@ -59,6 +72,16 @@ export const LegendItem = ({
                 </div>
               </div>
             )}
+          </div>
+        )}
+        {comparison && (
+          <div className="flex flex-row text-xs">
+            <button type="button" onClick={handleChangeComparison('absolute')}>
+              absolute
+            </button>
+            <button type="submit" onClick={handleChangeComparison('relative')}>
+              relative
+            </button>
           </div>
         )}
         {!isLoading && children && (

--- a/client/src/components/legend/types/choropleth/component.tsx
+++ b/client/src/components/legend/types/choropleth/component.tsx
@@ -39,7 +39,9 @@ export const LegendTypeChoropleth: React.FC<LegendTypeChoroplethProps> = ({
       <ul className="flex w-full m-0 text-xs">
         {(!!min || min === 0) && (
           <li className="relative flex justify-start w-0">
-            <span className="absolute w-4 truncate left">{min}</span>
+            <span className="absolute w-4 truncate left" title={`${min}`}>
+              {min}
+            </span>
           </li>
         )}
         {items.map(({ label, value }, i) => (

--- a/client/src/components/select/component.tsx
+++ b/client/src/components/select/component.tsx
@@ -339,6 +339,9 @@ const InnerSelect = <OptionValue, IsMulti extends boolean = false>(
   );
 };
 
+/**
+ * @deprecated use `src/components/forms/select` instead
+ */
 const Select = React.forwardRef(InnerSelect) as <T, IsMulti extends boolean = false>(
   props: SelectProps<T> & {
     ref?: SelectRef<T, IsMulti>;

--- a/client/src/containers/analysis-visualization/analysis-dynamic-metadata/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-dynamic-metadata/component.tsx
@@ -53,104 +53,131 @@ const AnalysisDynamicMetadata: FC<AnalysisDynamicMetadataTypes> = ({
   );
 
   const { data: unit } = useIndicator(indicator?.value, { select: (data) => data?.unit });
-  const indicatorsTemplate = <span className="font-bold">{unit?.symbol}</span>;
-  const compareTemplate = <span className="font-bold whitespace-nowrap">{scenario2}</span>;
-  const materialTemplate = !!materials.length && (
-    <ul className="inline-flex pl-1 text-xs">
-      {materials.map((material) => (
-        <li key={material.value} className="pr-1">
-          <Badge
-            key={material.value}
-            data={material}
-            onClick={() => handleRemoveBadge('materials', materials, material)}
-            removable
-          >
-            {material.label}
-          </Badge>
-        </li>
-      ))}
-    </ul>
-  );
-  const originTemplate = !!origins.length && (
-    <ul className="inline-flex pl-1">
-      {origins.map((origin) => (
-        <li key={origin.value}>
-          <Badge
-            key={origin.value}
-            data={origin}
-            onClick={() => handleRemoveBadge('origins', origins, origin)}
-            removable
-          >
-            {origin.label}
-          </Badge>
-        </li>
-      ))}
-    </ul>
-  );
-  const supplierTemplate = !!suppliers.length && (
-    <ul className="inline-flex pl-1">
-      {suppliers.map((supplier) => (
-        <li key={supplier.value}>
-          <Badge
-            key={supplier.value}
-            data={supplier}
-            onClick={() => handleRemoveBadge('suppliers', suppliers, supplier)}
-            removable
-          >
-            {supplier.label}
-          </Badge>
-        </li>
-      ))}
-    </ul>
-  );
-  const locationTypeTemplate = !!locationTypes.length && (
-    <ul className="inline-flex pl-1">
-      {locationTypes.map((locationType) => (
-        <li key={locationType.value}>
-          <Badge
-            key={locationType.value}
-            data={locationType}
-            onClick={() => handleRemoveBadge('locationTypes', locationTypes, locationType)}
-            removable
-          >
-            {locationType.label}
-          </Badge>
-        </li>
-      ))}
-    </ul>
+
+  const indicatorsTemplate = useMemo(
+    () => indicator?.value !== 'all' && <span className="font-bold">({unit?.symbol})</span>,
+    [indicator?.value, unit?.symbol],
   );
 
-  const shouldDisplayComparePhrase = useMemo(
-    () => isComparisonEnabled && scenarioToCompare,
-    [isComparisonEnabled, scenarioToCompare],
+  const comparisonTemplate = useMemo(
+    () =>
+      !!isComparisonEnabled && (
+        <span>
+          compared to <span className="font-bold whitespace-nowrap">{scenario2}</span>
+        </span>
+      ),
+    [isComparisonEnabled, scenario2],
+  );
+
+  const materialTemplate = useMemo(
+    () =>
+      !!materials.length && (
+        <span>
+          {materialArticle}
+          <ul className="inline-flex text-xs">
+            {materials.map((material) => (
+              <li key={material.value} className="pr-1">
+                <Badge
+                  key={material.value}
+                  data={material}
+                  onClick={() => handleRemoveBadge('materials', materials, material)}
+                  removable
+                >
+                  {material.label}
+                </Badge>
+              </li>
+            ))}
+          </ul>
+        </span>
+      ),
+    [handleRemoveBadge, materials],
+  );
+  const originTemplate = useMemo(
+    () =>
+      !!origins.length && (
+        <span>
+          {originArticle}
+          <ul className="inline-flex">
+            {origins.map((origin) => (
+              <li key={origin.value}>
+                <Badge
+                  key={origin.value}
+                  data={origin}
+                  onClick={() => handleRemoveBadge('origins', origins, origin)}
+                  removable
+                >
+                  {origin.label}
+                </Badge>
+              </li>
+            ))}
+          </ul>
+        </span>
+      ),
+    [handleRemoveBadge, origins],
+  );
+  const supplierTemplate = useMemo(
+    () =>
+      !!suppliers.length && (
+        <span>
+          {supplierArticle}
+          <ul className="inline-flex">
+            {suppliers.map((supplier) => (
+              <li key={supplier.value}>
+                <Badge
+                  key={supplier.value}
+                  data={supplier}
+                  onClick={() => handleRemoveBadge('suppliers', suppliers, supplier)}
+                  removable
+                >
+                  {supplier.label}
+                </Badge>
+              </li>
+            ))}
+          </ul>
+        </span>
+      ),
+    [handleRemoveBadge, suppliers],
+  );
+  const locationTypeTemplate = useMemo(
+    () =>
+      !!locationTypes.length && (
+        <span>
+          {locationTypeArticle}
+          <ul className="inline-flex">
+            {locationTypes.map((locationType) => (
+              <li key={locationType.value}>
+                <Badge
+                  key={locationType.value}
+                  data={locationType}
+                  onClick={() => handleRemoveBadge('locationTypes', locationTypes, locationType)}
+                  removable
+                >
+                  {locationType.label}
+                </Badge>
+              </li>
+            ))}
+          </ul>
+        </span>
+      ),
+    [handleRemoveBadge, locationTypes],
   );
 
   return (
-    <div className={classNames('flex items-center justify-start text-xs space-x-1', className)}>
-      <div className="items-start -translate-y-[3px]">
-        <InformationCircleIcon className="w-4 h-4 text-gray-900 shrink-0" />
-      </div>
-      {shouldDisplayComparePhrase && (
-        <div className="flex items-baseline space-x-0.5">
-          <span>Viewing</span>
-          <ComparisonToggle />
-          <span>Impact values for </span>
-          <span className="font-bold">{scenario1}</span>
-          <span className="font-bold">
-            {!!compareTemplate && ' compared to'} {compareTemplate}
-          </span>
-        </div>
-      )}
-      {!shouldDisplayComparePhrase && (
-        <p className="flex-wrap items-center">
-          Viewing {values} <span className="whitespace-nowrap">Impact values for</span>
-          <span className="font-bold whitespace-nowrap"> {scenario1} </span>
-          {indicator?.value !== 'all' && indicatorsTemplate} {!!materials.length && materialArticle}
-          {materialTemplate} {!!origins.length && originArticle} {originTemplate}
-          {!!suppliers.length && supplierArticle} {supplierTemplate}
-          {!!locationTypes.length && locationTypeArticle} {locationTypeTemplate}
-        </p>
-      )}
+    <div
+      className={classNames('flex items-center justify-start text-xs gap-x-1 flex-wrap', className)}
+    >
+      <InformationCircleIcon className="w-4 h-4 text-gray-900 shrink-0" />
+      Viewing {isComparisonEnabled ? <ComparisonToggle /> : values}
+      <span>
+        <span className="whitespace-nowrap">Impact values for</span>
+        <span className="font-bold whitespace-nowrap"> {scenario1} </span>
+      </span>
+      {comparisonTemplate}
+      {indicatorsTemplate}
+      {materialTemplate}
+      {originTemplate}
+      {supplierTemplate}
+      {locationTypeTemplate}
     </div>
   );
 };

--- a/client/src/containers/analysis-visualization/analysis-dynamic-metadata/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-dynamic-metadata/component.tsx
@@ -73,7 +73,7 @@ const AnalysisDynamicMetadata: FC<AnalysisDynamicMetadataTypes> = ({
     () =>
       !!materials.length && (
         <span>
-          {materialArticle}
+          {materialArticle}{' '}
           <ul className="inline-flex text-xs">
             {materials.map((material) => (
               <li key={material.value} className="pr-1">
@@ -96,7 +96,7 @@ const AnalysisDynamicMetadata: FC<AnalysisDynamicMetadataTypes> = ({
     () =>
       !!origins.length && (
         <span>
-          {originArticle}
+          {originArticle}{' '}
           <ul className="inline-flex">
             {origins.map((origin) => (
               <li key={origin.value}>
@@ -119,7 +119,7 @@ const AnalysisDynamicMetadata: FC<AnalysisDynamicMetadataTypes> = ({
     () =>
       !!suppliers.length && (
         <span>
-          {supplierArticle}
+          {supplierArticle}{' '}
           <ul className="inline-flex">
             {suppliers.map((supplier) => (
               <li key={supplier.value}>
@@ -142,7 +142,7 @@ const AnalysisDynamicMetadata: FC<AnalysisDynamicMetadataTypes> = ({
     () =>
       !!locationTypes.length && (
         <span>
-          {locationTypeArticle}
+          {locationTypeArticle}{' '}
           <ul className="inline-flex">
             {locationTypes.map((locationType) => (
               <li key={locationType.value}>

--- a/client/src/containers/analysis-visualization/analysis-dynamic-metadata/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-dynamic-metadata/component.tsx
@@ -5,12 +5,11 @@ import { InformationCircleIcon } from '@heroicons/react/solid';
 import { useAppSelector, useAppDispatch } from 'store/hooks';
 import { useScenario } from 'hooks/scenarios';
 import { useIndicator } from 'hooks/indicators';
-import { scenarios, setComparisonMode } from 'store/features/analysis/scenarios';
+import { scenarios } from 'store/features/analysis/scenarios';
 import { analysisFilters, setFilters } from 'store/features/analysis/filters';
 import Badge from 'components/badge/component';
-import Select from 'components/select';
+import { ComparisonToggle } from 'components/legend/item/comparisonModeToggle';
 
-import type { ScenariosState } from 'store/features/analysis/scenarios';
 import type { SelectOption } from 'components/select';
 import type { FC } from 'react';
 
@@ -20,11 +19,6 @@ const originArticle = 'in';
 const supplierArticle = 'from';
 const locationTypeArticle = 'aggregated by';
 
-const DATA_VIEW_OPTIONS: SelectOption<ScenariosState['comparisonMode']>[] = [
-  { label: 'absolute', value: 'absolute' },
-  { label: 'relative', value: 'relative' },
-];
-
 type AnalysisDynamicMetadataTypes = {
   className?: string;
 };
@@ -33,8 +27,7 @@ const AnalysisDynamicMetadata: FC<AnalysisDynamicMetadataTypes> = ({
   className,
 }: AnalysisDynamicMetadataTypes) => {
   const dispatch = useAppDispatch();
-  const { currentScenario, scenarioToCompare, comparisonMode, isComparisonEnabled } =
-    useAppSelector(scenarios);
+  const { currentScenario, scenarioToCompare, isComparisonEnabled } = useAppSelector(scenarios);
   const { data: scenario } = useScenario(currentScenario);
   const { data: scenarioB } = useScenario(scenarioToCompare);
 
@@ -57,18 +50,6 @@ const AnalysisDynamicMetadata: FC<AnalysisDynamicMetadataTypes> = ({
       dispatch(setFilters({ [id]: filteredKeys }));
     },
     [dispatch],
-  );
-
-  const handleDataViewChange = useCallback(
-    ({ value }: typeof DATA_VIEW_OPTIONS[0]) => {
-      dispatch(setComparisonMode(value));
-    },
-    [dispatch],
-  );
-
-  const currentDataViewOption = useMemo(
-    () => DATA_VIEW_OPTIONS.find(({ value }) => value === comparisonMode),
-    [comparisonMode],
   );
 
   const { data: unit } = useIndicator(indicator?.value, { select: (data) => data?.unit });
@@ -152,12 +133,7 @@ const AnalysisDynamicMetadata: FC<AnalysisDynamicMetadataTypes> = ({
       {shouldDisplayComparePhrase && (
         <div className="flex items-baseline space-x-0.5">
           <span>Viewing</span>
-          <Select
-            theme="inline-primary"
-            current={currentDataViewOption}
-            options={DATA_VIEW_OPTIONS}
-            onChange={handleDataViewChange}
-          />
+          <ComparisonToggle />
           <span>Impact values for </span>
           <span className="font-bold">{scenario1}</span>
           <span className="font-bold">

--- a/client/src/containers/analysis-visualization/analysis-legend/contextual-legend-item/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-legend/contextual-legend-item/component.tsx
@@ -10,7 +10,6 @@ import LegendTypeGradient from 'components/legend/types/gradient';
 import { useContextualLayer } from 'hooks/layers/contextual';
 import useContextualLayers from 'hooks/layers/getContextualLayers';
 
-import type { ScenarioComparisonMode } from 'store/features/analysis/scenarios';
 import type { Layer } from 'types';
 
 interface ContextualLegendItemProps {
@@ -29,14 +28,6 @@ const ContextualLegendItem = ({ layer }: ContextualLegendItemProps) => {
       dispatch(setLayer({ id: layer.id, layer: { opacity } }));
     },
     [dispatch, layer],
-  );
-
-  const handleComparison = useCallback(
-    (mode: ScenarioComparisonMode) => {
-      if (mode === layer.comparisonMode) return;
-      dispatch(setLayer({ id: layer.id, layer: { comparisonMode: mode } }));
-    },
-    [dispatch, layer.comparisonMode, layer.id],
   );
 
   const Legend = useMemo(() => {
@@ -72,7 +63,6 @@ const ContextualLegendItem = ({ layer }: ContextualLegendItemProps) => {
       opacity={layer.opacity}
       {...layer.metadata?.legend}
       onChangeOpacity={handleOpacity}
-      onChangeComparisonMode={handleComparison}
     >
       {Legend}
     </LegendItem>

--- a/client/src/containers/analysis-visualization/analysis-legend/contextual-legend-item/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-legend/contextual-legend-item/component.tsx
@@ -10,6 +10,7 @@ import LegendTypeGradient from 'components/legend/types/gradient';
 import { useContextualLayer } from 'hooks/layers/contextual';
 import useContextualLayers from 'hooks/layers/getContextualLayers';
 
+import type { ScenarioComparisonMode } from 'store/features/analysis/scenarios';
 import type { Layer } from 'types';
 
 interface ContextualLegendItemProps {
@@ -28,6 +29,14 @@ const ContextualLegendItem = ({ layer }: ContextualLegendItemProps) => {
       dispatch(setLayer({ id: layer.id, layer: { opacity } }));
     },
     [dispatch, layer],
+  );
+
+  const handleComparison = useCallback(
+    (mode: ScenarioComparisonMode) => {
+      if (mode === layer.comparisonMode) return;
+      dispatch(setLayer({ id: layer.id, layer: { comparisonMode: mode } }));
+    },
+    [dispatch, layer.comparisonMode, layer.id],
   );
 
   const Legend = useMemo(() => {
@@ -61,8 +70,10 @@ const ContextualLegendItem = ({ layer }: ContextualLegendItemProps) => {
       name={layer.metadata!.legend.name}
       info={layer.metadata?.description}
       opacity={layer.opacity}
+      comparison={layer.comparisonMode}
       {...layer.metadata?.legend}
       onChangeOpacity={handleOpacity}
+      onChangeComparisonMode={handleComparison}
     >
       {Legend}
     </LegendItem>

--- a/client/src/containers/analysis-visualization/analysis-legend/contextual-legend-item/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-legend/contextual-legend-item/component.tsx
@@ -70,7 +70,6 @@ const ContextualLegendItem = ({ layer }: ContextualLegendItemProps) => {
       name={layer.metadata!.legend.name}
       info={layer.metadata?.description}
       opacity={layer.opacity}
-      comparison={layer.comparisonMode}
       {...layer.metadata?.legend}
       onChangeOpacity={handleOpacity}
       onChangeComparisonMode={handleComparison}

--- a/client/src/containers/analysis-visualization/analysis-legend/impact-legend-item/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-legend/impact-legend-item/component.tsx
@@ -2,10 +2,12 @@ import { useCallback, useMemo } from 'react';
 
 import { useAppSelector, useAppDispatch } from 'store/hooks';
 import { analysisMap, setLayer } from 'store/features/analysis/map';
-import { analysisFilters } from 'store/features/analysis';
+import { analysisFilters, scenarios } from 'store/features/analysis';
 import LegendTypeChoropleth from 'components/legend/types/choropleth';
 import LegendItem from 'components/legend/item';
+import { setComparisonMode } from 'store/features/analysis/scenarios';
 
+import type { ScenarioComparisonMode } from 'store/features/analysis/scenarios';
 import type { Legend } from 'types';
 
 const LAYER_ID = 'impact';
@@ -27,8 +29,9 @@ const ImpactLayer = () => {
   const dispatch = useAppDispatch();
   const { indicator } = useAppSelector(analysisFilters);
   const {
-    layers: { [LAYER_ID]: impactLayer },
+    layers: { [LAYER_ID]: layer },
   } = useAppSelector(analysisMap);
+  const { comparisonMode } = useAppSelector(scenarios);
   const handleOpacity = useCallback(
     (opacity: number) => {
       dispatch(setLayer({ id: LAYER_ID, layer: { opacity } }));
@@ -38,27 +41,36 @@ const ImpactLayer = () => {
 
   const legendItems = useMemo<Legend['items']>(
     () =>
-      impactLayer.metadata?.legend?.items?.map((item) => ({
+      layer.metadata?.legend?.items?.map((item) => ({
         ...item,
         label: item.label || `${item.value}`,
       })) || [],
-    [impactLayer.metadata?.legend.items],
+    [layer.metadata?.legend.items],
   );
 
-  if (!impactLayer.metadata) return null;
+  const handleChangeComparison = useCallback(
+    (comparisonMode: ScenarioComparisonMode) => {
+      dispatch(setComparisonMode(comparisonMode));
+    },
+    [dispatch],
+  );
+
+  if (!layer.metadata) return null;
   // TO-DO: add Loading component
   return (
     <LegendItem
       info={INFO_METADATA[`impact-${indicator?.value}`]}
-      {...impactLayer.metadata.legend}
-      opacity={impactLayer.opacity}
+      {...layer.metadata.legend}
+      opacity={layer.opacity}
       onChangeOpacity={handleOpacity}
-      isLoading={impactLayer.loading}
+      comparison={comparisonMode}
+      onChangeComparisonMode={handleChangeComparison}
+      isLoading={layer.loading}
       main
     >
       <LegendTypeChoropleth
         className="flex-1 text-sm text-gray-500"
-        min={impactLayer.metadata.legend.min}
+        min={layer.metadata.legend.min}
         items={legendItems}
       />
     </LegendItem>

--- a/client/src/containers/analysis-visualization/analysis-legend/impact-legend-item/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-legend/impact-legend-item/component.tsx
@@ -2,7 +2,7 @@ import { useCallback, useMemo } from 'react';
 
 import { useAppSelector, useAppDispatch } from 'store/hooks';
 import { analysisMap, setLayer } from 'store/features/analysis/map';
-import { analysisFilters } from 'store/features/analysis';
+import { analysisFilters, scenarios } from 'store/features/analysis';
 import LegendTypeChoropleth from 'components/legend/types/choropleth';
 import LegendItem from 'components/legend/item';
 
@@ -46,12 +46,25 @@ const ImpactLayer = () => {
     [layer.metadata?.legend.items],
   );
 
+  const { isComparisonEnabled } = useAppSelector(scenarios);
+
+  const name = useMemo(() => {
+    if (!layer.metadata?.legend?.name) return null;
+
+    if (isComparisonEnabled) {
+      return `Difference in ${layer.metadata.legend.name}`;
+    }
+
+    return layer.metadata.legend.name;
+  }, [isComparisonEnabled, layer.metadata?.legend]);
+
   if (!layer.metadata) return null;
   // TO-DO: add Loading component
   return (
     <LegendItem
       info={INFO_METADATA[`impact-${indicator?.value}`]}
       {...layer.metadata.legend}
+      name={name}
       opacity={layer.opacity}
       onChangeOpacity={handleOpacity}
       showComparisonModeToggle

--- a/client/src/containers/analysis-visualization/analysis-legend/impact-legend-item/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-legend/impact-legend-item/component.tsx
@@ -2,12 +2,10 @@ import { useCallback, useMemo } from 'react';
 
 import { useAppSelector, useAppDispatch } from 'store/hooks';
 import { analysisMap, setLayer } from 'store/features/analysis/map';
-import { analysisFilters, scenarios } from 'store/features/analysis';
+import { analysisFilters } from 'store/features/analysis';
 import LegendTypeChoropleth from 'components/legend/types/choropleth';
 import LegendItem from 'components/legend/item';
-import { setComparisonMode } from 'store/features/analysis/scenarios';
 
-import type { ScenarioComparisonMode } from 'store/features/analysis/scenarios';
 import type { Legend } from 'types';
 
 const LAYER_ID = 'impact';
@@ -31,7 +29,7 @@ const ImpactLayer = () => {
   const {
     layers: { [LAYER_ID]: layer },
   } = useAppSelector(analysisMap);
-  const { comparisonMode } = useAppSelector(scenarios);
+
   const handleOpacity = useCallback(
     (opacity: number) => {
       dispatch(setLayer({ id: LAYER_ID, layer: { opacity } }));
@@ -48,13 +46,6 @@ const ImpactLayer = () => {
     [layer.metadata?.legend.items],
   );
 
-  const handleChangeComparison = useCallback(
-    (comparisonMode: ScenarioComparisonMode) => {
-      dispatch(setComparisonMode(comparisonMode));
-    },
-    [dispatch],
-  );
-
   if (!layer.metadata) return null;
   // TO-DO: add Loading component
   return (
@@ -63,8 +54,7 @@ const ImpactLayer = () => {
       {...layer.metadata.legend}
       opacity={layer.opacity}
       onChangeOpacity={handleOpacity}
-      comparison={comparisonMode}
-      onChangeComparisonMode={handleChangeComparison}
+      showComparisonModeToggle
       isLoading={layer.loading}
       main
     >

--- a/client/src/containers/analysis-visualization/analysis-map/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-map/component.tsx
@@ -39,6 +39,13 @@ const AnalysisMap = () => {
   });
 
   const contextualData = useAllContextualLayersData();
+  const contextualDataById = useMemo(() => {
+    return Object.fromEntries(
+      contextualData
+        .filter((d) => d.isSuccess)
+        .map(({ data: { layerId, ...rest } }) => [layerId, rest]),
+    );
+  }, [contextualData]);
 
   const layers = useMemo(() => {
     const legends = Object.values(layerDeckGLProps)
@@ -49,7 +56,7 @@ const AnalysisMap = () => {
         }
 
         const data = layerInfo.isContextual
-          ? contextualData.get(props.id)?.data
+          ? contextualDataById[props.id]?.data
           : layerInfo.id === 'material'
           ? materialData?.data
           : impactData;
@@ -77,7 +84,7 @@ const AnalysisMap = () => {
       })
       .filter((l) => !!l);
     return sortBy(legends, (l) => layersMetadata[l.id].order).reverse();
-  }, [contextualData, impactData, layerDeckGLProps, layersMetadata, materialData?.data]);
+  }, [contextualDataById, impactData, layerDeckGLProps, layersMetadata, materialData?.data]);
 
   const handleMapStyleChange = useCallback((newStyle: BasemapValue) => {
     setMapStyle(newStyle);

--- a/client/src/hooks/h3-data/contextual.ts
+++ b/client/src/hooks/h3-data/contextual.ts
@@ -115,12 +115,12 @@ export const useAllContextualLayersData = <T = { layerId: Layer['id'] } & H3APIR
   const queryList = Object.values(layers)
     .filter((layer) => layer.isContextual)
     .map((layer) => ({
-      queryKey: ['h3-data-contextual-all', layer.id, urlParams, layer.comparisonMode] as const,
-      queryFn: (({ queryKey: [, id, params, comparisonMode] }) => {
+      queryKey: ['h3-data-contextual-all', layer.id, urlParams] as const,
+      queryFn: (({ queryKey: [, id, params] }) => {
         return (
           apiRawService
             .get<H3APIResponse>(`/contextual-layers/${id}/h3data`, {
-              params: { ...params, relative: comparisonMode === 'relative' },
+              params,
             })
             // Adding color to the response
             .then((response) => {
@@ -132,12 +132,7 @@ export const useAllContextualLayersData = <T = { layerId: Layer['id'] } & H3APIR
         );
       }) as QueryFunction<
         H3APIResponse & { layerId: Layer['id'] },
-        [
-          'h3-data-contextual',
-          Layer['id'],
-          ContextualH3APIParams,
-          ScenarioComparisonMode | undefined,
-        ]
+        ['h3-data-contextual', Layer['id'], ContextualH3APIParams]
       >,
       keepPreviousData: true,
       refetchOnMount: false,

--- a/client/src/hooks/h3-data/contextual.ts
+++ b/client/src/hooks/h3-data/contextual.ts
@@ -1,16 +1,15 @@
 import { useQuery, useQueries } from '@tanstack/react-query';
 import chroma from 'chroma-js';
-import { useMemo } from 'react';
 
 import { DEFAULT_QUERY_OPTIONS, scaleByLegendType } from './utils';
 
 import { apiRawService } from 'services/api';
-import { analysisFilters, analysisMap } from 'store/features/analysis';
+import { analysisFilters, analysisMap, scenarios } from 'store/features/analysis';
 import { useAppSelector } from 'store/hooks';
 
-import type { H3APIResponse, H3Data, H3Item, Layer } from 'types';
+import type { ContextualH3APIParams, ErrorResponse, H3APIResponse, H3Item, Layer } from 'types';
 import type { AxiosResponse } from 'axios';
-import type { QueryFunction, UseQueryOptions, UseQueryResult } from '@tanstack/react-query';
+import type { UseQueryOptions, UseQueryResult, QueryFunction } from '@tanstack/react-query';
 
 const responseContextualParser = (response: AxiosResponse<H3APIResponse>): H3APIResponse => {
   const { data, metadata } = response.data;
@@ -31,96 +30,121 @@ const responseContextualParser = (response: AxiosResponse<H3APIResponse>): H3API
   return { data: h3DataWithColor, metadata };
 };
 
-// The fetch function is the same when fetching one or more layers
-const fetchContextualLayerData: QueryFunction<
-  H3APIResponse,
-  ['h3-data-contextual', Layer['id'], Record<string, string>]
-> = ({ queryKey: [, id, urlParams] }) =>
-  apiRawService
-    .get(`/contextual-layers/${id}/h3data`, {
-      params: urlParams,
-    })
-    // Adding color to the response
-    .then((response) => responseContextualParser(response));
-
 const useH3ContextualData = <T = H3APIResponse>(
-  id: string,
-  options: UseQueryOptions<H3APIResponse, unknown, T> = {},
+  id: Layer['id'],
+  options?: UseQueryOptions<
+    H3APIResponse,
+    ErrorResponse,
+    T,
+    ['h3-data-contextual', typeof id, ContextualH3APIParams]
+  >,
 ) => {
   const filters = useAppSelector(analysisFilters);
   const { startYear, materials, indicator, suppliers, origins, locationTypes } = filters;
-  const urlParams = {
+  const { comparisonMode } = useAppSelector(scenarios);
+
+  const params = {
     year: startYear,
     indicatorId: indicator?.value && indicator?.value === 'all' ? null : indicator?.value,
     ...(materials?.length ? { materialIds: materials?.map(({ value }) => value) } : {}),
     ...(suppliers?.length ? { supplierIds: suppliers?.map(({ value }) => value) } : {}),
     ...(origins?.length ? { originIds: origins?.map(({ value }) => value) } : {}),
     ...(locationTypes?.length ? { locationTypes: locationTypes?.map(({ value }) => value) } : {}),
+    relative: comparisonMode === 'relative',
     resolution: origins?.length ? 6 : 4,
   };
 
-  const query = useQuery(['h3-data-contextual', id, urlParams], fetchContextualLayerData, {
-    ...DEFAULT_QUERY_OPTIONS,
-    placeholderData: {
-      data: [],
-      metadata: {
-        name: null,
-        legend: {
-          unit: null,
-          items: [],
+  const query = useQuery(
+    ['h3-data-contextual', id, params],
+    () =>
+      apiRawService
+        .get<H3APIResponse>(`/contextual-layers/${id}/h3data`, {
+          params,
+        })
+        // Adding color to the response
+        .then((response) => responseContextualParser(response)),
+    {
+      ...DEFAULT_QUERY_OPTIONS,
+      placeholderData: {
+        data: [],
+        metadata: {
+          name: null,
+          legend: {
+            unit: null,
+            items: [],
+          },
         },
       },
+      ...options,
+      enabled: (options.enabled ?? true) && !!id && !!params.year,
     },
-    ...options,
-    enabled: (options.enabled ?? true) && !!id && !!urlParams.year,
-  });
+  );
 
   return query;
 };
 
-export const useAllContextualLayersData = (options: Partial<UseQueryOptions> = {}) => {
+export const useAllContextualLayersData = <T = { layerId: Layer['id'] } & H3APIResponse>(
+  options?: Omit<
+    UseQueryOptions<
+      { layerId: Layer['id'] } & H3APIResponse,
+      ErrorResponse,
+      T,
+      ['h3-data-contextual-all', Layer['id'], ContextualH3APIParams]
+    >,
+    'context' | 'queryKey' | 'queryFn'
+  >,
+) => {
   const { layers } = useAppSelector(analysisMap);
-  const filters = useAppSelector(analysisFilters);
-  const { startYear, materials, indicator, suppliers, origins, locationTypes } = filters;
-  const urlParams = {
+  const { startYear, materials, indicator, suppliers, origins, locationTypes } =
+    useAppSelector(analysisFilters);
+  const { comparisonMode } = useAppSelector(scenarios);
+
+  const urlParams: ContextualH3APIParams = {
     year: startYear,
     indicatorId: indicator?.value && indicator?.value === 'all' ? null : indicator?.value,
     ...(materials?.length ? { materialIds: materials?.map(({ value }) => value) } : {}),
     ...(suppliers?.length ? { supplierIds: suppliers?.map(({ value }) => value) } : {}),
     ...(origins?.length ? { originIds: origins?.map(({ value }) => value) } : {}),
     ...(locationTypes?.length ? { locationTypes: locationTypes?.map(({ value }) => value) } : {}),
+    relative: comparisonMode === 'relative',
     resolution: origins?.length ? 6 : 4,
   };
 
-  const queries = useQueries({
-    queries: Object.values(layers)
-      .filter((layer) => layer.isContextual)
-      .map((layer) => ({
-        queryKey: ['h3-data-contextual', layer.id, urlParams],
-        queryFn: fetchContextualLayerData,
-        ...DEFAULT_QUERY_OPTIONS,
-        keepPreviousData: true,
-        refetchOnMount: false,
-        refetchOnWindowFocus: false,
-        refetchOnReconnect: false,
-        staleTime: 10 * 60 * 1000, // 10 minutes
-        ...options,
-        select: (data: H3APIResponse) => ({ ...data, layerId: layer.id }),
-        enabled: (options.enabled ?? true) && layer.active && !!layer.id && !!urlParams.year,
-      })),
-  });
+  const queryList = Object.values(layers)
+    .filter((layer) => layer.isContextual)
+    .map((layer) => ({
+      queryKey: ['h3-data-contextual-all', layer.id, urlParams] as const,
+      queryFn: (({ queryKey: [, id, params] }) => {
+        return (
+          apiRawService
+            .get<H3APIResponse>(`/contextual-layers/${id}/h3data`, {
+              params,
+            })
+            // Adding color to the response
+            .then((response) => {
+              return responseContextualParser(response);
+            })
+            .then((response) => {
+              return { layerId: id, ...response };
+            })
+        );
+      }) as QueryFunction<
+        H3APIResponse & { layerId: Layer['id'] },
+        ['h3-data-contextual', Layer['id'], ContextualH3APIParams]
+      >,
+      keepPreviousData: true,
+      refetchOnMount: false,
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: false,
+      staleTime: 10 * 60 * 1000, // 10 minutes
+      ...options,
+      enabled: (options?.enabled ?? true) && layer.active && !!layer.id && !!urlParams.year,
+    }));
 
-  const map = useMemo(
-    () =>
-      new Map(
-        queries.map(({ data: { layerId, ...data }, ...rest }) => [
-          layerId,
-          { ...data, ...rest } as UseQueryResult<H3Data>,
-        ]),
-      ),
-    [queries],
-  );
-  return map;
+  const queries = useQueries({
+    queries: queryList,
+  }) as unknown[] as UseQueryResult<T, ErrorResponse>[];
+  return queries;
 };
 
 export default useH3ContextualData;

--- a/client/src/hooks/h3-data/contextual.ts
+++ b/client/src/hooks/h3-data/contextual.ts
@@ -118,7 +118,7 @@ export const useAllContextualLayersData = <T = { layerId: Layer['id'] } & H3APIR
         return (
           apiRawService
             .get<H3APIResponse>(`/contextual-layers/${id}/h3data`, {
-              params,
+              params: { ...params, relative: layer.comparisonMode === 'relative' },
             })
             // Adding color to the response
             .then((response) => {

--- a/client/src/hooks/h3-data/index.ts
+++ b/client/src/hooks/h3-data/index.ts
@@ -9,12 +9,24 @@ import { useAppSelector } from 'store/hooks';
 import { analysisFilters, scenarios } from 'store/features/analysis';
 
 import type { UseQueryOptions } from '@tanstack/react-query';
-import type { H3APIResponse, MaterialH3APIParams, ImpactH3APIParams, Layer } from 'types';
+import type {
+  H3APIResponse,
+  MaterialH3APIParams,
+  ImpactH3APIParams,
+  Layer,
+  ContextualH3APIParams,
+  ErrorResponse,
+} from 'types';
 
 interface UseH3DataProps<T> {
   id: Layer['id'];
   params?: Partial<MaterialH3APIParams & ImpactH3APIParams>;
-  options?: UseQueryOptions<H3APIResponse, unknown, T>;
+  options?: UseQueryOptions<
+    H3APIResponse,
+    ErrorResponse,
+    T
+    // ['h3-data-contextual', string, ContextualH3APIParams]
+  >;
 }
 
 export const useH3Data = <T = H3APIResponse>({
@@ -56,7 +68,15 @@ export const useH3Data = <T = H3APIResponse>({
   const impactQuery = useH3ImpactData(impactParams, impactOptions);
 
   const contextualOptions = useMemo(
-    () => ({ ...options, enabled: enabled && isContextual }),
+    () => ({
+      ...(options as UseQueryOptions<
+        H3APIResponse,
+        ErrorResponse,
+        T,
+        ['h3-data-contextual', string, ContextualH3APIParams]
+      >),
+      enabled: enabled && isContextual,
+    }),
     [enabled, isContextual, options],
   );
   const contextualQuery = useH3ContextualData(id, contextualOptions);

--- a/client/src/store/features/analysis/map.ts
+++ b/client/src/store/features/analysis/map.ts
@@ -10,6 +10,7 @@ const DEFAULT_LAYER_ATTRIBUTES = {
   opacity: 0.7,
   loading: false,
   isContextual: false,
+  comparisonMode: 'relative' as const,
 };
 
 const DEFAULT_DECKGL_PROPS = {
@@ -61,7 +62,6 @@ export const initialState: AnalysisMapState = {
     impact: {
       ...DEFAULT_LAYER_ATTRIBUTES,
       id: 'impact',
-      ...DEFAULT_LAYER_ATTRIBUTES,
       order: 0,
       active: true,
       isContextual: false,

--- a/client/src/store/features/analysis/map.ts
+++ b/client/src/store/features/analysis/map.ts
@@ -64,7 +64,6 @@ export const initialState: AnalysisMapState = {
       order: 0,
       active: true,
       isContextual: false,
-      comparisonMode: 'relative',
     },
     material: {
       ...DEFAULT_LAYER_ATTRIBUTES,

--- a/client/src/store/features/analysis/map.ts
+++ b/client/src/store/features/analysis/map.ts
@@ -10,7 +10,6 @@ const DEFAULT_LAYER_ATTRIBUTES = {
   opacity: 0.7,
   loading: false,
   isContextual: false,
-  comparisonMode: 'relative' as const,
 };
 
 const DEFAULT_DECKGL_PROPS = {
@@ -65,6 +64,7 @@ export const initialState: AnalysisMapState = {
       order: 0,
       active: true,
       isContextual: false,
+      comparisonMode: 'relative',
     },
     material: {
       ...DEFAULT_LAYER_ATTRIBUTES,

--- a/client/src/store/features/analysis/scenarios.ts
+++ b/client/src/store/features/analysis/scenarios.ts
@@ -4,9 +4,11 @@ import type { PayloadAction } from '@reduxjs/toolkit';
 import type { RootState } from 'store';
 import type { Scenario } from 'containers/scenarios/types';
 
+export type ScenarioComparisonMode = 'relative' | 'absolute';
+
 export type ScenariosState = {
   isComparisonEnabled: boolean;
-  comparisonMode: 'relative' | 'absolute';
+  comparisonMode: ScenarioComparisonMode;
   /**
    * The current scenario id
    * If the current scenario is the actual data, the id will be null

--- a/client/src/store/features/analysis/scenarios.ts
+++ b/client/src/store/features/analysis/scenarios.ts
@@ -28,7 +28,7 @@ export type ScenariosState = {
 // Define the initial state using that type
 export const initialState: ScenariosState = {
   isComparisonEnabled: false,
-  comparisonMode: 'relative',
+  comparisonMode: 'absolute',
   currentScenario: null,
   scenarioToCompare: null,
   searchTerm: null,

--- a/client/src/types.d.ts
+++ b/client/src/types.d.ts
@@ -58,9 +58,7 @@ export type ImpactH3APIParams = CommonH3APIParams & {
   locationTypes?: string[];
 };
 
-export interface ContextualH3APIParams extends ImpactH3APIParams {
-  relative: boolean;
-}
+export type ContextualH3APIParams = ImpactH3APIParams;
 
 export type ImpactTabularAPIParams = {
   groupBy: string;
@@ -224,7 +222,7 @@ export type Layer = {
   active: boolean;
   opacity: number;
   metadata?: WithRequiredProperty<Partial<LayerMetadata>, 'legend'>;
-  comparisonMode: ScenarioComparisonMode;
+  comparisonMode?: ScenarioComparisonMode;
   loading?: boolean;
 };
 

--- a/client/src/types.d.ts
+++ b/client/src/types.d.ts
@@ -1,3 +1,4 @@
+import type { ScenarioComparisonMode } from 'store/features/analysis/scenarios';
 import type { Scenario } from 'containers/scenarios/types';
 
 export type RGBColor = [number, number, number];
@@ -56,6 +57,10 @@ export type ImpactH3APIParams = CommonH3APIParams & {
   scenarioId?: Scenario['id'];
   locationTypes?: string[];
 };
+
+export interface ContextualH3APIParams extends ImpactH3APIParams {
+  relative: boolean;
+}
 
 export type ImpactTabularAPIParams = {
   groupBy: string;
@@ -219,6 +224,7 @@ export type Layer = {
   active: boolean;
   opacity: number;
   metadata?: WithRequiredProperty<Partial<LayerMetadata>, 'legend'>;
+  comparisonMode: ScenarioComparisonMode;
   loading?: boolean;
 };
 

--- a/client/src/types.d.ts
+++ b/client/src/types.d.ts
@@ -1,4 +1,3 @@
-import type { ScenarioComparisonMode } from 'store/features/analysis/scenarios';
 import type { Scenario } from 'containers/scenarios/types';
 
 export type RGBColor = [number, number, number];
@@ -222,7 +221,6 @@ export type Layer = {
   active: boolean;
   opacity: number;
   metadata?: WithRequiredProperty<Partial<LayerMetadata>, 'legend'>;
-  comparisonMode?: ScenarioComparisonMode;
   loading?: boolean;
 };
 


### PR DESCRIPTION
### General description

This PR adds a comparison mode selector to the impact legend in the map view. This selector is synchronized with the store's `comparisonMode`.

The selector will only appear if comparisons are enabled.

## Checklist before merging

- [x] Branch name / PR includes the related Jira ticket Id.
- [ ] Tests to check core implementation / bug fix added.
- [ ] All checks in Continuous Integration workflow pass.
- [ ] Feature functionally tested by reviewer(s).
- [ ] Code reviewed by reviewer(s).
- [x] Documentation updated (README, CHANGELOG...) (if required)
