### PR TITLE
Bugfix: LANDGRIF-980 Refresh view after intervention creation

### DIFF
--- a/api/src/modules/indicator-records/indicator-record.entity.ts
+++ b/api/src/modules/indicator-records/indicator-record.entity.ts
@@ -1,5 +1,4 @@
 import {
-  AfterInsert,
   Column,
   Entity,
   getManager,
@@ -49,7 +48,10 @@ export class IndicatorRecord extends TimestampedBaseEntity {
   @Column({ type: 'float', nullable: true })
   value!: number;
 
-  @ApiProperty()
+  @ApiProperty({
+    enum: INDICATOR_RECORD_STATUS,
+    enumName: 'INDICATOR_RECORD_STATUS',
+  })
   @Column({
     type: 'enum',
     enum: INDICATOR_RECORD_STATUS,
@@ -107,9 +109,8 @@ export class IndicatorRecord extends TimestampedBaseEntity {
   @Column({ nullable: false })
   materialH3DataId: string;
 
-  @AfterInsert()
-  static async updateImpactView(): Promise<void> {
-    await getManager().query(
+  static updateImpactView(): Promise<void> {
+    return getManager().query(
       `REFRESH MATERIALIZED VIEW ${IMPACT_VIEW_NAME} WITH DATA`,
     );
   }

--- a/api/src/modules/indicator-records/indicator-record.entity.ts
+++ b/api/src/modules/indicator-records/indicator-record.entity.ts
@@ -48,10 +48,7 @@ export class IndicatorRecord extends TimestampedBaseEntity {
   @Column({ type: 'float', nullable: true })
   value!: number;
 
-  @ApiProperty({
-    enum: INDICATOR_RECORD_STATUS,
-    enumName: 'INDICATOR_RECORD_STATUS',
-  })
+  @ApiProperty()
   @Column({
     type: 'enum',
     enum: INDICATOR_RECORD_STATUS,

--- a/api/src/modules/scenario-interventions/scenario-intervention.repository.ts
+++ b/api/src/modules/scenario-interventions/scenario-intervention.repository.ts
@@ -25,6 +25,7 @@ import {
 } from 'modules/scenario-interventions/intermediate-table-names/intermediate.table.names';
 import { chunk } from 'lodash';
 import * as config from 'config';
+import { IMPACT_VIEW_NAME } from 'modules/impact/views/impact.materialized-view.entity';
 
 @EntityRepository(ScenarioIntervention)
 export class ScenarioInterventionRepository extends Repository<ScenarioIntervention> {
@@ -249,10 +250,10 @@ export class ScenarioInterventionRepository extends Repository<ScenarioIntervent
         .values(replacedBusinessUnitsToSave)
         .execute();
       this.logger.log('Committing transaction...');
-
       await queryRunner.commitTransaction();
+      this.logger.warn(`REFRESHING ${IMPACT_VIEW_NAME} ON THE BACKGROUND...`);
+      IndicatorRecord.updateImpactView();
       this.logger.log('New Intervention Saving Finished');
-
       return intervention;
     } catch (err) {
       // rollback changes before throwing error

--- a/api/test/e2e/scenario-interventions/scenario-interventions.spec.ts
+++ b/api/test/e2e/scenario-interventions/scenario-interventions.spec.ts
@@ -142,6 +142,8 @@ describe('ScenarioInterventionsModule (e2e)', () => {
     },
   };
 
+  jest.spyOn(IndicatorRecord, 'updateImpactView').mockResolvedValue('' as any);
+
   let app: INestApplication;
   let scenarioInterventionRepository: ScenarioInterventionRepository;
   let scenarioRepository: ScenarioRepository;


### PR DESCRIPTION
### General description

This PR adds an Event Subscriber which listens to db events happening to Indicator Records. Implements a method to refresh the impact materialized view **after any commited transaction over this table**

**NOTES:** 
1. For some reason seems to listen to Scenario events as well, even when creating a new one which has no chained interaction to Indicator Records. For deletes, in example, it makes total sense.
 I need to test if this somehow affects to other entities related somehow to IR even if a transaction does not target this table at all.
 2. Not returning the promise of the queryManager triggers the refresh but the request can move one, so maybe this can do the job for now, because by the time the user gets back to the map to compare, the view can be easily refreshed.
 We need to take in account concurrent updating and also caching, let´s discuss further tomorrow
 3. Automated tests are on the way

### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

Create some Intervention which adds a location that is not part of the actual data. You should see a log message letting know the refresh has been triggered.
Go back to the map, select a scenario or select a comparison and filter by the location you added. You should be able to see the location on the map

Same applies for deletion. Delete an intervention or a scenario with interventions. You should see that a refresh has been triggered, and you should no longer be able to see the location. **(Take in account that you won´t be able to filter by the location after a deletion, as the filters are not relying on the view to show data)**

- Apart from the added feature / bug fix, check overall performance, styling...

## Checklist before merging

- [ ] Branch name / PR includes the related Jira ticket Id.
- [ ] Tests to check core implementation / bug fix added.
- [ ] All checks in Continuous Integration workflow pass.
- [ ] Feature functionally tested by reviewer(s).
- [ ] Code reviewed by reviewer(s).
- [ ] Documentation updated (README, CHANGELOG...) (if required)
