### PR TITLE
Fixed an issue where scenarioId param was missing in table analysis

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -5,12 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [v0.2.0 Unreleased]
+## [v0.2.1]
+
+### Fixed
+- Analysis table is not updating selecting an scenario [LANDGRIF-1019](https://vizzuality.atlassian.net/browse/LANDGRIF-1019)
+
+## [v0.2.0]
 
 ### Added
 
 - Comparison mode toggle for impact table H3 data [LANDGRIF-941](https://vizzuality.atlassian.net/browse/LANDGRIF-941)
-- Readded material layer to the map as a contextual layer [LANDGRIF-827](https://vizzuality.atlassian.net/browse/LANDGRIF-827)
+- Re-added material layer to the map as a contextual layer [LANDGRIF-827](https://vizzuality.atlassian.net/browse/LANDGRIF-827)
 - Add map preview to legend settings modal [LANDGRIF-827](https://vizzuality.atlassian.net/browse/LANDGRIF-827)
 - In chart view, when a comparison is enabled the chart changes to line chart [LANDGRIF-807](https://vizzuality.atlassian.net/browse/LANDGRIF-807)
 - Scenario creation link from analysis [LANDGRIF-805](https://vizzuality.atlassian.net/browse/LANDGRIF-805)

--- a/client/cypress/e2e/analysis-scenarios.cy.ts
+++ b/client/cypress/e2e/analysis-scenarios.cy.ts
@@ -90,6 +90,10 @@ describe('Analysis and scenarios', () => {
   });
 
   it('should be able to select a scenario vs scenario in the comparison select', () => {
+    cy.intercept(
+      'GET',
+      '/api/v1/impact/table?*scenarioId=8dfd0ce0-67b7-4f1d-be9c-41bc3ceafde7*',
+    ).as('fetchImpactTableData');
     cy.visit('/analysis/table');
     cy.wait('@scenariosNoPaginated');
     cy.wait('@scenariosList');
@@ -97,6 +101,10 @@ describe('Analysis and scenarios', () => {
     cy.get('[data-testid="scenario-item-8dfd0ce0-67b7-4f1d-be9c-41bc3ceafde7"]')
       .find('[data-testid="scenario-item-radio"]')
       .click();
+
+    cy.wait('@fetchImpactTableData')
+      .its('request.url')
+      .should('contain', 'scenarioId=8dfd0ce0-67b7-4f1d-be9c-41bc3ceafde7');
 
     cy.url().should('contain', 'scenarioId=8dfd0ce0-67b7-4f1d-be9c-41bc3ceafde7');
 

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "landgriffon-client",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/client/src/containers/analysis-visualization/analysis-table/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-table/component.tsx
@@ -2,6 +2,7 @@ import { useCallback, useMemo, useState } from 'react';
 import classNames from 'classnames';
 import { DownloadIcon } from '@heroicons/react/outline';
 import uniq from 'lodash/uniq';
+import omit from 'lodash/omit';
 
 import ComparisonCell from './comparison-cell/component';
 
@@ -109,6 +110,7 @@ const AnalysisTable = () => {
     endYear: filters.endYear,
     groupBy: filters.groupBy,
     ...restFilters,
+    scenarioId: currentScenario,
     'page[number]': paginationState.pageIndex,
     'page[size]': paginationState.pageSize,
   };
@@ -118,14 +120,14 @@ const AnalysisTable = () => {
   });
 
   const impactActualComparisonData = useImpactComparison(
-    { ...params, comparedScenarioId: scenarioToCompare },
+    { ...omit(params, 'scenarioId'), comparedScenarioId: scenarioToCompare },
     {
       enabled: isComparisonEnabled && !currentScenario && isEnable,
     },
   );
   const impactScenarioComparisonData = useImpactScenarioComparison(
     {
-      ...params,
+      ...omit(params, 'scenarioId'),
       baseScenarioId: currentScenario,
       comparedScenarioId: scenarioToCompare,
     },


### PR DESCRIPTION
Fixed an issue where the `scenarioId` param was missing when the user selects a scenario in the analysis table view.

1. Visit analysis, and go to table mode.
2. Choice an scenario from the sidebar
3. Ensure the `scenarioId` param is in the request of `impact/table` endpoint