### PR TITLE
adding relative value in the chart tooltip

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Not include scenarios with 0 interventions in the scenario dropdowns for comparison [LANDGRIF-999](https://vizzuality.atlassian.net/browse/LANDGRIF-999)
 - Legend alignment in charts
 - Click on the legend also change the opacity of projected areas
+- Relative and absolute switcher was not working on the chart view [LANDGRIF-993](https://vizzuality.atlassian.net/browse/LANDGRIF-993)
 
 ## [v0.2.1]
 

--- a/client/src/containers/analysis-chart/comparison-chart/tooltip/component.tsx
+++ b/client/src/containers/analysis-chart/comparison-chart/tooltip/component.tsx
@@ -1,6 +1,8 @@
 import classNames from 'classnames';
 import { uniqBy } from 'lodash';
 
+import { useAppSelector } from 'store/hooks';
+import { scenarios } from 'store/features/analysis';
 import { NUMBER_FORMAT } from 'utils/number-format';
 
 type CustomTooltipProps = {
@@ -10,16 +12,19 @@ type CustomTooltipProps = {
     type: string;
     payload: {
       absoluteDifference: number;
+      percentageDifference: number;
     };
   }[];
 };
 
 const CustomTooltip: React.FC<CustomTooltipProps> = ({ payload }) => {
+  const { comparisonMode } = useAppSelector(scenarios);
   const tooltipData = uniqBy(payload, 'stroke');
   // We will assume that actual-data is the first item and the scenario is the second one
   const baseValue = tooltipData[0]?.value;
   const comparedValue = tooltipData[1]?.value;
   const absoluteDifference = tooltipData[1]?.payload.absoluteDifference;
+  const percentageDifference = tooltipData[1]?.payload.percentageDifference;
 
   return (
     <div className="p-4 text-gray-900 bg-white border border-gray-200 rounded-md">
@@ -44,7 +49,9 @@ const CustomTooltip: React.FC<CustomTooltipProps> = ({ payload }) => {
           >
             {absoluteDifference > 0 && '+'}
             {absoluteDifference < 0 && '-'}
-            {NUMBER_FORMAT(absoluteDifference)}
+            {comparisonMode === 'absolute'
+              ? NUMBER_FORMAT(absoluteDifference)
+              : `${NUMBER_FORMAT(percentageDifference)}%`}
           </div>
         )}
       </div>


### PR DESCRIPTION
### General description

Apply changes in the chart when the users click on relative or absolute.

### Designs

[_Link to the related design prototypes (if applicable)_](https://www.figma.com/file/7bmF29CIXDJwCpuloW5Nt6/%F0%9F%94%B5-Landgriffon---Redesign_BLUE?node-id=1870%3A171530)

### Testing instructions

1. Visit the analysis page and click on chart mode
2. In the phrase at the top you can click on relative or absolute.
3. Interacting with the chart, you have to see a change in the tooltip depending on the previous selection

## Checklist before merging

- [x] Branch name / PR includes the related Jira ticket Id.
- [ ] Tests to check core implementation / bug fix added.
- [ ] All checks in Continuous Integration workflow pass.
- [ ] Feature functionally tested by reviewer(s).
- [ ] Code reviewed by reviewer(s).
- [x] Documentation updated (README, CHANGELOG...) (if required)
