### PR TITLE
Fix filters

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -5,9 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## Unreleased
+
+## [v0.2.2]
+
+- Filters resetting when switching scenario [LANDGRIF-1021](https://vizzuality.atlassian.net/browse/LLANDGRIF-1021)
+
 ## [v0.2.1]
 
 ### Fixed
+
 - Analysis table is not updating selecting an scenario [LANDGRIF-1019](https://vizzuality.atlassian.net/browse/LANDGRIF-1019)
 
 ## [v0.2.0]

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "landgriffon-client",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/client/src/components/map/controls/zoom/component.tsx
+++ b/client/src/components/map/controls/zoom/component.tsx
@@ -17,7 +17,7 @@ const DISABLED_CLASSES = 'bg-gray-100 opacity-75 cursor-default';
 
 export const ZoomControl: React.FC<ZoomControlProps> = ({
   className,
-  viewport: { zoom, maxZoom, minZoom },
+  viewport: { zoom, maxZoom, minZoom } = {},
   onZoomChange,
 }) => {
   const increaseZoom = useCallback<MouseEventHandler<HTMLButtonElement>>(() => {

--- a/client/src/components/tree-select/component.tsx
+++ b/client/src/components/tree-select/component.tsx
@@ -110,6 +110,7 @@ const InnerTreeSelect = <IsMulti extends boolean>(
   ]);
 
   const [searchTerm, setSearchTerm] = useState<string>('');
+
   const [selected, setSelected] = useState<TreeSelectOption>(null);
   const [selectedKeys, setSelectedKeys] = useState<TreeProps['selectedKeys']>([]);
   const [expandedKeys, setExpandedKeys] = useState<TreeProps['expandedKeys']>([]);
@@ -296,6 +297,12 @@ const InnerTreeSelect = <IsMulti extends boolean>(
           onClick={(e) => {
             e.stopPropagation();
             setIsOpen(true);
+          }}
+          onKeyUp={(e) => {
+            // Pressing space closes the selector, so the event is prevented in that case
+            if (e.key !== ' ') return;
+            e.stopPropagation();
+            e.currentTarget.value += ' ';
           }}
           onChange={handleSearch}
           autoComplete="off"

--- a/client/src/components/tree-select/component.tsx
+++ b/client/src/components/tree-select/component.tsx
@@ -15,7 +15,7 @@ import { ChevronDownIcon, XIcon, SearchIcon } from '@heroicons/react/solid';
 import Tree from 'rc-tree';
 import Fuse from 'fuse.js';
 
-import { CHECKED_STRATEGIES } from './utils';
+import { CHECKED_STRATEGIES, flattenTree } from './utils';
 
 import Badge from 'components/badge';
 import Loading from 'components/loading';
@@ -220,7 +220,7 @@ const InnerTreeSelect = <IsMulti extends boolean>(
           children: childrenResult.map(({ item: itemChildren }) => itemChildren),
         };
       });
-      setFilteredKeys(filteredOptions.flatMap(flattenKeys));
+      setFilteredKeys(filteredOptions.flatMap((opt) => flattenTree(opt).map((opt) => opt.value)));
     }
   }, [fuse, options, searchTerm]);
 
@@ -487,15 +487,6 @@ const InnerTreeSelect = <IsMulti extends boolean>(
       )}
     </div>
   );
-};
-
-const flattenKeys: (root: TreeSelectOption) => TreeSelectOption['value'][] = (root) => {
-  const keys: TreeSelectOption['value'][] = [root.value];
-  if (root.children) {
-    keys.push(...root.children.flatMap(flattenKeys));
-  }
-
-  return keys;
 };
 
 const TreeSelect = React.forwardRef(InnerTreeSelect) as <IsMulti extends boolean = false>(

--- a/client/src/components/tree-select/utils.ts
+++ b/client/src/components/tree-select/utils.ts
@@ -1,3 +1,4 @@
+import type { TreeSelectOption } from './types';
 import type { DataNode, Key } from 'rc-tree/lib/interface';
 
 const ALL = (checkedKeys: Key[], checkedNodes: DataNode[]): DataNode['key'][] =>
@@ -27,3 +28,12 @@ const CHILD = (checkedKeys: Key[], checkedNodes: DataNode[]): DataNode['key'][] 
 };
 
 export const CHECKED_STRATEGIES = { ALL, PARENT, CHILD };
+
+export const flattenTree = (tree: TreeSelectOption) => {
+  const flattenedTree: TreeSelectOption[] = [tree];
+  if (tree.children) {
+    flattenedTree.push(...tree.children.flatMap(flattenTree));
+  }
+
+  return flattenedTree;
+};

--- a/client/src/containers/analysis-sidebar/component.tsx
+++ b/client/src/containers/analysis-sidebar/component.tsx
@@ -53,14 +53,14 @@ const ScenariosComponent: React.FC<{ scrollref?: MutableRefObject<HTMLDivElement
   }, [data]);
 
   const handleOnChange = useCallback(
-    (id: Scenario['id']) => {
-      // TO-DO: deprecated, we'll keep only for retro-compatibility
+    async (id: Scenario['id']) => {
+      await setScenarioId(id);
+      await setScenarioToCompare(null);
+
+      // TODO: deprecated, we'll keep only for retro-compatibility
       dispatch(setCurrentScenario(id));
       dispatch(setScenarioToCompareAction(null));
       dispatch(setComparisonEnabled(false));
-
-      setScenarioId(id);
-      setScenarioToCompare(null);
     },
     [dispatch, setScenarioId, setScenarioToCompare],
   );

--- a/client/src/containers/analysis-visualization/analysis-filters/more-filters/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-filters/more-filters/component.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState, useMemo } from 'react';
+import React, { useCallback, useState, useMemo, useEffect } from 'react';
 import { FilterIcon } from '@heroicons/react/solid';
 import {
   offset,
@@ -102,22 +102,26 @@ const MoreFilters = () => {
   const [counter, setCounter] = useState<number>(0);
   const [isOpen, setIsOpen] = useState(false);
 
-  // Restoring state from initial state from redux
-  useEffect(() => {
-    if (isOpen) return;
-    setSelectedFilters(moreFilters);
-  }, [isOpen, moreFilters]);
+  const handleOpen = useCallback(
+    (open: boolean) => {
+      setIsOpen(open);
+      if (open) {
+        setSelectedFilters(moreFilters);
+      }
+    },
+    [moreFilters],
+  );
 
   // Only the changes are applied when the user clicks on Apply
   const handleApply = useCallback(() => {
     dispatch(setFilters(selectedFilters));
-    setIsOpen(false);
-  }, [dispatch, selectedFilters]);
+    handleOpen(false);
+  }, [dispatch, handleOpen, selectedFilters]);
 
   // Close filters window
   const handleCancel = useCallback(() => {
-    setIsOpen(false);
-  }, []);
+    handleOpen(false);
+  }, [handleOpen]);
 
   // Restoring state from initial state only internally,
   // the user have to apply the changes
@@ -147,7 +151,7 @@ const MoreFilters = () => {
 
   const { reference, floating, strategy, x, y, context } = useFloating({
     open: isOpen,
-    onOpenChange: setIsOpen,
+    onOpenChange: handleOpen,
     placement: 'bottom-start',
     middleware: [offset({ mainAxis: 4 }), shift({ padding: 4 })],
   });
@@ -228,16 +232,12 @@ const MoreFilters = () => {
   );
 
   // Check current values are valid if the scenario changes
-  const handleScenarioChange = useCallback(
-    () => {
-      reviewFilterContent('materials', materials, materialOptions);
-      reviewFilterContent('locationTypes', locationTypes, locationTypes);
-      reviewFilterContent('origins', origins, origins);
-      reviewFilterContent('suppliers', suppliers, suppliers);
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [],
-  );
+  const handleScenarioChange = useCallback(() => {
+    reviewFilterContent('materials', materials, materialOptions);
+    reviewFilterContent('locationTypes', locationTypes, locationTypes);
+    reviewFilterContent('origins', origins, origins);
+    reviewFilterContent('suppliers', suppliers, suppliers);
+  }, [locationTypes, materialOptions, materials, origins, reviewFilterContent, suppliers]);
 
   useQueryParam('scenarioId', { onChange: handleScenarioChange });
 

--- a/client/src/containers/analysis-visualization/analysis-filters/origin-regions/index.tsx
+++ b/client/src/containers/analysis-visualization/analysis-filters/origin-regions/index.tsx
@@ -5,7 +5,7 @@ import Component from './component';
 import { useAppDispatch, useAppSelector } from 'store/hooks';
 import { analysisFilters, setFilter } from 'store/features/analysis/filters';
 
-const MaterialsFilter: React.FC<{ multiple?: boolean }> = (props) => {
+const OriginRegionsFilter: React.FC<{ multiple?: boolean }> = (props) => {
   const { multiple = false } = props;
   const dispatch = useAppDispatch();
   const filters = useAppSelector(analysisFilters);
@@ -17,4 +17,4 @@ const MaterialsFilter: React.FC<{ multiple?: boolean }> = (props) => {
   return <Component current={filters.origins} multiple={multiple} onChange={handleChange} />;
 };
 
-export default MaterialsFilter;
+export default OriginRegionsFilter;

--- a/client/src/containers/analysis-visualization/analysis-map/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-map/component.tsx
@@ -94,7 +94,8 @@ const AnalysisMap = () => {
     return pick(view, ['latitude', 'longitude', 'zoom']);
   }, []);
 
-  const [viewState, setViewState] = useQueryParam('viewState', INITIAL_VIEW_STATE, {
+  const [viewState, setViewState] = useQueryParam('viewState', {
+    defaultValue: INITIAL_VIEW_STATE,
     formatParam,
   });
 

--- a/client/src/hooks/h3-data/impact/comparison.ts
+++ b/client/src/hooks/h3-data/impact/comparison.ts
@@ -25,7 +25,11 @@ const useH3ComparisonData = <T = H3ImpactResponse>(
   const params = { ...rawParams, ...(vsActual ? {} : { baseScenarioId }) };
 
   const url = `/h3/map/impact/compare/${vsActual ? 'actual' : 'scenario'}/vs/scenario`;
-  const enabled = (options.enabled ?? true) && !!(params.indicatorId && params.year);
+
+  const enabled =
+    (options.enabled ?? true) &&
+    !!params.comparedScenarioId &&
+    !!(params.indicatorId && params.year);
 
   const query = useQuery(
     ['h3-data-impact', 'comparison', params],


### PR DESCRIPTION
### General description

This PR fixes the analysis filters sometimes clearing themselves.

When a scenario changed, we checked those filter to remove those that don't belong in the scenario, but didn't filter them recursively. Hence, selecting a child would invalidate the selection.

While another state solution isn't used, the `useQueryParam` hook was refactored to allow multiple observers in the same page. Otherwise, observing the current scenario without entering a infinite loop was next to impossible.

https://vizzuality.atlassian.net/browse/LANDGRIF-1021

## Checklist before merging

- [x] Branch name / PR includes the related Jira ticket Id.
- [ ] Tests to check core implementation / bug fix added.
- [ ] All checks in Continuous Integration workflow pass.
- [ ] Feature functionally tested by reviewer(s).
- [ ] Code reviewed by reviewer(s).
- [x] Documentation updated (README, CHANGELOG...) (if required)
