### PR TITLE
Fix invalid url being built when navigating analysis modes

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -7,7 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## Unreleased
 
+## [v0.2.3]
+
+### Fixed
+
+- Switching between comparison modes not working [LANDGRIF-1033](https://vizzuality.atlassian.net/browse/LLANDGRIF-1033)
+
 ## [v0.2.2]
+
+### Fixed
 
 - Filters resetting when switching scenario [LANDGRIF-1021](https://vizzuality.atlassian.net/browse/LLANDGRIF-1021)
 

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "landgriffon-client",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/client/src/hooks/queryParam/index.ts
+++ b/client/src/hooks/queryParam/index.ts
@@ -33,8 +33,6 @@ const parse = <T>(value: string): T => {
   }
 };
 
-const window = typeof global.window === 'undefined' ? null : global.window;
-
 const useQueryParam = <T, F = T>(
   name: string,
   {
@@ -90,10 +88,8 @@ const useQueryParam = <T, F = T>(
 
   useEffect(() => {
     const handleParam = (href: string) => {
-      const url = new URL(`${window.location.host}${href}`);
-      const newQueryStr = Object.fromEntries(url.searchParams.entries())[name];
-
-      const value = parse<T>(newQueryStr);
+      const params = new URLSearchParams(href.split('?')[1]);
+      const value = parse<T>(params.get(name) || undefined);
 
       setValue(value);
     };


### PR DESCRIPTION
### General description

In the `useQueryParam` hook a URL was built to access it's query params. This URLs values were not valid outside of local development, and navigation broke.

## Checklist before merging

- [x] Branch name / PR includes the related Jira ticket Id.
- [ ] Tests to check core implementation / bug fix added.
- [ ] All checks in Continuous Integration workflow pass.
- [ ] Feature functionally tested by reviewer(s).
- [ ] Code reviewed by reviewer(s).
- [x] Documentation updated (README, CHANGELOG...) (if required)
