### PR TITLE
Add scaler value to intervention impacts with provided coefficients

### DIFF
--- a/api/src/modules/indicator-records/indicator-records.service.ts
+++ b/api/src/modules/indicator-records/indicator-records.service.ts
@@ -379,7 +379,7 @@ export class IndicatorRecordsService extends AppBaseService<
     calculatedIndicatorValues.sourcingRecordId = sourcingData.sourcingRecordId;
     calculatedIndicatorValues.materialH3DataId = materialH3DataId;
 
-    // now we have here production data thta will later be saved as scaler in new IR:
+    // now we have here production data that will later be saved as scaler in new IR:
     calculatedIndicatorValues.production = productionValue;
     calculatedIndicatorValues.values = new Map();
 

--- a/api/src/modules/indicator-records/indicator-records.service.ts
+++ b/api/src/modules/indicator-records/indicator-records.service.ts
@@ -344,13 +344,16 @@ export class IndicatorRecordsService extends AppBaseService<
       materialId: string;
       geoRegionId: string;
       year: number;
-      sourcingRecord: SourcingRecord;
+      sourcingRecord?: SourcingRecord;
     },
     indicators: Indicator[],
     materialH3DataId: string,
   ): Promise<IndicatorRecordCalculatedValuesDto> {
     let productionValue: number;
-    if (sourcingData.sourcingRecord.indicatorRecords) {
+    if (
+      sourcingData.sourcingRecord &&
+      sourcingData.sourcingRecord.indicatorRecords
+    ) {
       productionValue = sourcingData.sourcingRecord.indicatorRecords[0].scaler;
     } else {
       const materialH3s: Map<MATERIAL_TO_H3_TYPE, H3Data> =

--- a/api/src/modules/indicator-records/services/impact-calculator.service.ts
+++ b/api/src/modules/indicator-records/services/impact-calculator.service.ts
@@ -185,7 +185,7 @@ export class ImpactCalculator {
             ),
           );
 
-        const rawDataForNewSourcingRecord =
+        const rawDataForNewSourcingRecord: IndicatorRawDataBySourcingRecord =
           await this.getImpactRawDataPerSourcingRecord(
             queryForActiveIndicators,
             materialId,

--- a/api/src/modules/indicator-records/services/impact-calculator.service.ts
+++ b/api/src/modules/indicator-records/services/impact-calculator.service.ts
@@ -27,10 +27,10 @@ import { MissingH3DataError } from 'modules/indicator-records/errors/missing-h3-
 import { IndicatorRecordCalculatedValuesDtoV2 } from 'modules/indicator-records/dto/indicator-record-calculated-values.dto';
 import { MaterialsToH3sService } from 'modules/materials/materials-to-h3s.service';
 import { IndicatorsService } from 'modules/indicators/indicators.service';
-import { IndicatorDependencyManager } from 'modules/impact/services/indicator-dependency-manager.service';
 import { SourcingRecord } from 'modules/sourcing-records/sourcing-record.entity';
 import { H3Data } from 'modules/h3-data/h3-data.entity';
 import { H3DataService } from 'modules/h3-data/h3-data.service';
+import { IndicatorDependencyManager } from 'modules/indicator-records/services/indicator-dependency-manager.service';
 
 /**
  * @description: This is PoC (Proof of Concept) for the updated LG methodology v0.1

--- a/api/src/modules/scenario-interventions/services/intervention-builder.service.ts
+++ b/api/src/modules/scenario-interventions/services/intervention-builder.service.ts
@@ -209,6 +209,7 @@ export class InterventionBuilder {
           materialId: sourcingLocation.materialId,
           adminRegionId: sourcingLocation.adminRegionId,
           year: sourcingRecord.year,
+          sourcingRecord: sourcingRecord,
         };
         sourcingRecord.indicatorRecords = useNewMethodology
           ? await this.impactCalculator.createIndicatorRecordsBySourcingRecords(

--- a/api/test/e2e/scenario-interventions/scenario-interventions.spec.ts
+++ b/api/test/e2e/scenario-interventions/scenario-interventions.spec.ts
@@ -525,6 +525,8 @@ describe('ScenarioInterventionsModule (e2e)', () => {
             rawDeforestation: 500,
             rawCarbon: 600,
             rawWater: 700,
+            satDeforestation: 800,
+            satDeforestationRisk: 900,
           });
 
         const preconditions: ScenarioInterventionPreconditions =

--- a/api/test/e2e/scenario-interventions/scenario-interventions.spec.ts
+++ b/api/test/e2e/scenario-interventions/scenario-interventions.spec.ts
@@ -516,18 +516,11 @@ describe('ScenarioInterventionsModule (e2e)', () => {
         'then correct Indicator records with scaler should be saved',
       async () => {
         jest
-          .spyOn(impactCalculatorService, 'getImpactRawDataPerSourcingRecord')
-          .mockResolvedValue({
-            production: 100,
-            harvestedArea: 200,
-            weightedAllHarvest: 300,
-            waterStressPerct: 400,
-            rawDeforestation: 500,
-            rawCarbon: 600,
-            rawWater: 700,
-            satDeforestation: 800,
-            satDeforestationRisk: 900,
-          });
+          .spyOn(
+            impactCalculatorService,
+            'getProductionValueForGeoregionAndMaterial',
+          )
+          .mockResolvedValue(100);
 
         const preconditions: ScenarioInterventionPreconditions =
           await createInterventionPreconditionsForSupplierChange();

--- a/api/test/e2e/scenario-interventions/scenario-interventions.spec.ts
+++ b/api/test/e2e/scenario-interventions/scenario-interventions.spec.ts
@@ -67,6 +67,8 @@ import { H3Data } from 'modules/h3-data/h3-data.entity';
 import { Indicator } from 'modules/indicators/indicator.entity';
 import { Unit } from 'modules/units/unit.entity';
 import { SourcingLocationGroup } from 'modules/sourcing-location-groups/sourcing-location-group.entity';
+import { dropH3DataMock, h3DataMock } from '../h3-data/mocks/h3-data.mock';
+import { h3MaterialExampleDataFixture } from '../h3-data/mocks/h3-fixtures';
 
 const expectedJSONAPIAttributes: string[] = [
   'title',
@@ -218,6 +220,10 @@ describe('ScenarioInterventionsModule (e2e)', () => {
       SourcingLocation,
       SourcingLocationGroup,
       Scenario,
+    ]);
+    await dropH3DataMock([
+      'fake_material_table2002',
+      'fake_replacing_material_table',
     ]);
   });
 
@@ -593,15 +599,23 @@ describe('ScenarioInterventionsModule (e2e)', () => {
       });
 
       const replacingMaterial: Material = await createMaterial();
-      const h3data = await createH3Data();
+
+      const h3ReplacingMaterial = await h3DataMock({
+        h3TableName: 'fakeReplacingMaterialTable',
+        h3ColumnName: 'fakeReplacingMaterialColumn',
+        additionalH3Data: h3MaterialExampleDataFixture,
+        year: 2002,
+      });
+
       await createMaterialToH3(
         replacingMaterial.id,
-        h3data.id,
+        h3ReplacingMaterial.id,
         MATERIAL_TO_H3_TYPE.HARVEST,
       );
+
       await createMaterialToH3(
         replacingMaterial.id,
-        h3data.id,
+        h3ReplacingMaterial.id,
         MATERIAL_TO_H3_TYPE.PRODUCER,
       );
 
@@ -706,15 +720,22 @@ describe('ScenarioInterventionsModule (e2e)', () => {
         });
 
         const replacingMaterial: Material = await createMaterial();
-        const h3data = await createH3Data();
+        const h3ReplacingMaterial = await h3DataMock({
+          h3TableName: 'fakeReplacingMaterialTable',
+          h3ColumnName: 'fakeReplacingMaterialColumn',
+          additionalH3Data: h3MaterialExampleDataFixture,
+          year: 2002,
+        });
+
         await createMaterialToH3(
           replacingMaterial.id,
-          h3data.id,
+          h3ReplacingMaterial.id,
           MATERIAL_TO_H3_TYPE.HARVEST,
         );
+
         await createMaterialToH3(
           replacingMaterial.id,
-          h3data.id,
+          h3ReplacingMaterial.id,
           MATERIAL_TO_H3_TYPE.PRODUCER,
         );
 
@@ -803,15 +824,22 @@ describe('ScenarioInterventionsModule (e2e)', () => {
         });
 
         const replacingMaterial: Material = await createMaterial();
-        const h3data = await createH3Data();
+        const h3ReplacingMaterial = await h3DataMock({
+          h3TableName: 'fakeReplacingMaterialTable',
+          h3ColumnName: 'fakeReplacingMaterialColumn',
+          additionalH3Data: h3MaterialExampleDataFixture,
+          year: 2002,
+        });
+
         await createMaterialToH3(
           replacingMaterial.id,
-          h3data.id,
+          h3ReplacingMaterial.id,
           MATERIAL_TO_H3_TYPE.HARVEST,
         );
+
         await createMaterialToH3(
           replacingMaterial.id,
-          h3data.id,
+          h3ReplacingMaterial.id,
           MATERIAL_TO_H3_TYPE.PRODUCER,
         );
 

--- a/api/test/integration/indicator-record/indicator-records.service.spec.ts
+++ b/api/test/integration/indicator-record/indicator-records.service.spec.ts
@@ -10,6 +10,7 @@ import {
   createBusinessUnit,
   createGeoRegion,
   createH3Data,
+  createIndicatorRecord,
   createMaterial,
   createMaterialToH3,
   createSourcingLocation,
@@ -59,6 +60,7 @@ import { SupplierRepository } from '../../../src/modules/suppliers/supplier.repo
 import { GeoRegionRepository } from '../../../src/modules/geo-regions/geo-region.repository';
 import { MaterialRepository } from '../../../src/modules/materials/material.repository';
 import { CachedDataRepository } from '../../../src/modules/cached-data/cached-data.repository';
+import { SourcingRecord } from 'modules/sourcing-records/sourcing-record.entity';
 
 describe('Indicator Records Service', () => {
   let indicatorRecordRepository: IndicatorRecordRepository;
@@ -150,12 +152,20 @@ describe('Indicator Records Service', () => {
         MATERIAL_TO_H3_TYPE.HARVEST,
       );
 
+      const fakeIndicatorRecordForScaler: IndicatorRecord =
+        await createIndicatorRecord();
+
+      indicatorPreconditions.sourcingRecord1.indicatorRecords = [
+        fakeIndicatorRecordForScaler,
+      ];
+
       const sourcingData = {
         sourcingRecordId: indicatorPreconditions.sourcingRecord1.id,
         tonnage: indicatorPreconditions.sourcingRecord1.tonnage,
         geoRegionId: indicatorPreconditions.sourcingLocation1.geoRegionId,
         materialId: indicatorPreconditions.sourcingLocation1.materialId,
         year: indicatorPreconditions.sourcingRecord1.year,
+        sourcingRecord: indicatorPreconditions.sourcingRecord1,
       };
 
       const providedCoefficients: IndicatorCoefficientsDto = {
@@ -183,11 +193,24 @@ describe('Indicator Records Service', () => {
     test('When creating Indicator Records providing indicator coefficients, it should create the records properly', async () => {
       // ARRANGE
       const indicatorPreconditions = await createPreconditions();
-      const fakeH3Data = await createH3Data();
+
+      const h3Material = await h3DataMock({
+        h3TableName: 'fakeMaterialTable2002',
+        h3ColumnName: 'fakeMaterialColumn2002',
+        additionalH3Data: h3MaterialExampleDataFixture,
+        year: 2002,
+      });
+
       const materialH3Data = await createMaterialToH3(
         indicatorPreconditions.material1.id,
-        fakeH3Data.id,
+        h3Material.id,
         MATERIAL_TO_H3_TYPE.HARVEST,
+      );
+
+      await createMaterialToH3(
+        indicatorPreconditions.material1.id,
+        h3Material.id,
+        MATERIAL_TO_H3_TYPE.PRODUCER,
       );
 
       const sourcingData = {
@@ -196,6 +219,7 @@ describe('Indicator Records Service', () => {
         geoRegionId: indicatorPreconditions.sourcingLocation1.geoRegionId,
         materialId: indicatorPreconditions.sourcingLocation1.materialId,
         year: indicatorPreconditions.sourcingRecord1.year,
+        sourcingRecord: indicatorPreconditions.sourcingRecord1,
       };
 
       const providedCoefficients: IndicatorCoefficientsDto = {
@@ -223,7 +247,7 @@ describe('Indicator Records Service', () => {
         materialH3Data,
         sourcingData.sourcingRecordId,
         350,
-        null,
+        1610,
         calculatedIndicators,
       );
       await checkCreatedIndicatorRecord(
@@ -232,7 +256,7 @@ describe('Indicator Records Service', () => {
         materialH3Data,
         sourcingData.sourcingRecordId,
         100,
-        null,
+        1610,
         calculatedIndicators,
       );
       await checkCreatedIndicatorRecord(
@@ -241,7 +265,7 @@ describe('Indicator Records Service', () => {
         materialH3Data,
         sourcingData.sourcingRecordId,
         400,
-        null,
+        1610,
         calculatedIndicators,
       );
       await checkCreatedIndicatorRecord(
@@ -250,19 +274,22 @@ describe('Indicator Records Service', () => {
         materialH3Data,
         sourcingData.sourcingRecordId,
         200,
-        null,
+        1610,
         calculatedIndicators,
       );
     });
 
     test("When creating indicator record with no provided coefficients, and there's no H3 data for the given material, it should throw an error", async () => {
       //ARRANGE
+
+      const randomSourcingRecord: SourcingRecord = await createSourcingRecord();
       const sourcingData = {
         sourcingRecordId: UUIDv4(),
         geoRegionId: UUIDv4(),
         materialId: UUIDv4(),
         tonnage: 10000,
         year: 2010,
+        sourcingRecord: randomSourcingRecord,
       };
 
       jest
@@ -292,6 +319,7 @@ describe('Indicator Records Service', () => {
         geoRegionId: indicatorPreconditions.sourcingLocation2.geoRegionId,
         materialId: indicatorPreconditions.sourcingLocation2.materialId,
         year: indicatorPreconditions.sourcingRecord2.year,
+        sourcingRecord: indicatorPreconditions.sourcingRecord2,
       };
 
       const h3Material = await h3DataMock({
@@ -324,12 +352,19 @@ describe('Indicator Records Service', () => {
       //ARRANGE
       const indicatorPreconditions = await createPreconditions();
 
+      const fakeIndicatorRecordForScaler: IndicatorRecord =
+        await createIndicatorRecord();
+      indicatorPreconditions.sourcingRecord2.indicatorRecords = [
+        fakeIndicatorRecordForScaler,
+      ];
+
       const sourcingData = {
         sourcingRecordId: indicatorPreconditions.sourcingRecord2.id,
         tonnage: indicatorPreconditions.sourcingRecord2.tonnage,
         geoRegionId: indicatorPreconditions.sourcingLocation2.geoRegionId,
         materialId: indicatorPreconditions.sourcingLocation2.materialId,
         year: indicatorPreconditions.sourcingRecord2.year,
+        sourcingRecord: indicatorPreconditions.sourcingRecord2,
       };
 
       const h3Material = await h3DataMock({
@@ -376,6 +411,7 @@ describe('Indicator Records Service', () => {
         geoRegionId: indicatorPreconditions.sourcingLocation2.geoRegionId,
         materialId: indicatorPreconditions.sourcingLocation2.materialId,
         year: indicatorPreconditions.sourcingRecord2.year,
+        sourcingRecord: indicatorPreconditions.sourcingRecord2,
       };
 
       const h3Material = await h3DataMock({
@@ -563,6 +599,7 @@ describe('Indicator Records Service', () => {
         geoRegionId: indicatorPreconditions.sourcingLocation2.geoRegionId,
         materialId: indicatorPreconditions.sourcingLocation2.materialId,
         year: indicatorPreconditions.sourcingRecord2.year,
+        sourcingRecord: indicatorPreconditions.sourcingRecord2,
       };
 
       const h3MaterialProducer = await h3DataMock({
@@ -670,6 +707,7 @@ describe('Indicator Records Service', () => {
         geoRegionId: indicatorPreconditions.sourcingLocation2.geoRegionId,
         materialId: indicatorPreconditions.sourcingLocation2.materialId,
         year: indicatorPreconditions.sourcingRecord2.year,
+        sourcingRecord: indicatorPreconditions.sourcingRecord2,
       };
 
       const h3MaterialHarvest = await h3DataMock({

--- a/api/test/utils/scenario-interventions-preconditions.ts
+++ b/api/test/utils/scenario-interventions-preconditions.ts
@@ -24,6 +24,8 @@ import {
   createSupplier,
 } from '../entity-mocks';
 import { MATERIAL_TO_H3_TYPE } from '../../src/modules/materials/material-to-h3.entity';
+import { h3DataMock } from '../e2e/h3-data/mocks/h3-data.mock';
+import { h3MaterialExampleDataFixture } from '../e2e/h3-data/mocks/h3-fixtures';
 
 export interface ScenarioInterventionPreconditions {
   scenario: Scenario;
@@ -41,6 +43,10 @@ export interface ScenarioInterventionPreconditions {
   businessUnit2: BusinessUnit;
   sourcingLocation1: SourcingLocation;
   sourcingLocation2: SourcingLocation;
+  indicator1: Indicator;
+  indicator2: Indicator;
+  indicator3: Indicator;
+  indicator4: Indicator;
 }
 
 export async function createInterventionPreconditions(): Promise<ScenarioInterventionPreconditions> {
@@ -100,25 +106,37 @@ export async function createInterventionPreconditions(): Promise<ScenarioInterve
   await createH3Data({ indicatorId: indicator2.id });
   await createH3Data({ indicatorId: indicator3.id });
   await createH3Data({ indicatorId: indicator4.id });
+
+  // creating h3 data for material to be able to get scaler for new indicator records
+
+  const h3Material = await h3DataMock({
+    h3TableName: 'fakeMaterialTable2002',
+    h3ColumnName: 'fakeMaterialColumn2002',
+    additionalH3Data: h3MaterialExampleDataFixture,
+    year: 2002,
+  });
+
   await createMaterialToH3(
     material1Descendant.id,
-    h3data1.id,
+    h3Material.id,
     MATERIAL_TO_H3_TYPE.HARVEST,
   );
+
   await createMaterialToH3(
     material1Descendant.id,
-    h3data1.id,
+    h3Material.id,
     MATERIAL_TO_H3_TYPE.PRODUCER,
   );
 
   await createMaterialToH3(
     material2.id,
-    h3data1.id,
+    h3Material.id,
     MATERIAL_TO_H3_TYPE.HARVEST,
   );
+
   await createMaterialToH3(
     material2.id,
-    h3data1.id,
+    h3Material.id,
     MATERIAL_TO_H3_TYPE.PRODUCER,
   );
 
@@ -221,23 +239,42 @@ export async function createInterventionPreconditions(): Promise<ScenarioInterve
     businessUnit2,
     sourcingLocation1,
     sourcingLocation2,
+    indicator1,
+    indicator2,
+    indicator3,
+    indicator4,
   };
 }
 
 export async function createInterventionPreconditionsWithMultipleYearRecords(): Promise<ScenarioInterventionPreconditions> {
   const scenarioInterventionPreconditions: ScenarioInterventionPreconditions =
     await createInterventionPreconditions();
-  await createSourcingRecord({
+  const newSourcingRecord1: SourcingRecord = await createSourcingRecord({
     sourcingLocationId: scenarioInterventionPreconditions.sourcingLocation1.id,
     year: 2019,
     tonnage: 550,
   });
 
-  await createSourcingRecord({
+  const newSourcingRecord2: SourcingRecord = await createSourcingRecord({
     sourcingLocationId: scenarioInterventionPreconditions.sourcingLocation2.id,
     year: 2019,
     tonnage: 650,
   });
+
+  await createIndicatorRecordForIntervention(
+    {
+      indicator: scenarioInterventionPreconditions.indicator1,
+      value: 2000,
+    },
+    newSourcingRecord1,
+  );
+  await createIndicatorRecordForIntervention(
+    {
+      indicator: scenarioInterventionPreconditions.indicator1,
+      value: 2000,
+    },
+    newSourcingRecord2,
+  );
 
   return scenarioInterventionPreconditions;
 }

--- a/api/test/utils/scenario-interventions-preconditions.ts
+++ b/api/test/utils/scenario-interventions-preconditions.ts
@@ -4,10 +4,8 @@ import { Material } from 'modules/materials/material.entity';
 import { Scenario } from 'modules/scenarios/scenario.entity';
 import { SourcingLocation } from 'modules/sourcing-locations/sourcing-location.entity';
 import { Supplier } from 'modules/suppliers/supplier.entity';
-import { IndicatorRecord } from 'modules/indicator-records/indicator-record.entity';
 import {
   Indicator,
-  INDICATOR_TYPES,
   INDICATOR_TYPES_NEW,
 } from 'modules/indicators/indicator.entity';
 import { SourcingRecord } from 'modules/sourcing-records/sourcing-record.entity';
@@ -109,7 +107,7 @@ export async function createInterventionPreconditions(): Promise<ScenarioInterve
     nameCode: INDICATOR_TYPES_NEW.DEFORESTATION_RISK,
   });
 
-  const indicator5: Indicator = await createIndicator({
+  await createIndicator({
     name: 'land use',
     nameCode: INDICATOR_TYPES_NEW.LAND_USE,
   });
@@ -242,6 +240,7 @@ export async function createInterventionPreconditions(): Promise<ScenarioInterve
     {
       indicator: indicator1,
       value: 2000,
+      scaler: 222,
     },
     sourcingRecord2,
   );
@@ -250,6 +249,7 @@ export async function createInterventionPreconditions(): Promise<ScenarioInterve
     {
       indicator: indicator2,
       value: 2200,
+      scaler: 222,
     },
     sourcingRecord2,
   );


### PR DESCRIPTION
### General description

This PR solves the scaler bug when creating new indicator records with provided coefficients, which mostly happens when creating scenario interventions:
- if type of intervention is Change of coefficients, service receives 'old' indicator records that already have scaler value and copies it to new Indicator Records of the intervention
- if type of intervention is Change of material or supplier that comes with provided coefficients, service will get scaler value for new location/material using the previously implemented queries for that

Tests update: scenario intervention tests preconditions changed to new methodology, smalltest for scaler bug fix added

### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

_Provide minimal instructions on how to test this PR._

- Apart from the added feature / bug fix, check overall performance, styling...

## Checklist before merging

- [ ] Branch name / PR includes the related Jira ticket Id.
- [ ] Tests to check core implementation / bug fix added.
- [ ] All checks in Continuous Integration workflow pass.
- [ ] Feature functionally tested by reviewer(s).
- [ ] Code reviewed by reviewer(s).
- [ ] Documentation updated (README, CHANGELOG...) (if required)
