### PR TITLE
changed key value in tooltip items of impact chart

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Updated styles for tree-selectors according the design
 
 ### Fixed
-
+- Changed key value for items in Impact chart tooltip. [LANDGRIF-1056](https://vizzuality.atlassian.net/browse/LANDGRIF-1056)
 - Not include scenarios with 0 interventions in the scenario dropdowns for comparison [LANDGRIF-999](https://vizzuality.atlassian.net/browse/LANDGRIF-999)
 - Legend alignment in charts
 - Click on the legend also change the opacity of projected areas

--- a/client/src/containers/analysis-chart/impact-chart/tooltip/component.tsx
+++ b/client/src/containers/analysis-chart/impact-chart/tooltip/component.tsx
@@ -2,6 +2,7 @@ import { NUMBER_FORMAT } from 'utils/number-format';
 
 type CustomTooltipProps = {
   payload: {
+    dataKey: string;
     value: number;
     name: string;
     color: string;
@@ -15,7 +16,7 @@ const CustomTooltip: React.FC<CustomTooltipProps> = ({ payload }) => (
       {payload
         .filter(({ type }) => type !== 'none')
         .map((item) => (
-          <li key={item.value} className="flex justify-between space-x-2">
+          <li key={item.dataKey} className="flex justify-between space-x-2">
             <div
               className="w-2 h-3 rounded shrink-0 grow-0"
               style={{ backgroundColor: item.color }}


### PR DESCRIPTION
### General description

![image](https://user-images.githubusercontent.com/999124/201647883-db35eac3-2945-4a75-9b44-b5de6e854371.png)

Previously the `key` value was set by the `value` property of the payload. In some cases, this value could be `0` leading to produce more items than expected and some unexpected behaviours in the tooltip. Changing it to a unique key fixes should fix the issue.

### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

_Provide minimal instructions on how to test this PR._

- Apart from the added feature / bug fix, check overall performance, styling...

## Checklist before merging

- [x] Branch name / PR includes the related Jira ticket Id.
- [ ] Tests to check core implementation / bug fix added.
- [ ] All checks in Continuous Integration workflow pass.
- [ ] Feature functionally tested by reviewer(s).
- [ ] Code reviewed by reviewer(s).
- [x] Documentation updated (README, CHANGELOG...) (if required)
