### PR TITLE
Fix tree child select

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Fixed CHILD select strategy not working with empty children list [LANDGRIF-1079](https://vizzuality.atlassian.net/browse/LANDGRIF-1079)
 - Update rows expanded state on analysis table [LANDGRIF-967](https://vizzuality.atlassian.net/browse/LANDGRIF-967)
 - Horizontal scroll on the legend [LANDGRIF-1082](https://vizzuality.atlassian.net/browse/LANDGRIF-1082)
 - Format of numbers of the contextual layers in the legend [LANDGRIF-1090](https://vizzuality.atlassian.net/browse/LANDGRIF-1090)
@@ -86,6 +87,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Added interaction in the charts clicking on the legend [LANDGRIF-772](https://vizzuality.atlassian.net/browse/LANDGRIF-772)
 
 ### Changed
+
 - Removed minus sign (`-`) from absolute difference in comparison charts. [LANDGRIF-1046](https://vizzuality.atlassian.net/browse/LANDGRIF-1046)
 - Bigger table page size [LANDGRIF-922](https://vizzuality.atlassian.net/browse/LANDGRIF-922)
 - `ACTUAL_DATA` was removed and a null scenario id is used in it's place

--- a/client/src/components/tree-select/component.tsx
+++ b/client/src/components/tree-select/component.tsx
@@ -69,6 +69,10 @@ const CustomCheckbox = React.forwardRef<
     (ref as RefObject<HTMLInputElement>).current.indeterminate = !checked && indeterminate;
   }, [checked, indeterminate, ref]);
 
+  const onChange = useCallback(() => {
+    // noop
+  }, []);
+
   return (
     <input
       type="checkbox"
@@ -78,6 +82,7 @@ const CustomCheckbox = React.forwardRef<
         className,
       )}
       checked={checked}
+      onChange={onChange}
       {...props}
       ref={ref}
     />

--- a/client/src/components/tree-select/utils.ts
+++ b/client/src/components/tree-select/utils.ts
@@ -38,7 +38,9 @@ const PARENT = (checkedKeys: Key[], checkedNodes: TreeDataNode[]): TreeDataNode[
 };
 
 const CHILD = (checkedKeys: Key[], checkedNodes: TreeDataNode[]): TreeDataNode['value'][] => {
-  const onlyChildren = checkedNodes.filter((node) => !node?.children).map(({ value }) => value);
+  const onlyChildren = checkedNodes
+    .filter((node) => !node.children || node.children.length === 0)
+    .map(({ value }) => value);
   return onlyChildren;
 };
 


### PR DESCRIPTION
### General description

This PR fixes tree selects with `CHILD` select strategy not working.

The issue was caused by the code checking if the node had children interpreting an empty list as having children.

### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

_Provide minimal instructions on how to test this PR._

- Apart from the added feature / bug fix, check overall performance, styling...

## Checklist before merging

- [x] Branch name / PR includes the related Jira ticket Id.
- [ ] Tests to check core implementation / bug fix added.
- [x] All checks in Continuous Integration workflow pass.
- [ ] Feature functionally tested by reviewer(s).
- [ ] Code reviewed by reviewer(s).
- [x] Documentation updated (README, CHANGELOG...) (if required)
