### PR TITLE
Update creating intervention to save sourcing locations in chunks

### DIFF
--- a/api/src/modules/scenario-interventions/scenario-intervention.repository.ts
+++ b/api/src/modules/scenario-interventions/scenario-intervention.repository.ts
@@ -170,25 +170,14 @@ export class ScenarioInterventionRepository extends Repository<ScenarioIntervent
       this.logger.log(
         `Saving ${locations.length} Sourcing Locations for Intervention with Id: ${newIntervention.id}`,
       );
-      const sourcingLocationInsertPromises: Array<Promise<InsertResult>> = [];
-
-      for (const [index, dataChunk] of chunk(
-        locations,
-        batchChunkSize,
-      ).entries()) {
-        this.logger.debug(
-          `Inserting sourcing locations chunk #${index} (${dataChunk.length} items)...`,
+      const sourcingLocationInsertPromises: Array<Promise<InsertResult>> =
+        this.createInsertPromises(
+          locations,
+          batchChunkSize,
+          SourcingLocation,
+          queryRunner,
         );
 
-        sourcingLocationInsertPromises.push(
-          queryRunner.manager
-            .createQueryBuilder()
-            .insert()
-            .into(SourcingLocation)
-            .values(dataChunk)
-            .execute(),
-        );
-      }
       this.logger.log(
         `Saving ${sourcingLocationInsertPromises.length} Sourcing Locations chunks`,
       );
@@ -197,25 +186,14 @@ export class ScenarioInterventionRepository extends Repository<ScenarioIntervent
       this.logger.log(
         `Saving ${records.length} Sourcing Records for Intervention with Id: ${newIntervention.id}`,
       );
-      const sourcingRecordInsertPromises: Array<Promise<InsertResult>> = [];
-
-      for (const [index, dataChunk] of chunk(
-        records,
-        batchChunkSize,
-      ).entries()) {
-        this.logger.debug(
-          `Inserting sourcing record chunk #${index} (${dataChunk.length} items)...`,
+      const sourcingRecordInsertPromises: Array<Promise<InsertResult>> =
+        this.createInsertPromises(
+          records,
+          batchChunkSize,
+          SourcingRecord,
+          queryRunner,
         );
 
-        sourcingRecordInsertPromises.push(
-          queryRunner.manager
-            .createQueryBuilder()
-            .insert()
-            .into(SourcingRecord)
-            .values(dataChunk)
-            .execute(),
-        );
-      }
       this.logger.log(
         `Saving ${sourcingRecordInsertPromises.length} Sourcing Records chunks`,
       );
@@ -223,23 +201,14 @@ export class ScenarioInterventionRepository extends Repository<ScenarioIntervent
       this.logger.log(
         `Saving ${impacts.length} Indicator Records for Intervention with Id: ${newIntervention.id}`,
       );
-      const indicatorRecordInsertPromises: Array<Promise<InsertResult>> = [];
-      for (const [index, dataChunk] of chunk(
-        impacts,
-        batchChunkSize,
-      ).entries()) {
-        this.logger.debug(
-          `Inserting indicator record chunk #${index} (${dataChunk.length} items)...`,
+      const indicatorRecordInsertPromises: Array<Promise<InsertResult>> =
+        this.createInsertPromises(
+          impacts,
+          batchChunkSize,
+          IndicatorRecord,
+          queryRunner,
         );
-        indicatorRecordInsertPromises.push(
-          queryRunner.manager
-            .createQueryBuilder()
-            .insert()
-            .into(IndicatorRecord)
-            .values(dataChunk)
-            .execute(),
-        );
-      }
+
       this.logger.log(
         `Saving ${indicatorRecordInsertPromises.length} Indicator Records chunks`,
       );
@@ -291,5 +260,31 @@ export class ScenarioInterventionRepository extends Repository<ScenarioIntervent
       // release query runner which is manually created
       await queryRunner.release();
     }
+  }
+
+  private createInsertPromises(
+    data: any,
+    batchChunkSize: number,
+    entity: any,
+    queryRunner: QueryRunner,
+  ): Array<Promise<InsertResult>> {
+    const insertPromises: Array<Promise<InsertResult>> = [];
+
+    for (const [index, dataChunk] of chunk(data, batchChunkSize).entries()) {
+      this.logger.debug(
+        `Inserting chunk #${index} (${dataChunk.length} items)...`,
+      );
+
+      insertPromises.push(
+        queryRunner.manager
+          .createQueryBuilder()
+          .insert()
+          .into(entity)
+          .values(dataChunk)
+          .execute(),
+      );
+    }
+
+    return insertPromises;
   }
 }


### PR DESCRIPTION
### General description

Updating saveNewIntervention method of ScenarioInterventionrepository to save Sourcing Locations in chunks (same as it is done for Sourcing Records and Indicator Records), since in some cases the amount of Sourcing Locations to be inserted by creating new intervention exceeds pg limitation

### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

_Provide minimal instructions on how to test this PR._

- Apart from the added feature / bug fix, check overall performance, styling...

## Checklist before merging

- [ ] Branch name / PR includes the related Jira ticket Id.
- [ ] Tests to check core implementation / bug fix added.
- [ ] All checks in Continuous Integration workflow pass.
- [ ] Feature functionally tested by reviewer(s).
- [ ] Code reviewed by reviewer(s).
- [ ] Documentation updated (README, CHANGELOG...) (if required)
