### PR TITLE
fix(Impact Tables): Fixes call stack exceeded error

### DIFF
--- a/api/src/modules/impact/impact.service.ts
+++ b/api/src/modules/impact/impact.service.ts
@@ -371,11 +371,18 @@ export class ImpactService {
     this.logger.log('Building Impact Table...');
     const { groupBy, startYear, endYear } = queryDto;
     const impactTable: ImpactTableDataByIndicator[] = [];
+
     // Create a range of years by start and endYears
     const rangeOfYears: number[] = range(startYear, endYear + 1);
-    const lastYearWithData: number = Math.max(
-      ...dataForImpactTable.map((el: ImpactTableData) => el.year),
-    );
+
+    // NOTE: the impact Table Data can be quite large, so to calculate the maximum number of years is not as trivial
+    // as using Math.max(...impactTable.map(...)) since the call stack will be exceeded because of no of arguments
+    const yearsWithData: Set<number> = new Set();
+    for (const impactTableData of dataForImpactTable) {
+      yearsWithData.add(impactTableData.year);
+    }
+    const lastYearWithData: number = Math.max(...yearsWithData.values());
+
     // Append data by indicator and add its unit.symbol as metadata. We need awareness of this loop during the whole process
     indicators.forEach((indicator: Indicator, indicatorValuesIndex: number) => {
       const calculatedData: ImpactTableRows[] = [];


### PR DESCRIPTION
### General description

Fixes the call stack exceeded error when trying to determining the max year present in a large group of impact table data when building the impact table.

### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

_Provide minimal instructions on how to test this PR._

- Apart from the added feature / bug fix, check overall performance, styling...

## Checklist before merging

- [ ] Branch name / PR includes the related Jira ticket Id.
- [ ] Tests to check core implementation / bug fix added.
- [ ] All checks in Continuous Integration workflow pass.
- [ ] Feature functionally tested by reviewer(s).
- [ ] Code reviewed by reviewer(s).
- [ ] Documentation updated (README, CHANGELOG...) (if required)
