### PR TITLE
(feat) LANDGRIF-1120 crud owned scenarios

### DIFF
--- a/api/src/modules/authorization/authorization.module.ts
+++ b/api/src/modules/authorization/authorization.module.ts
@@ -2,12 +2,11 @@ import { Module } from '@nestjs/common';
 import { RequestScopeModule } from 'nj-request-scope';
 
 import { AccessControl } from 'modules/authorization/access-control.service';
-
-export const ACCESS_CONTROL: string = 'ACCESS_CONTROL';
+import { ScenariosAccessControl } from 'modules/authorization/modules/scenarios.access-control.service';
 
 @Module({
   imports: [RequestScopeModule],
-  providers: [AccessControl],
-  exports: [AccessControl],
+  providers: [AccessControl, ScenariosAccessControl],
+  exports: [AccessControl, ScenariosAccessControl],
 })
 export class AuthorizationModule {}

--- a/api/src/modules/authorization/modules/scenario-ownership.interceptor.ts
+++ b/api/src/modules/authorization/modules/scenario-ownership.interceptor.ts
@@ -1,0 +1,63 @@
+import {
+  applyDecorators,
+  CallHandler,
+  ExecutionContext,
+  ForbiddenException,
+  Injectable,
+  NestInterceptor,
+  SetMetadata,
+  UseInterceptors,
+} from '@nestjs/common';
+import { ScenariosAccessControl } from 'modules/authorization/modules/scenarios.access-control.service';
+import { Observable } from 'rxjs';
+import { Request } from 'express';
+import { Reflector } from '@nestjs/core';
+
+interface ScenarioCheckWhiteListOptions {
+  isPublic: boolean;
+}
+
+const SCENARIO_CHECK_METADATA_KEY: string = 'scenarioChecks';
+
+@Injectable()
+export class ScenarioOwnershipInterceptor implements NestInterceptor {
+  constructor(
+    private readonly scenarioAcl: ScenariosAccessControl,
+    private readonly reflector: Reflector,
+  ) {}
+
+  async intercept(
+    context: ExecutionContext,
+    next: CallHandler,
+  ): Promise<Observable<any>> {
+    const request: Request = context.switchToHttp().getRequest();
+    const scenarioId: string = request.params.id;
+    const additionalChecks: ScenarioCheckWhiteListOptions =
+      this.reflector.getAllAndOverride<ScenarioCheckWhiteListOptions>(
+        SCENARIO_CHECK_METADATA_KEY,
+        [context.getHandler(), context.getClass()],
+      );
+    if (this.scenarioAcl.isUserAdmin()) {
+      return next.handle();
+    }
+    let isPublic: boolean = false;
+    const isOwned: boolean = await this.scenarioAcl.ownsScenario(scenarioId);
+    if (additionalChecks?.isPublic) {
+      isPublic = await this.scenarioAcl.isScenarioPublic(scenarioId);
+    }
+
+    if (!isPublic && !isOwned) {
+      throw new ForbiddenException();
+    }
+    return next.handle();
+  }
+}
+
+export function UserOwnsScenario(
+  whiteListIf?: ScenarioCheckWhiteListOptions,
+): any {
+  return applyDecorators(
+    SetMetadata(SCENARIO_CHECK_METADATA_KEY, whiteListIf),
+    UseInterceptors(ScenarioOwnershipInterceptor),
+  );
+}

--- a/api/src/modules/authorization/modules/scenarios.access-control.service.ts
+++ b/api/src/modules/authorization/modules/scenarios.access-control.service.ts
@@ -1,0 +1,37 @@
+import { AccessControl } from 'modules/authorization/access-control.service';
+import { Injectable } from '@nestjs/common';
+import { Repository } from 'typeorm';
+import { Scenario } from 'modules/scenarios/scenario.entity';
+
+/**
+ * @desciption: Service extending base AccessControl which receives a fresh request object from it each time.
+ *              Use this class ta perform user's specific authorisation over scenarios, based on roles/permissions
+ */
+
+@Injectable()
+export class ScenariosAccessControl extends AccessControl {
+  private getScenarioBaseRepository(): Repository<Scenario> {
+    return super.getBaseRepositoryFor(Scenario);
+  }
+
+  async ownsScenario(scenarioId: string): Promise<boolean> {
+    if (super.isUserAdmin()) {
+      return true;
+    }
+    const ownedScenario: Scenario | null =
+      await this.getScenarioBaseRepository().findOne({
+        where: { id: scenarioId, userId: super.getUserId() },
+      });
+
+    return !!ownedScenario;
+  }
+
+  async isScenarioPublic(scenarioId: string): Promise<boolean> {
+    const publicScenario: Scenario | null =
+      await this.getScenarioBaseRepository().findOne({
+        where: { id: scenarioId, isPublic: true },
+      });
+
+    return !!publicScenario;
+  }
+}

--- a/api/src/modules/scenarios/scenarios.controller.ts
+++ b/api/src/modules/scenarios/scenarios.controller.ts
@@ -35,6 +35,7 @@ import { UpdateScenarioDto } from 'modules/scenarios/dto/update.scenario.dto';
 import { PaginationMeta } from 'utils/app-base.service';
 import { SetUserInterceptor } from 'decorators/set-user.interceptor';
 import { ScenarioIntervention } from 'modules/scenario-interventions/scenario-intervention.entity';
+import { UserOwnsScenario } from 'modules/authorization/modules/scenario-ownership.interceptor';
 
 @Controller(`/api/v1/scenarios`)
 @ApiTags(scenarioResource.className)
@@ -95,6 +96,7 @@ export class ScenariosController {
       }),
     ),
   })
+  @UserOwnsScenario({ isPublic: true })
   @Get(':id')
   async findOne(
     @Param('id') id: string,
@@ -114,6 +116,7 @@ export class ScenariosController {
   @ApiOkResponse({ type: Scenario })
   @ApiNotFoundResponse({ description: 'Scenario not found' })
   @JSONAPISingleEntityQueryParams()
+  @UserOwnsScenario({ isPublic: true })
   @Get(':id/interventions')
   async findInterventionsByScenario(
     @Param('id') id: string,
@@ -138,6 +141,7 @@ export class ScenariosController {
   @ApiOkResponse({ type: Scenario })
   @ApiNotFoundResponse({ description: 'Scenario not found' })
   @UseInterceptors(SetUserInterceptor)
+  @UserOwnsScenario()
   @Patch(':id')
   async update(
     @Body(new ValidationPipe()) dto: UpdateScenarioDto,
@@ -151,6 +155,7 @@ export class ScenariosController {
   @ApiOperation({ description: 'Deletes a scenario' })
   @ApiOkResponse()
   @ApiNotFoundResponse({ description: 'Scenario not found' })
+  @UserOwnsScenario()
   @Delete(':id')
   async delete(@Param('id') id: string): Promise<void> {
     return await this.scenariosService.remove(id);

--- a/api/src/modules/scenarios/scenarios.module.ts
+++ b/api/src/modules/scenarios/scenarios.module.ts
@@ -8,7 +8,11 @@ import { ScenarioRepository } from 'modules/scenarios/scenario.repository';
 import { AuthorizationModule } from 'modules/authorization/authorization.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Scenario]), ScenarioInterventionsModule,  AuthorizationModule],
+  imports: [
+    TypeOrmModule.forFeature([Scenario]),
+    ScenarioInterventionsModule,
+    AuthorizationModule,
+  ],
   controllers: [ScenariosController],
   providers: [ScenariosService, ScenarioRepository],
   exports: [ScenariosService, ScenarioRepository],

--- a/api/src/modules/scenarios/scenarios.service.ts
+++ b/api/src/modules/scenarios/scenarios.service.ts
@@ -11,7 +11,8 @@ import { UpdateScenarioDto } from 'modules/scenarios/dto/update.scenario.dto';
 import { ScenarioInterventionsService } from 'modules/scenario-interventions/scenario-interventions.service';
 import { ScenarioIntervention } from 'modules/scenario-interventions/scenario-intervention.entity';
 import { SelectQueryBuilder } from 'typeorm';
-import { AccessControl } from 'modules/authorization/access-control.service';
+import { FindOptions } from '@nestjs/schematics';
+import { ScenariosAccessControl } from 'modules/authorization/modules/scenarios.access-control.service';
 
 @Injectable()
 export class ScenariosService extends AppBaseService<
@@ -23,7 +24,7 @@ export class ScenariosService extends AppBaseService<
   constructor(
     protected readonly scenarioRepository: ScenarioRepository,
     protected readonly scenarioInterventionService: ScenarioInterventionsService,
-    protected readonly accessControl: AccessControl,
+    protected readonly scenarioAccessControl: ScenariosAccessControl,
   ) {
     super(
       scenarioRepository,
@@ -77,7 +78,6 @@ export class ScenariosService extends AppBaseService<
   extendFindAllQuery(
     query: SelectQueryBuilder<Scenario>,
     fetchSpecification: Record<string, unknown>,
-    info: AppInfoDTO,
   ): Promise<SelectQueryBuilder<Scenario>> {
     if (fetchSpecification.hasActiveInterventions) {
       query.andWhere(
@@ -94,9 +94,9 @@ export class ScenariosService extends AppBaseService<
         });
       }
     }
-    if (!this.accessControl.isUserAdmin()) {
+    if (!this.scenarioAccessControl.isUserAdmin()) {
       query.andWhere(`${this.alias}.userId = :userId`, {
-        userId: this.accessControl.getUserId(),
+        userId: this.scenarioAccessControl.getUserId(),
       });
       query.orWhere(`${this.alias}.isPublic = :isPublicValue`, {
         isPublicValue: true,

--- a/api/test/e2e/scenarios/scenarios.spec.ts
+++ b/api/test/e2e/scenarios/scenarios.spec.ts
@@ -49,7 +49,7 @@ describe('ScenariosModule (e2e)', () => {
   let scenarioInterventionRepository: ScenarioInterventionRepository;
   let sourcingLocationRepository: SourcingLocationRepository;
   let sourcingRecordRepository: SourcingRecordRepository;
-  let jwtToken: string;
+  let adminToken: string;
   let adminUserId: string;
 
   beforeAll(async () => {
@@ -72,7 +72,7 @@ describe('ScenariosModule (e2e)', () => {
     );
 
     const tokenWithId = await setupTestUser(testApplication);
-    jwtToken = tokenWithId.jwtToken;
+    adminToken = tokenWithId.jwtToken;
     adminUserId = tokenWithId.user.id;
   });
 
@@ -91,7 +91,7 @@ describe('ScenariosModule (e2e)', () => {
     test('Create a scenario should be successful (happy case)', async () => {
       const response = await request(testApplication.getHttpServer())
         .post('/api/v1/scenarios')
-        .set('Authorization', `Bearer ${jwtToken}`)
+        .set('Authorization', `Bearer ${adminToken}`)
         .send({
           title: 'test scenario',
         })
@@ -116,7 +116,7 @@ describe('ScenariosModule (e2e)', () => {
     test('Create a scenario without the required fields should fail with a 400 error', async () => {
       const response = await request(testApplication.getHttpServer())
         .post('/api/v1/scenarios')
-        .set('Authorization', `Bearer ${jwtToken}`)
+        .set('Authorization', `Bearer ${adminToken}`)
         .send()
         .expect(HttpStatus.BAD_REQUEST);
 
@@ -134,7 +134,7 @@ describe('ScenariosModule (e2e)', () => {
     test('When I create a scenario And I dont specify if its published or not Then it should be private by default', async () => {
       const response = await request(testApplication.getHttpServer())
         .post('/api/v1/scenarios')
-        .set('Authorization', `Bearer ${jwtToken}`)
+        .set('Authorization', `Bearer ${adminToken}`)
         .send({
           title: 'test scenario',
         })
@@ -154,7 +154,7 @@ describe('ScenariosModule (e2e)', () => {
 
       const response = await request(testApplication.getHttpServer())
         .patch(`/api/v1/scenarios/${scenario.id}`)
-        .set('Authorization', `Bearer ${jwtToken}`)
+        .set('Authorization', `Bearer ${adminToken}`)
         .send({
           title: 'updated test scenario',
         })
@@ -176,7 +176,7 @@ describe('ScenariosModule (e2e)', () => {
 
       const response = await request(testApplication.getHttpServer())
         .patch(`/api/v1/scenarios/${scenario.id}`)
-        .set('Authorization', `Bearer ${jwtToken}`)
+        .set('Authorization', `Bearer ${adminToken}`)
         .send({
           title: 'updated test scenario',
           isPublic: 'Make it public please',
@@ -194,7 +194,7 @@ describe('ScenariosModule (e2e)', () => {
 
       await request(testApplication.getHttpServer())
         .patch(`/api/v1/scenarios/${scenario.id}`)
-        .set('Authorization', `Bearer ${jwtToken}`)
+        .set('Authorization', `Bearer ${adminToken}`)
         .send({
           title: 'updated test scenario',
           isPublic: true,
@@ -206,6 +206,33 @@ describe('ScenariosModule (e2e)', () => {
       });
       expect(updatedScenario.isPublic).toEqual(true);
     });
+
+    test(
+      'When I filter Interventions by Scenario Id + ' +
+        'Then I should receive said Interventions in the response' +
+        'And they should be ordered by creation date in a DESC order',
+      async () => {
+        const interventions: ScenarioIntervention[] = [];
+
+        const scenario: Scenario = await createScenario();
+
+        for (const n of [1, 2, 3, 4, 5]) {
+          const intervention = await createScenarioIntervention({
+            scenario,
+            title: `inter ${n}`,
+          });
+          interventions.push(intervention);
+        }
+        const response = await request(testApplication.getHttpServer())
+          .get(`/api/v1/scenarios/${scenario.id}/interventions`)
+          .set('Authorization', `Bearer ${adminToken}`)
+          .send();
+
+        expect(
+          interventions.map((i: ScenarioIntervention) => i.id).reverse(),
+        ).toEqual(response.body.data.map((i: ScenarioIntervention) => i.id));
+      },
+    );
   });
 
   describe('Scenarios - Delete', () => {
@@ -214,7 +241,7 @@ describe('ScenariosModule (e2e)', () => {
 
       await request(testApplication.getHttpServer())
         .delete(`/api/v1/scenarios/${scenario.id}`)
-        .set('Authorization', `Bearer ${jwtToken}`)
+        .set('Authorization', `Bearer ${adminToken}`)
         .send()
         .expect(HttpStatus.OK);
 
@@ -269,7 +296,7 @@ describe('ScenariosModule (e2e)', () => {
 
       const response = await request(testApplication.getHttpServer())
         .get(`/api/v1/scenarios`)
-        .set('Authorization', `Bearer ${jwtToken}`)
+        .set('Authorization', `Bearer ${adminToken}`)
         .send()
         .expect(HttpStatus.OK);
 
@@ -343,7 +370,7 @@ describe('ScenariosModule (e2e)', () => {
 
       const response = await request(testApplication.getHttpServer())
         .get(`/api/v1/scenarios`)
-        .set('Authorization', `Bearer ${jwtToken}`)
+        .set('Authorization', `Bearer ${adminToken}`)
         .query({
           hasActiveInterventions: true,
         })
@@ -399,7 +426,7 @@ describe('ScenariosModule (e2e)', () => {
       //ACT
       const response = await request(testApplication.getHttpServer())
         .get(`/api/v1/scenarios`)
-        .set('Authorization', `Bearer ${jwtToken}`)
+        .set('Authorization', `Bearer ${adminToken}`)
         .query({
           search: {
             title: 'JEDI',
@@ -432,7 +459,7 @@ describe('ScenariosModule (e2e)', () => {
 
       const response = await request(testApplication.getHttpServer())
         .get(`/api/v1/scenarios`)
-        .set('Authorization', `Bearer ${jwtToken}`)
+        .set('Authorization', `Bearer ${adminToken}`)
         .query({
           filter: {
             status: SCENARIO_STATUS.ACTIVE,
@@ -457,7 +484,7 @@ describe('ScenariosModule (e2e)', () => {
 
       const responseOne = await request(testApplication.getHttpServer())
         .get(`/api/v1/scenarios`)
-        .set('Authorization', `Bearer ${jwtToken}`)
+        .set('Authorization', `Bearer ${adminToken}`)
         .query({
           page: {
             size: 3,
@@ -471,7 +498,7 @@ describe('ScenariosModule (e2e)', () => {
 
       const responseTwo = await request(testApplication.getHttpServer())
         .get(`/api/v1/scenarios`)
-        .set('Authorization', `Bearer ${jwtToken}`)
+        .set('Authorization', `Bearer ${adminToken}`)
         .query({
           page: {
             size: 3,
@@ -492,7 +519,7 @@ describe('ScenariosModule (e2e)', () => {
 
       const response = await request(testApplication.getHttpServer())
         .get(`/api/v1/scenarios/${scenario.id}`)
-        .set('Authorization', `Bearer ${jwtToken}`)
+        .set('Authorization', `Bearer ${adminToken}`)
         .send()
         .expect(HttpStatus.OK);
 
@@ -545,7 +572,7 @@ describe('ScenariosModule (e2e)', () => {
 
         const response = await request(testApplication.getHttpServer())
           .get(`/api/v1/scenarios/${scenario.id}/interventions`)
-          .set('Authorization', `Bearer ${jwtToken}`)
+          .set('Authorization', `Bearer ${adminToken}`)
           .send();
 
         expect(
@@ -599,7 +626,7 @@ describe('ScenariosModule (e2e)', () => {
       });
       const requests = [];
 
-      for (const token of [jwtToken, user1.jwtToken, user2.jwtToken]) {
+      for (const token of [adminToken, user1.jwtToken, user2.jwtToken]) {
         requests.push(
           request(testApplication.getHttpServer())
             .get(`/api/v1/scenarios`)
@@ -610,7 +637,7 @@ describe('ScenariosModule (e2e)', () => {
       const response: any = await Promise.all(requests);
 
       const adminRequest = response.find((res: any) =>
-        res.request.header.Authorization.includes(jwtToken),
+        res.request.header.Authorization.includes(adminToken),
       );
       expect(adminRequest.body.data).toHaveLength(3);
 
@@ -679,31 +706,100 @@ describe('ScenariosModule (e2e)', () => {
         ),
       ).toBe(undefined);
     });
+    test('Given I am a user, When I want to GET/PATCH/DELETE a Scenario, But its not mine, Then I should get an error', async () => {
+      const { user } = await setupTestUser(testApplication, ROLES.USER, {
+        email: 'scenariouser@email.com',
+      });
+      const scenario = await createScenario({ user });
+      const requestingUser = await setupTestUser(testApplication, ROLES.USER, {
+        email: 'requestinguser@email.com',
+      });
+
+      await request(testApplication.getHttpServer())
+        .get(`/api/v1/scenarios/${scenario.id}`)
+        .set('Authorization', `Bearer ${requestingUser.jwtToken}`)
+        .send()
+        .expect(HttpStatus.FORBIDDEN);
+
+      await request(testApplication.getHttpServer())
+        .patch(`/api/v1/scenarios/${scenario.id}`)
+        .set('Authorization', `Bearer ${requestingUser.jwtToken}`)
+        .send({ title: 'another name' })
+        .expect(HttpStatus.FORBIDDEN);
+
+      await request(testApplication.getHttpServer())
+        .delete(`/api/v1/scenarios/${scenario.id}`)
+        .set('Authorization', `Bearer ${requestingUser.jwtToken}`)
+        .send()
+        .expect(HttpStatus.FORBIDDEN);
+    });
+
+    test('Given I am a user, When I want to GET other users Scenario, And its public, Then I should be allowed', async () => {
+      const { user } = await setupTestUser(testApplication, ROLES.USER, {
+        email: 'publicscenariouser@email.com',
+      });
+      const scenario = await createScenario({ user, isPublic: true });
+      const requestingUser = await setupTestUser(testApplication, ROLES.USER, {
+        email: 'requestinpublicscenariouser@email.com',
+      });
+
+      await request(testApplication.getHttpServer())
+        .get(`/api/v1/scenarios/${scenario.id}`)
+        .set('Authorization', `Bearer ${requestingUser.jwtToken}`)
+        .send()
+        .expect(HttpStatus.OK);
+    });
   });
-  test(
-    'When I filter Interventions by Scenario Id + ' +
-      'Then I should receive said Interventions in the response' +
-      'And they should be ordered by creation date in a DESC order',
-    async () => {
-      const interventions: ScenarioIntervention[] = [];
+  test('Given I am a user, When I want to GET/PATCH/DELETE a Scenario, And its mine, Then I should be allowed', async () => {
+    const myUser = await setupTestUser(testApplication, ROLES.USER, {
+      email: 'myUser@email.com',
+    });
+    const scenario = await createScenario({
+      user: myUser.user,
+      title: 'Best scenario',
+    });
 
-      const scenario: Scenario = await createScenario();
+    await request(testApplication.getHttpServer())
+      .get(`/api/v1/scenarios/${scenario.id}`)
+      .set('Authorization', `Bearer ${myUser.jwtToken}`)
+      .send()
+      .expect(HttpStatus.OK);
 
-      for (const n of [1, 2, 3, 4, 5]) {
-        const intervention = await createScenarioIntervention({
-          scenario,
-          title: `inter ${n}`,
-        });
-        interventions.push(intervention);
-      }
-      const response = await request(testApplication.getHttpServer())
-        .get(`/api/v1/scenarios/${scenario.id}/interventions`)
-        .set('Authorization', `Bearer ${jwtToken}`)
-        .send();
+    await request(testApplication.getHttpServer())
+      .patch(`/api/v1/scenarios/${scenario.id}`)
+      .set('Authorization', `Bearer ${myUser.jwtToken}`)
+      .send({ title: 'another name' })
+      .expect(HttpStatus.OK);
 
-      expect(
-        interventions.map((i: ScenarioIntervention) => i.id).reverse(),
-      ).toEqual(response.body.data.map((i: ScenarioIntervention) => i.id));
-    },
-  );
+    await request(testApplication.getHttpServer())
+      .delete(`/api/v1/scenarios/${scenario.id}`)
+      .set('Authorization', `Bearer ${myUser.jwtToken}`)
+      .send()
+      .expect(HttpStatus.OK);
+  });
+
+  test('Given I am a Admin, When I want to GET/PATCH/DELETE a Scenario, And its not mine, Then I should be allowed', async () => {
+    const scenario = await createScenario({
+      userId: adminUserId,
+      title: 'Admin scenario',
+    });
+
+    await request(testApplication.getHttpServer())
+      .get(`/api/v1/scenarios/${scenario.id}`)
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send()
+      .expect(HttpStatus.OK);
+
+    await request(testApplication.getHttpServer())
+      .patch(`/api/v1/scenarios/${scenario.id}`)
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ title: 'another name' })
+      .expect(HttpStatus.OK);
+
+    await request(testApplication.getHttpServer())
+      .delete(`/api/v1/scenarios/${scenario.id}`)
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send()
+      .expect(HttpStatus.OK);
+  });
 });


### PR DESCRIPTION
### General description

This PR adds access control to check that a user can only CRUD it's own scenarios 

Adds a new ScenarioAccessControl which extends AccessControl to perform scenario specific authorisation

I also extended base Access Control's implementation with more useful features

### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

_Provide minimal instructions on how to test this PR._

- Apart from the added feature / bug fix, check overall performance, styling...

## Checklist before merging

- [x] Branch name / PR includes the related Jira ticket Id.
- [x] Tests to check core implementation / bug fix added.
- [x] All checks in Continuous Integration workflow pass.
- [ ] Feature functionally tested by reviewer(s).
- [x] Code reviewed by reviewer(s).
- [ ] Documentation updated (README, CHANGELOG...) (if required)
