### PR TITLE
[LANDGRIF-1141]: fixes `material` type layer fetching from the wrong endpoint

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Move the users page from data to user [LANDGRIF-1122](https://vizzuality.atlassian.net/browse/LANDGRIF-1122)
 
 ### Fixed
+- Fixed condition to fetch available years for material layer. [LANDGRIF-1141](https://vizzuality.atlassian.net/browse/LANDGRIF-1141)
 - Undefined `endYear` value sent to API regardless being deactivated. [LANDGRIF-1145](https://vizzuality.atlassian.net/browse/LANDGRIF-1145)
 - Undefined value of coefficients. [LANDGRIF-1142](https://vizzuality.atlassian.net/browse/LANDGRIF-1142)
 - Disable the filter in the manage data page [LANDGRIF-1110](https://vizzuality.atlassian.net/browse/LANDGRIF-1110)

--- a/client/src/containers/analysis-visualization/analysis-filters/years-range/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-filters/years-range/component.tsx
@@ -17,7 +17,9 @@ const YearsFilter: React.FC = () => {
 
   const materialIds = useMemo(() => materials.map((mat) => mat.value), [materials]);
 
-  const { data, isLoading } = useYears(layer, materialIds, indicator?.value);
+  const { data, isLoading } = useYears(layer, materialIds, indicator?.value, {
+    enabled: !!(layer === 'impact' && indicator?.value) || true,
+  });
 
   const { startYear, endYear, yearsGap, setYearsRange } = useYearsRange({
     years,

--- a/client/src/containers/analysis-visualization/analysis-filters/years/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-filters/years/component.tsx
@@ -13,7 +13,9 @@ const YearsFilter: React.FC = () => {
   const filters = useAppSelector(analysisFilters);
   const { layer, materials, indicator, startYear } = filters;
   const materialsIds = useMemo(() => materials.map((mat) => mat.value), [materials]);
-  const { data, isLoading } = useYears(layer, materialsIds, indicator?.value);
+  const { data, isLoading } = useYears(layer, materialsIds, indicator?.value, {
+    enabled: !!(layer === 'impact' && indicator?.value) || true,
+  });
 
   const [years, setYears] = useState(data);
 

--- a/client/src/containers/analysis-visualization/analysis-legend/material-legend-item/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-legend/material-legend-item/component.tsx
@@ -97,6 +97,7 @@ const MaterialLayer = () => {
 
   const handleHideLayer = useCallback(() => {
     dispatch(setLayer({ id: layer.id, layer: { visible: false } }));
+    dispatch(setFilter({ id: 'materialId', value: null }));
   }, [dispatch, layer.id]);
 
   return (

--- a/client/src/containers/years/component.tsx
+++ b/client/src/containers/years/component.tsx
@@ -13,7 +13,9 @@ const YearsFilter: React.FC = () => {
   const { layer, materials, indicator, startYear } = filters;
 
   const materialsIds = useMemo(() => materials.map((mat) => mat.value), [materials]);
-  const { data: years, isLoading } = useYears(layer, materialsIds, indicator?.value);
+  const { data: years, isLoading } = useYears(layer, materialsIds, indicator?.value, {
+    enabled: !!(layer === 'impact' && indicator?.value) || true,
+  });
   const [selectedOption, setSelectedOption] = useState<SelectProps['value']>(null);
 
   useEffect(() => {

--- a/client/src/hooks/years/index.ts
+++ b/client/src/hooks/years/index.ts
@@ -20,10 +20,8 @@ export const useYears = <T = YearsData>(
   materialIds: Material['id'][],
   indicatorId: Indicator['id'],
   options: UseQueryOptions<YearsData, unknown, T> = {},
-) => {
-  const enabled = (options.enabled ?? true) && !!indicatorId;
-
-  const query = useQuery(
+) =>
+  useQuery(
     ['years', layer, materialIds, indicatorId],
     () =>
       apiRawService
@@ -40,9 +38,5 @@ export const useYears = <T = YearsData>(
     {
       ...DEFAULT_QUERY_OPTIONS,
       ...options,
-      enabled,
     },
   );
-
-  return query;
-};

--- a/client/src/store/features/analysis/map.ts
+++ b/client/src/store/features/analysis/map.ts
@@ -65,13 +65,11 @@ export const initialState: AnalysisMapState = {
       order: 0,
       active: true,
       visible: true,
-      isContextual: false,
     },
     material: {
       ...DEFAULT_LAYER_ATTRIBUTES,
       id: 'material',
       order: 1,
-      isContextual: true,
     },
   },
   tooltipData: [],


### PR DESCRIPTION
### General description

Fixes material layer fetching from the wrong endpoint.

This [condition](https://github.com/Vizzuality/landgriffon/blob/dev/client/src/hooks/years/index.ts#L24) is a bit tricky and bad practice as it doesn't allow to have full control over when the hook is actually enabled or not from outside. The solution is to move the particular logic where it is needed.

Also, by default, [the material layer was treated as a contextual layer](https://github.com/Vizzuality/landgriffon/blob/dev/client/src/store/features/analysis/map.ts#L74), this has been changed to avoid fetching from the wrong endpoint.

https://vizzuality.atlassian.net/browse/LANDGRIF-1141

### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

_Provide minimal instructions on how to test this PR._

Go to [http://localhost:3000/analysis/map](the analysis page) and add some contextual layers to the main map. They should be visible now.

## Checklist before merging

- [x] Branch name / PR includes the related Jira ticket Id.
- [ ] Tests to check core implementation / bug fix added.
- [ ] All checks in Continuous Integration workflow pass.
- [ ] Feature functionally tested by reviewer(s).
- [ ] Code reviewed by reviewer(s).
- [x] Documentation updated (README, CHANGELOG...) (if required)