### PR TITLE
[LANDGRIF-1108]: disables materials in tree-select according to API

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 - Filter indicators in the chart and table view [LANDGRIF-1173](https://vizzuality.atlassian.net/browse/LANDGRIF-1173)
+- Disables materials in tree-select when needed. Also, materials are sorted alphabetically now. [LANDGRIF-1108](https://vizzuality.atlassian.net/browse/LANDGRIF-1108)
 - Disabled `Country of delivery` and `Unknown` location types options from intervention form. [LANDGRIF-1148](https://vizzuality.atlassian.net/browse/LANDGRIF-1148)
 - Bumped `react-hook-form` fixing several validation issues. [LANDGRIF-1142](https://vizzuality.atlassian.net/browse/LANDGRIF-1142)
 - Bumped `browserslist-db` dependency.

--- a/client/cypress/e2e/analysis-filters.cy.ts
+++ b/client/cypress/e2e/analysis-filters.cy.ts
@@ -121,7 +121,6 @@ describe('Analysis and filters', () => {
       .find('.rc-tree-treenode')
       .eq(1)
       .click();
-    // cy.get('#floating-ui-root').find('.rc-tree-treenode').eq(1).click();
     cy.get('[data-testid="tree-select-origins-filter"]')
       .find('input:visible:first')
       .type('{enter}');

--- a/client/src/components/tree-select/component.tsx
+++ b/client/src/components/tree-select/component.tsx
@@ -55,7 +55,7 @@ const THEMES = {
 const CustomSwitcherIcon: TreeProps<TreeDataNode>['switcherIcon'] = ({ isLeaf, expanded }) => {
   if (isLeaf) return <span className="block w-4" />;
 
-  return <ChevronDownIcon className={classNames('h-4 w-4', { '-rotate-90': !expanded })} />;
+  return <ChevronDownIcon className={classNames('h-5 w-5', { '-rotate-90': !expanded })} />;
 };
 
 const CustomCheckbox = React.forwardRef<
@@ -177,6 +177,7 @@ const InnerTreeSelect = <IsMulti extends boolean>({
         className: classNames(THEMES[theme].treeNodes, {
           'w-full': fitContent,
           'bg-navy-50 font-bold': !multiple && selected?.value === node?.value,
+          'text-gray-300 cursor-default pointer-events-none': node.disabled,
         }),
       };
     },
@@ -562,7 +563,7 @@ const InnerTreeSelect = <IsMulti extends boolean>({
             />
           ) : (
             <ChevronDownIcon
-              className={classNames('h-4 w-4', { 'rotate-180': isOpen, 'text-gray-300': disabled })}
+              className={classNames('h-5 w-5', { 'rotate-180': isOpen, 'text-gray-300': disabled })}
               aria-hidden="true"
             />
           )}

--- a/client/src/components/tree-select/component.tsx
+++ b/client/src/components/tree-select/component.tsx
@@ -52,10 +52,24 @@ const THEMES = {
     'flex-row max-w-full bg-gray-300/20 border border-gray-200 rounded-md shadow-sm cursor-default pointer-events-none min-h-[2.5rem] text-sm p-0.5 px-[0.2rem]',
 };
 
-const CustomSwitcherIcon: TreeProps<TreeDataNode>['switcherIcon'] = ({ isLeaf, expanded }) => {
+const CustomSwitcherIcon: TreeProps<TreeDataNode>['switcherIcon'] = ({
+  isLeaf,
+  expanded,
+  data,
+}) => {
   if (isLeaf) return <span className="block w-4" />;
 
-  return <ChevronDownIcon className={classNames('h-5 w-5', { '-rotate-90': !expanded })} />;
+  const allChildrenDisabled = data.children.some(({ disabled }) => disabled);
+
+  return (
+    <ChevronDownIcon
+      className={classNames('h-4 w-4 cursor-pointer', {
+        '-rotate-90': !expanded,
+        'fill-gray-900': !allChildrenDisabled,
+        'fill-grey-300': allChildrenDisabled,
+      })}
+    />
+  );
 };
 
 const CustomCheckbox = React.forwardRef<
@@ -79,7 +93,7 @@ const CustomCheckbox = React.forwardRef<
     <input
       type="checkbox"
       className={classNames(
-        'flex-shrink-0 rounded w-4 h-4 focus:ring-2 active:ring-2 ring-offset-1 focus:outline-offset-0 ring-navy-200 m-0.5 focus:outline-none focus:ring-offset-0',
+        'flex-shrink-0 rounded w-4 h-4 focus:ring-2 active:ring-2 ring-offset-1 focus:outline-offset-0 ring-navy-200 m-0.5 focus:outline-none focus:ring-offset-0 disabled:ring-0 disabled:ring-offset-0',
         checked || indeterminate ? 'bg-navy-4 border-none' : 'border border-gray-200',
         className,
       )}
@@ -177,7 +191,7 @@ const InnerTreeSelect = <IsMulti extends boolean>({
         className: classNames(THEMES[theme].treeNodes, {
           'w-full': fitContent,
           'bg-navy-50 font-bold': !multiple && selected?.value === node?.value,
-          'text-gray-300 cursor-default pointer-events-none': node.disabled,
+          'text-gray-300 cursor-default hover:bg-white': node.disabled,
         }),
       };
     },
@@ -563,7 +577,7 @@ const InnerTreeSelect = <IsMulti extends boolean>({
             />
           ) : (
             <ChevronDownIcon
-              className={classNames('h-5 w-5', { 'rotate-180': isOpen, 'text-gray-300': disabled })}
+              className={classNames('h-4 w-4', { 'rotate-180': isOpen, 'text-gray-300': disabled })}
               aria-hidden="true"
             />
           )}

--- a/client/src/containers/analysis-visualization/analysis-filters/materials/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-filters/materials/component.tsx
@@ -4,7 +4,7 @@ import { useMaterialsTrees } from 'hooks/materials';
 import TreeSelect from 'components/tree-select';
 import { recursiveMap, recursiveSort } from 'components/tree-select/utils';
 
-import type { MakePropOptional, MaterialTreeItem } from 'types';
+import type { MakePropOptional } from 'types';
 import type { MaterialsTreesParams } from 'hooks/materials';
 import type { TreeSelectProps, TreeSelectOption } from 'components/tree-select/types';
 
@@ -23,9 +23,7 @@ const MaterialsFilter = <IsMulti extends boolean>({
   options,
   ...props
 }: MaterialsFilterProps<IsMulti>) => {
-  const { data: materials, isFetching } = useMaterialsTrees<
-    TreeSelectOption<string>[] | MaterialTreeItem[]
-  >(
+  const { data: materials, isFetching } = useMaterialsTrees<TreeSelectOption<string>[]>(
     {
       depth,
       supplierIds,
@@ -49,18 +47,7 @@ const MaterialsFilter = <IsMulti extends boolean>({
     },
   );
 
-  const treeOptions: TreeSelectOption[] = useMemo(
-    () =>
-      options ??
-      recursiveSort(materials as MaterialTreeItem[], 'name')?.map((item) =>
-        recursiveMap(item, ({ id, name, status }) => ({
-          value: id,
-          label: name,
-          disabled: status === 'inactive',
-        })),
-      ),
-    [materials, options],
-  );
+  const treeOptions = useMemo(() => options ?? materials, [materials, options]);
 
   return (
     <TreeSelect

--- a/client/src/containers/analysis-visualization/analysis-filters/more-filters/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-filters/more-filters/component.tsx
@@ -16,6 +16,7 @@ import Materials from '../materials/component';
 import OriginRegions from '../origin-regions/component';
 import Suppliers from '../suppliers/component';
 
+import { flattenTree, recursiveMap, recursiveSort } from 'components/tree-select/utils';
 import Select from 'components/forms/select';
 import { useAppDispatch, useAppSelector } from 'store/hooks';
 import { analysisFilters, setFilters } from 'store/features/analysis/filters';
@@ -25,7 +26,6 @@ import { useAdminRegionsTrees } from 'hooks/admin-regions';
 import { useSuppliersTrees } from 'hooks/suppliers';
 import { useLocationTypes } from 'hooks/location-types';
 import Button from 'components/button/component';
-import { flattenTree, recursiveMap, recursiveSort } from 'components/tree-select/utils';
 
 import type { Option } from 'components/forms/select';
 import type { LocationTypes as LocationTyping } from 'containers/interventions/enums';
@@ -160,7 +160,17 @@ const MoreFilters = () => {
       supplierIds,
       locationTypes: locationTypesIds,
     },
-    DEFAULT_QUERY_OPTIONS,
+    {
+      ...DEFAULT_QUERY_OPTIONS,
+      select: (_materials) =>
+        recursiveSort(_materials, 'name')?.map((item) =>
+          recursiveMap(item, ({ id, name, status }) => ({
+            value: id,
+            label: name,
+            disabled: status === 'inactive',
+          })),
+        ),
+    },
   );
 
   const { data: originOptions } = useAdminRegionsTrees(

--- a/client/src/containers/materials/select/component.tsx
+++ b/client/src/containers/materials/select/component.tsx
@@ -1,8 +1,8 @@
-import React, { useMemo } from 'react';
-import { sortBy } from 'lodash-es';
+import React from 'react';
 
 import { useMaterialsTrees } from 'hooks/materials';
 import TreeSelect from 'components/tree-select';
+import { recursiveMap, recursiveSort } from 'components/tree-select/utils';
 
 import type { MaterialsTreesParams } from 'hooks/materials';
 import type { ComponentRef, Ref } from 'react';
@@ -48,22 +48,15 @@ const InnerMaterialsFilter = <IsMulti extends boolean>(
       withSourcingLocations,
     },
     {
-      // 2 minutes stale time
-      staleTime: 2 * 60 * 1000,
+      select: (_materials) =>
+        recursiveSort(_materials, 'name')?.map((item) =>
+          recursiveMap(item, ({ id, name, status }) => ({
+            value: id,
+            label: name,
+            disabled: status === 'inactive',
+          })),
+        ),
     },
-  );
-
-  const treeOptions: TreeSelectProps<IsMulti>['options'] = useMemo(
-    () =>
-      sortBy(
-        data?.map(({ name, id, children }) => ({
-          label: name,
-          value: id,
-          children: children?.map(({ name, id }) => ({ label: name, value: id })),
-        })),
-        'label',
-      ),
-    [data],
   );
 
   return (
@@ -71,7 +64,7 @@ const InnerMaterialsFilter = <IsMulti extends boolean>(
       multiple={multiple}
       showSearch
       loading={isFetching}
-      options={treeOptions}
+      options={data}
       placeholder="Materials"
       onChange={onChange}
       current={current}

--- a/client/src/styles/globals.css
+++ b/client/src/styles/globals.css
@@ -81,7 +81,7 @@
 }
 
 .rc-tree .rc-tree-node-content-wrapper {
-  @apply w-full overflow-hidden truncate text-ellipsis flex flex-row gap-1 place-items-center;
+  @apply flex flex-row w-full gap-1 overflow-hidden truncate text-ellipsis place-items-center;
 }
 
 .rc-tree .rc-tree-title {
@@ -90,6 +90,10 @@
 
 .rc-tree .rc-tree-indent-unit {
   @apply w-4;
+}
+
+.rc-tree-treenode-disabled .rc-tree-title {
+  @apply text-gray-300;
 }
 
 /* Recharts */

--- a/client/src/types.d.ts
+++ b/client/src/types.d.ts
@@ -124,7 +124,7 @@ export type Material = {
   hsCodeId: string;
   name: string;
   parentId: Material['id'];
-  status: string | 'active';
+  status: 'active' | 'inactive';
   metadata: {
     cautions: string;
     citation: string;
@@ -141,8 +141,9 @@ export type Material = {
 };
 
 export type MaterialTreeItem = {
-  id: string;
-  name: string;
+  id: Material['id'];
+  name: Material['name'];
+  status: Material['status'];
   children: MaterialTreeItem[];
 };
 


### PR DESCRIPTION
### General description

**Blocked**: waiting for BE to pass the `status` property to the `/materials/trees?depth=1&withSourcingLocations=true` endpoint.

https://vizzuality.atlassian.net/browse/LANDGRIF-1108

Disables materials in `tree-select` according to API. Also, sorts materials out alphabetically.

![image](https://user-images.githubusercontent.com/999124/218509211-756d26e6-80ce-4321-9e64-0593d0721ed4.png)


![image](https://user-images.githubusercontent.com/999124/218509032-7af7fb10-cecc-4d72-a059-63f85e449459.png)


These changes apply to `/analysis` filters and `/data/scenarios/{X}/interventions/new` material dropdowns (raw material and new material).


### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

_Provide minimal instructions on how to test this PR._

- Apart from the added feature / bug fix, check overall performance, styling...

## Checklist before merging

- [x] Branch name / PR includes the related Jira ticket Id.
- [ ] Tests to check core implementation / bug fix added.
- [ ] All checks in Continuous Integration workflow pass.
- [ ] Feature functionally tested by reviewer(s).
- [ ] Code reviewed by reviewer(s).
- [x] Documentation updated (README, CHANGELOG...) (if required)
