### PR TITLE
[LANDGRIF-1208]: omits scenarioId param from /h3/map/impact/compare endpoint

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 - Issue preventing new users to sign up in the platform. [LANDGRIF-1222](https://vizzuality.atlassian.net/browse/LANDGRIF-1222)
+- Error requesting scenario comparison. [LANDGRIF-1208](https://vizzuality.atlassian.net/browse/LANDGRIF-1208)
 - Issue with focus in tree-select and some styling. [LANDGRIF-1155](https://vizzuality.atlassian.net/browse/LANDGRIF-1155)
 - Fixed condition to fetch available years for material layer. [LANDGRIF-1141](https://vizzuality.atlassian.net/browse/LANDGRIF-1141)
 - Undefined `endYear` value sent to API regardless being deactivated. [LANDGRIF-1145](https://vizzuality.atlassian.net/browse/LANDGRIF-1145)

--- a/client/src/hooks/layers/impact.ts
+++ b/client/src/hooks/layers/impact.ts
@@ -1,5 +1,6 @@
 import { useEffect, useMemo } from 'react';
 import { useRouter } from 'next/router';
+import { omit } from 'lodash-es';
 
 import { useAppDispatch, useAppSelector } from 'store/hooks';
 import { analysisFilters } from 'store/features/analysis/filters';
@@ -44,7 +45,7 @@ export const useImpactLayer = () => {
   const normalQuery = useH3ImpactData(params, { enabled: !isComparisonEnabled });
   const comparisonQuery = useH3ComparisonData(
     {
-      ...params,
+      ...omit(params, ['scenarioId']),
       baseScenarioId: params.scenarioId,
       comparedScenarioId: compareScenarioId as string,
       relative: comparisonMode === 'relative',


### PR DESCRIPTION
### General description


### Description

https://vizzuality.atlassian.net/browse/LANDGRIF-1208

Omits `scenarioId` from query params sent to `/h3/map/impact/compare` endpoint.

### Testing instructions

_Provide minimal instructions on how to test this PR._

- Apart from the added feature / bug fix, check overall performance, styling...

## Checklist before merging

- [x] Branch name / PR includes the related Jira ticket Id.
- [ ] Tests to check core implementation / bug fix added.
- [ ] All checks in Continuous Integration workflow pass.
- [ ] Feature functionally tested by reviewer(s).
- [ ] Code reviewed by reviewer(s).
- [x] Documentation updated (README, CHANGELOG...) (if required)
