### PR TITLE
[LANGRIF-1125]: Add role check to enable upload data source button

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [v0.4.0 Unreleased]
 
+### Added
+- Added role check to enable upload data source button[LANGRIF-1125](https://vizzuality.atlassian.net/browse/LANDGRIF-1125)
+
 ## [v0.3.6]
 
 ### Added

--- a/client/cypress/e2e/data.cy.ts
+++ b/client/cypress/e2e/data.cy.ts
@@ -45,4 +45,14 @@ describe('Data page', () => {
       .should('be.disabled')
       .should('have.class', 'bg-gray-300/20');
   });
+
+  it('admin should be able to upload data source', () => {
+    cy.intercept('api/v1/users/me', { fixture: 'profiles/admin' });
+    cy.get('[data-testid="upload-data-source-btn"]').should('not.be.disabled');
+  });
+
+  it('not admin user should not be able to upload data source', () => {
+    cy.intercept('api/v1/users/me', { fixture: 'profiles/no-permissions' });
+    cy.get('[data-testid="upload-data-source-btn"]').should('be.disabled');
+  });
 });

--- a/client/cypress/fixtures/profiles/admin.json
+++ b/client/cypress/fixtures/profiles/admin.json
@@ -1,0 +1,21 @@
+{
+  "data": {
+    "type": "users",
+    "id": "368bbd1f-8c37-4999-9c01-da0ac7750597",
+    "attributes": {
+      "fname": null,
+      "lname": null,
+      "email": "user@vizzuality.com",
+      "displayName": null,
+      "avatarDataUrl": null,
+      "isActive": true,
+      "isDeleted": false,
+      "roles": [
+        {
+          "name": "admin",
+          "permissions": []
+        }
+      ]
+    }
+  }
+}

--- a/client/src/containers/admin/data-table/component.tsx
+++ b/client/src/containers/admin/data-table/component.tsx
@@ -16,6 +16,8 @@ import Search from 'components/search';
 import Modal from 'components/modal';
 import Table from 'components/table';
 import { DEFAULT_PAGE_SIZES } from 'components/table/pagination/constants';
+import { usePermissions } from 'hooks/permissions';
+import { RoleName } from 'hooks/permissions/enums';
 
 import type { PaginationState, SortingState, VisibilityState } from '@tanstack/react-table';
 import type { TableProps } from 'components/table/component';
@@ -23,6 +25,9 @@ import type { TableProps } from 'components/table/component';
 const AdminDataPage: React.FC = () => {
   const { push, query } = useRouter();
   const [sorting, setSorting] = useState<SortingState>([]);
+
+  const { hasRole } = usePermissions();
+  const isAdmin = hasRole(RoleName.ADMIN);
 
   // Search
   const [searchText, setSearchText] = useState<string>('');
@@ -191,6 +196,8 @@ const AdminDataPage: React.FC = () => {
           <Button
             variant="primary"
             onClick={openUploadDataSourceModal}
+            disabled={!isAdmin}
+            data-testid="upload-data-source-btn"
             icon={
               <div
                 aria-hidden="true"


### PR DESCRIPTION
### General description

This PR adds a role check to enable upload data source

### Testing instructions

1. Login with an admin user and go to /data page

- The update data button should be enabled;

2. Login with an NO admin user and go to /data page

- The update data button should be disabled;

### Related task
[LANGRIF-1125](https://vizzuality.atlassian.net/browse/LANDGRIF-1125)


## Checklist before merging

- [x] Branch name / PR includes the related Jira ticket Id.
- [x] Tests to check core implementation / bug fix added.
- [x] All checks in Continuous Integration workflow pass.
- [ ] Feature functionally tested by reviewer(s).
- [ ] Code reviewed by reviewer(s).
- [x] Documentation updated (README, CHANGELOG...) (if required)
