### PR TITLE
fixes empty object for coefficients

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Move the users page from data to user [LANDGRIF-1122](https://vizzuality.atlassian.net/browse/LANDGRIF-1122)
 
 ### Fixed
+- Intervention form: an empty object was being sent for coefficients when these were `undefined`. [LANDGRIF-1238](https://vizzuality.atlassian.net/browse/LANDGRIF-1238)
 - Material layer fixed to resolution 4 [LANDGRIF-1234](https://vizzuality.atlassian.net/browse/LANDGRIF-1234)
 - Issue preventing new users to sign up in the platform. [LANDGRIF-1222](https://vizzuality.atlassian.net/browse/LANDGRIF-1222)
 - Error requesting scenario comparison. [LANDGRIF-1208](https://vizzuality.atlassian.net/browse/LANDGRIF-1208)

--- a/client/src/containers/interventions/form/component.tsx
+++ b/client/src/containers/interventions/form/component.tsx
@@ -1114,7 +1114,7 @@ const InterventionForm: React.FC<InterventionFormProps> = ({
                 closeImpactsRef.current = close;
 
                 return (
-                  <>
+                  <div data-testid="fieldset-impacts-per-ton">
                     <div className="flex items-center justify-between w-full">
                       <div className="flex items-center space-x-1">
                         <h3>Impacts per ton</h3>
@@ -1169,7 +1169,7 @@ const InterventionForm: React.FC<InterventionFormProps> = ({
                         ))}
                       </div>
                     </Disclosure.Panel>
-                  </>
+                  </div>
                 );
               }}
             </Disclosure>

--- a/client/src/containers/interventions/utils.ts
+++ b/client/src/containers/interventions/utils.ts
@@ -36,7 +36,7 @@ export function parseInterventionFormDataToDto(
     ...rest
   } = interventionFormData;
 
-  const areCoefficientsSet = Object.values(coefficients).some((v) => +v !== 0);
+  const areCoefficientsSet = Object.values(coefficients).some((v) => +v !== 0 && v);
 
   const result: InterventionDto = {
     ...rest,


### PR DESCRIPTION
### General description

https://vizzuality.atlassian.net/browse/LANDGRIF-1238

Fixes issue where the intervention form was sending an empty object `{}` for coefficients when these were `undefined` actually.

The issue lied in the parser of the form DTO.

### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

_Provide minimal instructions on how to test this PR._

- Apart from the added feature / bug fix, check overall performance, styling...

## Checklist before merging

- [x] Branch name / PR includes the related Jira ticket Id.
- [ ] Tests to check core implementation / bug fix added.
- [ ] All checks in Continuous Integration workflow pass.
- [ ] Feature functionally tested by reviewer(s).
- [ ] Code reviewed by reviewer(s).
- [x] Documentation updated (README, CHANGELOG...) (if required)
