### PR TITLE
Fix senario edition permission bug

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [v0.5.0 Unreleased]
 
+### Fixed
+- Fix permissions for edit scenarios on analysis pages [LANDGRIF-1253](https://vizzuality.atlassian.net/browse/LANDGRIF-1253)
+
 ## [v0.4.0]
 
 ### Added

--- a/client/src/containers/analysis-sidebar/component.tsx
+++ b/client/src/containers/analysis-sidebar/component.tsx
@@ -46,7 +46,7 @@ const ScenariosComponent: React.FC<{ scrollref?: MutableRefObject<HTMLDivElement
     sort: sort as string,
     'page[size]': 10,
     'search[title]': searchTerm,
-    include: 'scenarioInterventions',
+    include: 'scenarioInterventions,user',
     hasActiveInterventions: true,
   });
 

--- a/client/src/containers/scenarios/item/component.tsx
+++ b/client/src/containers/scenarios/item/component.tsx
@@ -117,7 +117,7 @@ const ScenarioItem = ({ scenario, isSelected }: ScenariosItemProps) => {
                           href={`/data/scenarios/${scenario.id}/edit`}
                           variant="white"
                           size="xs"
-                          disabled={canEdit}
+                          disabled={!canEdit}
                         >
                           Edit
                         </LinkAnchor>


### PR DESCRIPTION
### General description

This PR fixes a bug with scenario edit button bug

### Testing instructions

Using a user with permission to edit scenarios or an admin, go to '/analysis', select a intervention and click on the Edit button
You should be able to go to the edition page

### Related task
https://vizzuality.atlassian.net/browse/LANDGRIF-1253

## Checklist before merging

- [x] Branch name / PR includes the related Jira ticket Id.
- [ ] Tests to check core implementation / bug fix added.
- [ ] All checks in Continuous Integration workflow pass.
- [ ] Feature functionally tested by reviewer(s).
- [ ] Code reviewed by reviewer(s).
- [x] Documentation updated (README, CHANGELOG...) (if required)
