### PR TITLE
[LANDGRIF-1246]: fixes weird behaviour of coefficients panel

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [v0.5.0 Unreleased]
 
 ### Fixed
+- Fixed coefficients panel acting weird when values are edited. [LANDGRIF-1246](https://vizzuality.atlassian.net/browse/LANDGRIF-1246)
 - Fix permissions for edit scenarios on analysis pages [LANDGRIF-1253](https://vizzuality.atlassian.net/browse/LANDGRIF-1253)
 
 ## [v0.4.0]

--- a/client/src/containers/interventions/form/component.tsx
+++ b/client/src/containers/interventions/form/component.tsx
@@ -474,11 +474,6 @@ const InterventionForm: React.FC<InterventionFormProps> = ({
     if (closeSupplierRef.current !== null) {
       closeSupplierRef.current();
     }
-
-    // * closes "Impacts per ton" panel whenever the intervention type changes
-    if (closeImpactsRef.current !== null) {
-      closeImpactsRef.current();
-    }
   }, [currentInterventionType, resetField, closeSupplierRef, intervention, indicatorNameCodes]);
 
   useEffect(() => {
@@ -551,6 +546,17 @@ const InterventionForm: React.FC<InterventionFormProps> = ({
     () => Boolean(currentT1SupplierId || currentProducerId),
     [currentT1SupplierId, currentProducerId],
   );
+
+  useEffect(() => {
+    // * closes "Impacts per ton" panel whenever the intervention type changes and coefficients are not edited
+    if (
+      closeImpactsRef.current !== null &&
+      !areCoefficientsEdited &&
+      currentInterventionType !== InterventionTypes.Efficiency
+    ) {
+      closeImpactsRef.current();
+    }
+  }, [currentInterventionType, areCoefficientsEdited]);
 
   return (
     <form
@@ -1109,7 +1115,13 @@ const InterventionForm: React.FC<InterventionFormProps> = ({
               </Disclosure>
             )}
 
-            <Disclosure as="div" className="space-y-4">
+            <Disclosure
+              as="div"
+              className="space-y-4"
+              defaultOpen={
+                currentInterventionType === InterventionTypes.Efficiency || areCoefficientsEdited
+              }
+            >
               {({ open, close }) => {
                 closeImpactsRef.current = close;
 
@@ -1138,10 +1150,7 @@ const InterventionForm: React.FC<InterventionFormProps> = ({
                       </Disclosure.Button>
                     </div>
                     <Disclosure.Panel
-                      static={
-                        currentInterventionType === InterventionTypes.Efficiency ||
-                        areCoefficientsEdited
-                      }
+                      static={currentInterventionType === InterventionTypes.Efficiency}
                     >
                       <div className="space-y-4">
                         {indicators?.map((indicator) => (


### PR DESCRIPTION
### General description

https://vizzuality.atlassian.net/browse/LANDGRIF-1246

Fixes issue toggling coefficients panel in intervention form. Now the panel is static (no way to handle open/close states) when the intervention type is `Change production efficiency`. Also, the panel will be open by default whenever the intervention type is `Change production efficiency` and coefficients are modified. Swapping to other intervention types will close the panel if coefficients are not modified.

![image](https://user-images.githubusercontent.com/999124/223415016-45b68eb3-8a50-4d41-991b-fb363a9e00e2.png)


### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

_Provide minimal instructions on how to test this PR._

- Apart from the added feature / bug fix, check overall performance, styling...

## Checklist before merging

- [x] Branch name / PR includes the related Jira ticket Id.
- [ ] Tests to check core implementation / bug fix added.
- [ ] All checks in Continuous Integration workflow pass.
- [ ] Feature functionally tested by reviewer(s).
- [ ] Code reviewed by reviewer(s).
- [x] Documentation updated (README, CHANGELOG...) (if required)
