### PR TITLE
Fix selector allowing to select disabled options on search

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Replaced Deck.gl map with `react-map-gl` to prepare migration to Layer Manager. [LANDGRIF-812](https://vizzuality.atlassian.net/browse/LANDGRIF-812)
 
 ### Fixed
+- Fix selectors allowing select disabled options when searching [LANDGRIF-1318](https://vizzuality.atlassian.net/browse/LANDGRIF-1318)
 - Wrong error message in the scenario creation [LANDGRIF-1302](https://vizzuality.atlassian.net/browse/LANDGRIF-1302)
 - Fix map resizing when sidebar is collapsed [LANDGRIF-1305](https://vizzuality.atlassian.net/browse/LANDGRIF-1305)
 - Uploading excel [LANDGRIF-1304](https://vizzuality.atlassian.net/browse/LANDGRIF-1304)

--- a/client/src/components/tree-select/search-overlay.tsx
+++ b/client/src/components/tree-select/search-overlay.tsx
@@ -13,13 +13,15 @@ interface SearchOverlayProps {
   options: (WithRequiredProperty<Partial<FlattenNode<TreeDataNode>>, 'key' | 'title'> & {
     isSelected: boolean;
     matchingParts: MatchResult[];
+    disabled?: boolean;
   })[];
   onChange: Dispatch<Key>;
 }
 
 const SearchOverlay = ({ options, onChange }: SearchOverlayProps) => {
   const getHandleChange = useCallback(
-    (value: TreeSelectOption['value']) => () => {
+    (value: TreeSelectOption['value'], disabled?: boolean) => () => {
+      if (disabled) return;
       onChange(value);
     },
     [onChange],
@@ -27,18 +29,19 @@ const SearchOverlay = ({ options, onChange }: SearchOverlayProps) => {
 
   return (
     <div data-testid="tree-select-search-results">
-      {options.map(({ matchingParts, data: { label }, key, isSelected, parent }) => {
+      {options.map(({ matchingParts, data: { label }, key, isSelected, parent, disabled }) => {
         const parents = getParents({ parent } as FlattenNode<TreeDataNode>);
         return (
           <button
             title={label}
             type="button"
-            className={classNames(
-              'text-sm p-2 hover:bg-navy-50 cursor-pointer w-full text-left',
-              isSelected ? 'font-bold text-navy-400' : 'text-gray-900',
-            )}
+            className={classNames('text-sm p-2 w-full text-left', {
+              'font-bold cursor-pointer text-navy-400 hover:bg-navy-50': isSelected,
+              'text-gray-300 hover:bg-white cursor-default pointer-events-none': disabled,
+              'text-gray-900 cursor-pointer hover:bg-navy-50': !isSelected && !disabled,
+            })}
             key={key}
-            onClick={getHandleChange(key as string)}
+            onClick={getHandleChange(key as string, disabled)}
           >
             {matchingParts.map(({ value, isMatch }, i) => {
               return (

--- a/client/src/components/tree-select/search-overlay.tsx
+++ b/client/src/components/tree-select/search-overlay.tsx
@@ -41,7 +41,7 @@ const SearchOverlay = ({ options, onChange }: SearchOverlayProps) => {
               'text-gray-900 cursor-pointer hover:bg-navy-50': !isSelected && !disabled,
             })}
             key={key}
-            onClick={getHandleChange(key as string, disabled)}
+            onClick={!disabled && getHandleChange(key as string)}
           >
             {matchingParts.map(({ value, isMatch }, i) => {
               return (

--- a/client/src/components/tree-select/search-overlay.tsx
+++ b/client/src/components/tree-select/search-overlay.tsx
@@ -38,7 +38,7 @@ const SearchOverlay = ({ options, onChange }: SearchOverlayProps) => {
               'text-gray-900 cursor-pointer hover:bg-navy-50': !isSelected && !disabled,
             })}
             key={key}
-            onClick={!disabled && getHandleChange(key as string)}
+            onClick={() => !disabled && getHandleChange(key as string)}
           >
             {matchingParts.map(({ value, isMatch }, i) => {
               return (

--- a/client/src/components/tree-select/search-overlay.tsx
+++ b/client/src/components/tree-select/search-overlay.tsx
@@ -20,10 +20,7 @@ interface SearchOverlayProps {
 
 const SearchOverlay = ({ options, onChange }: SearchOverlayProps) => {
   const getHandleChange = useCallback(
-    (value: TreeSelectOption['value'], disabled?: boolean) => () => {
-      if (disabled) return;
-      onChange(value);
-    },
+    (value: TreeSelectOption['value']) => onChange(value),
     [onChange],
   );
 


### PR DESCRIPTION
### General description 

This PR fixes the filter selectors that was allowing to select disabled options when searching

### Testing instructions

1. Go to [/analysis/map](https://landgriffon-client-git-client-bugfixlandgrif-627d64-vizzuality1.vercel.app/analysis/map)
2. Click on 'Filters' icon and 'Materials'
3. Look for a disabled material option and search for it
4. Try to click the material that is disabled. The style should be different from the others, the pointer events should be disabled 

https://github.com/Vizzuality/landgriffon/assets/48164343/78ae97e1-cc30-4aed-8084-1d59263be3f2

### Related task
[LANDGRIF-1318](https://vizzuality.atlassian.net/browse/LANDGRIF-1318)

## Checklist before merging

- [x] Branch name / PR includes the related Jira ticket Id.
- [ ] Tests to check core implementation / bug fix added.
- [x] All checks in Continuous Integration workflow pass.
- [ ] Feature functionally tested by reviewer(s).
- [ ] Code reviewed by reviewer(s).
- [ ] Documentation updated (README, CHANGELOG...) (if required)


[LANDGRIF-1318]: https://vizzuality.atlassian.net/browse/LANDGRIF-1318?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ