### PR TITLE
Remove signup from client

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Add filter by year on analysis table. [LANDGRIF-965](https://vizzuality.atlassian.net/browse/LANDGRIF-965)
 
 ### Changed
+- Signup removed from auth page.[LANDGRIF-1314](https://vizzuality.atlassian.net/browse/LANDGRIF-1314) 
 - Updated date and time format in the upload data page, also added the author [LANDGRIF-1297](https://vizzuality.atlassian.net/browse/LANDGRIF-1297)
 - Changed table style. [LANDGRIF-1299](https://vizzuality.atlassian.net/browse/LANDGRIF-1299)
 - Updated axios version.

--- a/client/cypress/e2e/data.cy.ts
+++ b/client/cypress/e2e/data.cy.ts
@@ -11,6 +11,7 @@ describe('Data page', () => {
     cy.interceptAllRequests();
     cy.login();
     cy.visit('/data');
+    cy.wait('@sourcingLocations');
   });
 
   afterEach(() => {
@@ -33,12 +34,12 @@ describe('Data page', () => {
   });
 
   it('admin should be able to upload data source', () => {
-    cy.intercept('api/v1/users/me', { fixture: 'profiles/admin' });
+    cy.intercept('/api/v1/users/me', { fixture: 'profiles/admin' });
     cy.get('[data-testid="upload-data-source-btn"]').should('not.be.disabled');
   });
 
   it('not admin user should not be able to upload data source', () => {
-    cy.intercept('api/v1/users/me', { fixture: 'profiles/no-permissions' });
+    cy.intercept('/api/v1/users/me', { fixture: 'profiles/no-permissions' });
     cy.get('[data-testid="upload-data-source-btn"]').should('be.disabled');
   });
 });

--- a/client/cypress/e2e/sign-up.cy.ts
+++ b/client/cypress/e2e/sign-up.cy.ts
@@ -8,20 +8,24 @@ describe('Sign up', () => {
     cy.visit('/auth/signup');
   });
 
-  it('A user is able to sign up for the platform', () => {
-    cy.fixture('auth/sign-up').then((signUpPayload) => {
-      // * full fills signup form
-      cy.get('[data-testid="lname-input"]').type(signUpPayload.fname);
-      cy.get('[data-testid="fname-input"]').type(signUpPayload.lname);
-      cy.get('[data-testid="email-input"]').type(signUpPayload.email);
-      cy.get('[data-testid="password-input"]').type(signUpPayload.password);
-      cy.get('[data-testid="confirm-password-input"]').type(signUpPayload.password);
-      cy.get('[data-testid="sign-up-submit-btn"]').click();
-
-      // * waits for the request and confirms toast message. Then, we confirm the user has been redirected to /auth/signin page
-      cy.wait('@signUpRequest').its('response.statusCode').should('eq', 201);
-      cy.get('[data-testid="toast-message"]').should('contain', 'Account created successfully');
-      cy.url().should('contain', '/auth/signin');
-    });
+  it('Signing up is temporally disabled and the path redirects to signin page', () => {
+    cy.url().should('contain', '/auth/signin');
   });
+
+  // it('A user is able to sign up for the platform', () => {
+  //   cy.fixture('auth/sign-up').then((signUpPayload) => {
+  //     // * full fills signup form
+  //     cy.get('[data-testid="lname-input"]').type(signUpPayload.fname);
+  //     cy.get('[data-testid="fname-input"]').type(signUpPayload.lname);
+  //     cy.get('[data-testid="email-input"]').type(signUpPayload.email);
+  //     cy.get('[data-testid="password-input"]').type(signUpPayload.password);
+  //     cy.get('[data-testid="confirm-password-input"]').type(signUpPayload.password);
+  //     cy.get('[data-testid="sign-up-submit-btn"]').click();
+
+  //     // * waits for the request and confirms toast message. Then, we confirm the user has been redirected to /auth/signin page
+  //     cy.wait('@signUpRequest').its('response.statusCode').should('eq', 201);
+  //     cy.get('[data-testid="toast-message"]').should('contain', 'Account created successfully');
+  //     cy.url().should('contain', '/auth/signin');
+  //   });
+  // });
 });

--- a/client/cypress/support/commands.ts
+++ b/client/cypress/support/commands.ts
@@ -202,7 +202,7 @@ Cypress.Commands.add('interceptAllRequests', (): void => {
   cy.intercept('GET', '/api/v1/sourcing-locations*', {
     statusCode: 200,
     fixture: 'sourcing-locations/index',
-  });
+  }).as('sourcingLocations');
 
   // Sourcing record years requests
   cy.intercept('GET', '/api/v1/sourcing-records/years', {

--- a/client/next.config.js
+++ b/client/next.config.js
@@ -20,6 +20,11 @@ const nextConfig = {
         destination: '/analysis/map',
         permanent: false,
       },
+      {
+        source: '/auth/signup',
+        destination: '/auth/signin',
+        permanent: false,
+      },
     ];
   },
 };

--- a/client/src/pages/auth/signin.tsx
+++ b/client/src/pages/auth/signin.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import Head from 'next/head';
+// import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { signIn } from 'next-auth/react';
 import { useForm } from 'react-hook-form';
@@ -128,6 +129,14 @@ const SignIn: NextPageWithLayout = () => {
             </div>
           </form>
         </div>
+        {/* <div className="my-4">
+          <p className="text-sm text-center">
+            <span className="text-white/50">Don&apos;t have an account? </span>
+            <Link href="/auth/signup" className="text-white">
+              Sign-up
+            </Link>
+          </p>
+        </div> */}
       </div>
     </>
   );

--- a/client/src/pages/auth/signin.tsx
+++ b/client/src/pages/auth/signin.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
 import Head from 'next/head';
-import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { signIn } from 'next-auth/react';
 import { useForm } from 'react-hook-form';
@@ -128,14 +127,6 @@ const SignIn: NextPageWithLayout = () => {
               </Button>
             </div>
           </form>
-        </div>
-        <div className="my-4">
-          <p className="text-sm text-center">
-            <span className="text-white/50">Don&apos;t have an account? </span>
-            <Link href="/auth/signup" className="text-white">
-              Sign-up
-            </Link>
-          </p>
         </div>
       </div>
     </>


### PR DESCRIPTION
### General description
This PR removes the signup link from auth page, creates a redirect from signup to signin and changes the cypress test

### Testing instructions

1. Go to [/auth](https://landgriffon-client-git-client-featurelandgri-d7e84d-vizzuality1.vercel.app/auth/signin): the sign-up link should not exist
2. Change manually the url to [/auth/signup](https://landgriffon-client-git-client-featurelandgri-d7e84d-vizzuality1.vercel.app/auth/signup): you should be redirected to [/auth/signin](https://landgriffon-client-git-client-featurelandgri-d7e84d-vizzuality1.vercel.app/auth/signin)


### Task
https://vizzuality.atlassian.net/browse/LANDGRIF-1314

## Checklist before merging

- [ ] Branch name / PR includes the related Jira ticket Id.
- [ ] Tests to check core implementation / bug fix added.
- [ ] All checks in Continuous Integration workflow pass.
- [ ] Feature functionally tested by reviewer(s).
- [ ] Code reviewed by reviewer(s).
- [ ] Documentation updated (README, CHANGELOG...) (if required)
