### PR TITLE
(bugfix) CI/CD fixes

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -20,7 +20,7 @@
     "test:cov": "node --expose-gc ./node_modules/.bin/jest --config test/jest-config.json --coverage --forceExit",
     "test:debug": "node --inspect-brk --expose-gc -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --config test/jest-config.json --detectOpenHandles --forceExit",
     "test:integration": "node --expose-gc ./node_modules/.bin/jest --config test/jest-config.json --forceExit test/integration/",
-    "test:e2e": "NODE_OPTIONS=\"--max-old-space-size=6144\" node --expose-gc ./node_modules/.bin/jest --config test/jest-config.json --logHeapUsage --forceExit test/e2e/"
+    "test:e2e": "NODE_OPTIONS=\"--max-old-space-size=8192\" node --expose-gc ./node_modules/.bin/jest --config test/jest-config.json --logHeapUsage --forceExit test/e2e/"
   },
   "engines": {
     "node": "^18.12"

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -17,6 +17,7 @@
     "strictNullChecks": true,
     "strictPropertyInitialization": false,
     "target": "es2017",
+    "moduleResolution": "nodenext"
   },
   "exclude": [
     "node_modules",


### PR DESCRIPTION
1. bumps node memory to 8GB for CI runs
2. adds ts module resolution option to fix docker image builds