### PR TITLE
Fixes vector ingestion to slugify column names

### DIFF
--- a/data/h3_data_importer/vector_folder_to_h3_table.py
+++ b/data/h3_data_importer/vector_folder_to_h3_table.py
@@ -106,6 +106,8 @@ def vector_file_to_h3dataframe(
     if not h3df.empty:
         # we want h3index as hex, do we?
         h3df.index = pd.Series(h3df.index).apply(lambda x: hex(x))
+        # slugify column name to be ColumnName as everywhere else
+        h3df = h3df.rename(columns={column: slugify(column)})
         return h3df
 
 
@@ -168,7 +170,7 @@ def main(
     if len(vectors) == 1:  # folder just contains one vector file
         df = vector_file_to_h3dataframe(vectors[0], column, h3_res)
         create_h3_grid_table(table, df, conn)
-        insert_to_h3_grid_table(table, df, conn)  # apply multiprocessing here if needed
+        insert_to_h3_grid_table(table, df, conn)
         # slugify the column name to follow the convention of db column naming
         column = slugify(column)
         insert_to_h3_data_and_contextual_layer_tables(table, column, h3_res, dataset, category, year, conn)


### PR DESCRIPTION
Because of a small refactor ( [this](https://github.com/Vizzuality/landgriffon/commit/07ea0fc53cc904781c0ceafa5194977524c77e77#diff-2a278b14a8f1fa0ca6b068a14735794325308de74fceb18bfb892de4112a80f8L118) to [this](https://github.com/Vizzuality/landgriffon/commit/07ea0fc53cc904781c0ceafa5194977524c77e77#diff-4f3cb26a91c983470f700a0d6d9f3270961fca4c14b40b7528548c58a16a7c05R154-R169) ) I destroyed the slugification of the column name in vecotor_folder_to_h3_table. My fault. This PR re introduces the slugification of the column name in a nicer place (hopefully)