### PR TITLE
Add download of upload file errors

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [v0.5.0 Unreleased]
 
 ### Added
+- Download file with upload errors [LANGRIF-1342](https://vizzuality.atlassian.net/browse/LANDGRIF-1342)
 - Showing progress and errors for data upload [LANDGRIF-1293](https://vizzuality.atlassian.net/browse/LANDGRIF-1293)
 - Integration of local layer to handle different type of layers in the future. [LANDGRIF-1248](https://vizzuality.atlassian.net/browse/LANDGRIF-1248)
 - New purple style for scenario select in analysis page. [LANDGRIF-1037](https://vizzuality.atlassian.net/browse/LANDGRIF-1037)

--- a/client/src/containers/admin/data-upload-error/component.tsx
+++ b/client/src/containers/admin/data-upload-error/component.tsx
@@ -31,7 +31,7 @@ const DataUploadError: React.FC<DataUploadErrorProps> = ({ task }) => {
     updateTask.mutate({ id: task.id, data: { dismissedBy: profile?.id } });
   }, [profile?.id, task.id, updateTask]);
 
-  const { data: taskErrors, isLoading: isTaskErrorsLoading } = useTaskErrors(task.id, {
+  const { data: taskErrors, isFetching } = useTaskErrors(task.id, {
     enabled: task?.status === 'failed' && task?.errors.length > 0,
   });
 
@@ -117,7 +117,7 @@ const DataUploadError: React.FC<DataUploadErrorProps> = ({ task }) => {
             </Button>
           ) : (
             <Button
-              loading={isTaskErrorsLoading}
+              loading={isFetching}
               variant="white"
               disabled={!taskErrors}
               onClick={handleDownload}

--- a/client/src/containers/admin/data-upload-error/component.tsx
+++ b/client/src/containers/admin/data-upload-error/component.tsx
@@ -31,16 +31,12 @@ const DataUploadError: React.FC<DataUploadErrorProps> = ({ task }) => {
     updateTask.mutate({ id: task.id, data: { dismissedBy: profile?.id } });
   }, [profile?.id, task.id, updateTask]);
 
-  const { data: taskErrors, isFetching } = useTaskErrors(task.id, {
-    enabled: task?.status === 'failed' && task?.errors.length > 0,
+  const { isFetching, refetch } = useTaskErrors(task.id, {
+    enabled: false,
+    onSuccess: (data) => triggerCsvDownload(data, `${task.data?.filename}_errors.csv`),
   });
 
   if (task?.dismissedBy) return null;
-
-  const handleDownload = () => {
-    if (!taskErrors) return;
-    triggerCsvDownload(taskErrors, `${task.data?.filename}_errors.csv`);
-  };
 
   return (
     <Disclaimer
@@ -119,8 +115,8 @@ const DataUploadError: React.FC<DataUploadErrorProps> = ({ task }) => {
             <Button
               loading={isFetching}
               variant="white"
-              disabled={!taskErrors}
-              onClick={handleDownload}
+              disabled={!task.errors?.length}
+              onClick={() => refetch()}
             >
               Download
             </Button>

--- a/client/src/hooks/tasks/index.ts
+++ b/client/src/hooks/tasks/index.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
-import { apiService } from 'services/api';
+import { apiRawService, apiService } from 'services/api';
 
 import type { UseQueryResult, UseQueryOptions, UseMutationResult } from '@tanstack/react-query';
 import type { APIMetadataPagination, ErrorResponse, Task } from 'types';
@@ -99,4 +99,28 @@ export function useUpdateTask(): UseMutationResult<TaskAPIResponse> {
       },
     },
   );
+}
+
+export function useTaskErrors(
+  id: Task['id'],
+  options: UseQueryOptions<string> = {},
+): UseQueryResult<string> {
+  const query = useQuery<string>(
+    ['task-error', id],
+    () =>
+      apiRawService
+        .request({
+          method: 'GET',
+          url: `/tasks/report/errors/${id}`,
+          params: {
+            type: 'sourcing_data_import',
+          },
+        })
+        .then(({ data: responseData }) => responseData),
+    {
+      ...DEFAULT_QUERY_OPTIONS,
+      ...options,
+    },
+  );
+  return query;
 }

--- a/client/src/types.d.ts
+++ b/client/src/types.d.ts
@@ -349,6 +349,7 @@ export type Task = {
   status: 'completed' | 'abort' | 'failed' | 'processing';
   errors?: Record<string, string>[];
   user?: User;
+  data?: Record<string, unknown>;
   createdAt: string;
   dismissedBy: string;
 };


### PR DESCRIPTION
### General description

This PR adds the download of the upload errors

### Testing instructions

1. Upload a file with errors
2. After the uploading process is finished, an error message will be displayed and a download button should be enabled.
3. Click on the button. A csv file with 2 columns (line, error) should be downloaded.   

### Related task
https://vizzuality.atlassian.net/browse/LANDGRIF-1342

## Checklist before merging

- [ ] Branch name / PR includes the related Jira ticket Id.
- [ ] Tests to check core implementation / bug fix added.
- [ ] All checks in Continuous Integration workflow pass.
- [ ] Feature functionally tested by reviewer(s).
- [ ] Code reviewed by reviewer(s).
- [ ] Documentation updated (README, CHANGELOG...) (if required)
