### PR TITLE
Fix treeselect auto scroll

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Replaced Deck.gl map with `react-map-gl` to prepare migration to Layer Manager. [LANDGRIF-812](https://vizzuality.atlassian.net/browse/LANDGRIF-812)
 
 ### Fixed
+- Fixed treeselect auto scroll [LANDGRIF-1435](https://vizzuality.atlassian.net/browse/LANDGRIF-1435)
 - Fix selectors allowing select disabled options when searching [LANDGRIF-1318](https://vizzuality.atlassian.net/browse/LANDGRIF-1318)
 - Wrong error message in the scenario creation [LANDGRIF-1302](https://vizzuality.atlassian.net/browse/LANDGRIF-1302)
 - Fix map resizing when sidebar is collapsed [LANDGRIF-1305](https://vizzuality.atlassian.net/browse/LANDGRIF-1305)

--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Changed
 - Updated sidebar design. [LANDGRIF-1035](https://vizzuality.atlassian.net/browse/LANDGRIF-1035)
 
+### Fixed
+- Fixed treeselect auto scroll [LANDGRIF-1435](https://vizzuality.atlassian.net/browse/LANDGRIF-1435)
+
 ## [v0.5.0]
 
 ### Added
@@ -40,7 +43,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Replaced Deck.gl map with `react-map-gl` to prepare migration to Layer Manager. [LANDGRIF-812](https://vizzuality.atlassian.net/browse/LANDGRIF-812)
 
 ### Fixed
-- Fixed treeselect auto scroll [LANDGRIF-1435](https://vizzuality.atlassian.net/browse/LANDGRIF-1435)
 - Fix selectors allowing select disabled options when searching [LANDGRIF-1318](https://vizzuality.atlassian.net/browse/LANDGRIF-1318)
 - Wrong error message in the scenario creation [LANDGRIF-1302](https://vizzuality.atlassian.net/browse/LANDGRIF-1302)
 - Fix map resizing when sidebar is collapsed [LANDGRIF-1305](https://vizzuality.atlassian.net/browse/LANDGRIF-1305)

--- a/client/src/components/tree-select/component.tsx
+++ b/client/src/components/tree-select/component.tsx
@@ -308,7 +308,9 @@ const InnerTreeSelect = <IsMulti extends boolean>(
 
     // for some reason, there's an invisible .rc-tree-treenode outside of the list. With this selector we ensure to get the element only if it has a sibling of the same type
     const firstChild = listContainer.querySelector('.rc-tree-treenode ~ .rc-tree-treenode');
-    const offset = firstChild?.clientHeight || 0;
+
+    // ELEMENT.getBoundingClientRect().height returns the height with decimals, and ELEMENT.clientHeight returns just the integer. If the list size is large, the decimals are enough to make the scroll not work properly
+    const offset = firstChild?.getBoundingClientRect().height || 0;
 
     listContainer.scrollTop = offset * (elementIndex + 1) - listHeight / 2;
     setKeyToScroll(undefined);
@@ -548,6 +550,7 @@ const InnerTreeSelect = <IsMulti extends boolean>(
               'bg-white max-h-80 overflow-y-auto',
               fitContent ? 'max-w-full w-full' : 'max-w-xs',
             )}
+            id="list-container"
           >
             {loading ? (
               <div className="p-4">


### PR DESCRIPTION
### General description

This pr fixes a bug with the tree-select auto-scroll when selecting a item

### Testing instructions

1. Go to analysis/map and open the filters
2. Type 'spain' in the 'Producers' selector and click in the 'Spain' option
3. The selected item 'Spain' should appear in the middle of the dropdown

Try the same with other filters. The longer the list, the more likely the bug appears. 

### Task
https://vizzuality.atlassian.net/browse/LANDGRIF-1435

## Checklist before merging

- [ ] Branch name / PR includes the related Jira ticket Id.
- [ ] Tests to check core implementation / bug fix added.
- [ ] All checks in Continuous Integration workflow pass.
- [ ] Feature functionally tested by reviewer(s).
- [ ] Code reviewed by reviewer(s).
- [ ] Documentation updated (README, CHANGELOG...) (if required)
