### PR TITLE
Add T1 Supplier and Producer to analysis 'group by' filter

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- Changed analysis/table 'group by' filter value 'Supplier' to 'T1 Supplier' and 'Producer' [LANDGRIF-1441](https://vizzuality.atlassian.net/browse/LANDGRIF-1441)
 - Updated sidebar design. [LANDGRIF-1035](https://vizzuality.atlassian.net/browse/LANDGRIF-1035)
 
 ### Fixed

--- a/client/src/containers/analysis-visualization/analysis-filters/group-by/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-filters/group-by/component.tsx
@@ -22,8 +22,12 @@ const GROUP_BY_OPTIONS: Group[] = [
     name: 'Region',
   },
   {
-    id: 'supplier',
-    name: 'Supplier',
+    id: 't1Supplier',
+    name: 'T1 Supplier',
+  },
+  {
+    id: 'producer',
+    name: 'Producer',
   },
   {
     id: 'location-type',


### PR DESCRIPTION
This PR changes the analysis/table  and analysis/chart 'group by' filter value 'Supplier' to 'T1 Supplier' and 'Producer'


### Testing instructions

In analysis table and chart, select the 'group by' filter option 'T1 Supplier' and 'Producer'
The table/chart should be updated with the correct filter

### Task
[LANDGRIF-1441](https://vizzuality.atlassian.net/browse/LANDGRIF-1441)


[LANDGRIF-1441]: https://vizzuality.atlassian.net/browse/LANDGRIF-1441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ