### PR TITLE
Fix remove badge when unselecting 'T1 supplier' filter in analysis

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Fixed remove badge when unselecting 'T1 supplier' filter in analysis [LANDGRIF-1442](https://vizzuality.atlassian.net/browse/LANDGRIF-1442)
 - Fixed analysis filters selectors width [LANDGRIF-1437](https://vizzuality.atlassian.net/browse/LANDGRIF-1437)
 - Fixed treeselect auto scroll [LANDGRIF-1435](https://vizzuality.atlassian.net/browse/LANDGRIF-1435)
 

--- a/client/src/containers/analysis-visualization/analysis-dynamic-metadata/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-dynamic-metadata/component.tsx
@@ -127,7 +127,7 @@ const AnalysisDynamicMetadata: FC<AnalysisDynamicMetadataTypes> = ({
                 <Badge
                   key={supplier.value}
                   data={supplier}
-                  onClick={() => handleRemoveBadge('suppliers', t1Suppliers, supplier)}
+                  onClick={() => handleRemoveBadge('t1Suppliers', t1Suppliers, supplier)}
                   removable
                 >
                   {supplier.label}


### PR DESCRIPTION
### General description

Changed analysis/table 'group by' filter value 'Supplier' to 'T1 Supplier' and 'Producer' 

### Testing instructions

Go to analysis/table or analysis/chart
Select a t1 supplier filter
Unselect it clicking at the t1 supplier badge. The filter should be removed

## Task
[LANDGRIF-1442](https://vizzuality.atlassian.net/browse/LANDGRIF-1442)

[LANDGRIF-1442]: https://vizzuality.atlassian.net/browse/LANDGRIF-1442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ