### PR TITLE
Fix intervention creation: business units check strategy

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Fixed
 
 - Fixed remove badge when unselecting 'T1 supplier' filter in analysis [LANDGRIF-1442](https://vizzuality.atlassian.net/browse/LANDGRIF-1442)
+- Fixed intervention creation: business units check strategy [LANDGRIF-1444](https://vizzuality.atlassian.net/browse/LANDGRIF-1444)
 - Fixed analysis filters selectors width [LANDGRIF-1437](https://vizzuality.atlassian.net/browse/LANDGRIF-1437)
 - Fixed treeselect auto scroll [LANDGRIF-1435](https://vizzuality.atlassian.net/browse/LANDGRIF-1435)
 

--- a/client/src/containers/interventions/form/component.tsx
+++ b/client/src/containers/interventions/form/component.tsx
@@ -646,22 +646,23 @@ const InterventionForm: React.FC<InterventionFormProps> = ({
           <Controller
             name="businessUnitIds"
             control={control}
-            render={({ field: { value, ...field } }) => (
-              <BusinessUnitsSelect
-                {...field}
-                multiple
-                placeholder="All business units"
-                checkedStrategy={isCreation ? 'CHILD' : undefined}
-                materialIds={currentMaterialIds?.map(({ value }) => value)}
-                t1SupplierIds={currentT1SupplierIds?.map(({ value }) => value)}
-                producerIds={currentProducerIds?.map(({ value }) => value)}
-                originIds={currentLocationIds?.map(({ value }) => value)}
-                withSourcingLocations
-                current={value}
-                error={!!errors?.businessUnitIds}
-                data-testid="business-units-select"
-              />
-            )}
+            render={({ field: { value, ...field } }) => {
+              return (
+                <BusinessUnitsSelect
+                  {...field}
+                  multiple
+                  placeholder="All business units"
+                  materialIds={currentMaterialIds?.map(({ value }) => value)}
+                  t1SupplierIds={currentT1SupplierIds?.map(({ value }) => value)}
+                  producerIds={currentProducerIds?.map(({ value }) => value)}
+                  originIds={currentLocationIds?.map(({ value }) => value)}
+                  withSourcingLocations
+                  current={value}
+                  error={!!errors?.businessUnitIds}
+                  data-testid="business-units-select"
+                />
+              );
+            }}
           />
         </div>
         <div>


### PR DESCRIPTION
### General description

This PR fixes the intervention creation form, changing the business units check strategy.

Undesired behaviour (before)
<img width="363" alt="Screenshot 2023-07-17 at 10 05 14" src="https://github.com/Vizzuality/landgriffon/assets/48164343/f7a93dd1-5082-45fd-9776-043aad75d325">

Desired behaviour (now)
<img width="297" alt="Screenshot 2023-07-17 at 10 05 31" src="https://github.com/Vizzuality/landgriffon/assets/48164343/7bd9cf2b-3853-4715-a353-aff5ca4fb832">



### Testing instructions

Go to a scenario and add a new intervention.
Check the business unit  'Hair Care'. If the parent or both the children are selected, the value showed in the tag should be the parent 'Hair Care'.

## Task
 [LANDGRIF-1441](https://vizzuality.atlassian.net/browse/LANDGRIF-1441)

[LANDGRIF-1441]: https://vizzuality.atlassian.net/browse/LANDGRIF-1441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ