### PR TITLE
Fix edit intervention admin region

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Fixed edit intervention admin region [LANDGRIF-1445](https://vizzuality.atlassian.net/browse/LANDGRIF-1445)
 - Fixed remove badge when unselecting 'T1 supplier' filter in analysis [LANDGRIF-1442](https://vizzuality.atlassian.net/browse/LANDGRIF-1442)
 - Fixed analysis filters selectors width [LANDGRIF-1437](https://vizzuality.atlassian.net/browse/LANDGRIF-1437)
 - Fixed treeselect auto scroll [LANDGRIF-1435](https://vizzuality.atlassian.net/browse/LANDGRIF-1435)

--- a/client/src/containers/interventions/form/component.tsx
+++ b/client/src/containers/interventions/form/component.tsx
@@ -373,7 +373,7 @@ const InterventionForm: React.FC<InterventionFormProps> = ({
           newLocationAdminRegionInput: intervention.newAdminRegion
             ? {
                 label: intervention.newAdminRegion.name,
-                value: intervention.newAdminRegion.id,
+                value: intervention.newAdminRegion.name,
               }
             : null,
 


### PR DESCRIPTION
### General description

This PR fixes a bug that was generated when the user tried to edit the admin region of a intervention for the second time

please read the [task](https://vizzuality.atlassian.net/browse/LANDGRIF-1445) for more detailed explanation

### Testing instructions

1. Go to a scenarios, choose a intervention and click 'edit'
2. At the bottom of the page, on 'New location', change  the 'region' field.
3. Save the edition. Go back to the same intervention 'edit' and try to 'save intervention' without changing any  property. 
