### PR TITLE
Client/feature/landgrif 1343 show role of the user in the profile page but its not editable

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- From update user form: removed 'display name' adn added 'company title' [LANDGRIF-1343](https://vizzuality.atlassian.net/browse/LANDGRIF-1343)
 - Changed analysis/table 'group by' filter value 'Supplier' to 'T1 Supplier' and 'Producer' [LANDGRIF-1441](https://vizzuality.atlassian.net/browse/LANDGRIF-1441)
 - Add avatar to user list [LANDGRIF-1344](https://vizzuality.atlassian.net/browse/LANDGRIF-1344)
 - Updated sidebar design. [LANDGRIF-1035](https://vizzuality.atlassian.net/browse/LANDGRIF-1035)

--- a/client/src/containers/update-profile-form/component.tsx
+++ b/client/src/containers/update-profile-form/component.tsx
@@ -13,9 +13,8 @@ import type { ProfilePayload, ErrorResponse } from 'types';
 const schemaValidation = yup.object({
   fname: yup.string(),
   lname: yup.string(),
-  email: yup.string().email().required(),
-  roles: yup.array().of(yup.string()).optional().nullable(),
-  id: yup.string().nullable().optional(),
+  // email: yup.string().email().optional().nullable(), API DOES NOT SUPPORT EMAIL
+  companyTitle: yup.string().optional().nullable(),
 });
 
 const UserDataForm: React.FC = () => {
@@ -76,13 +75,23 @@ const UserDataForm: React.FC = () => {
                   />
                 </div>
 
-                <div className="">
+                <div>
                   <Label htmlFor="email">Email</Label>
                   <Input
-                    {...register('email')}
+                    // error={errors.email?.message as string}
+                    // {...register('email')} API DOES NOT SUPPORT EMAIL
                     defaultValue={user.data.email}
                     type="email"
-                    error={errors.email?.message as string}
+                    disabled
+                  />
+                </div>
+                <div>
+                  <Label htmlFor="companyTitle">Company title</Label>
+                  <Input
+                    {...register('companyTitle')}
+                    defaultValue={user.data.companyTitle}
+                    error={errors.companyTitle?.message as string}
+                    disabled
                   />
                 </div>
               </div>

--- a/client/src/containers/update-profile-form/component.tsx
+++ b/client/src/containers/update-profile-form/component.tsx
@@ -13,7 +13,6 @@ import type { ProfilePayload, ErrorResponse } from 'types';
 const schemaValidation = yup.object({
   fname: yup.string(),
   lname: yup.string(),
-  // email: yup.string().email().optional().nullable(), API DOES NOT SUPPORT EMAIL
   companyTitle: yup.string().optional().nullable(),
 });
 
@@ -78,8 +77,7 @@ const UserDataForm: React.FC = () => {
                 <div>
                   <Label htmlFor="email">Email</Label>
                   <Input
-                    // error={errors.email?.message as string}
-                    // {...register('email')} API DOES NOT SUPPORT EMAIL
+                    // {...register('email')} API DOES NOT SUPPORT EDIT EMAIL
                     defaultValue={user.data.email}
                     type="email"
                     disabled
@@ -91,7 +89,7 @@ const UserDataForm: React.FC = () => {
                     {...register('companyTitle')}
                     defaultValue={user.data.companyTitle}
                     error={errors.companyTitle?.message as string}
-                    disabled
+                    disabled // DISABLED UNTIL API SUPPORTS IT
                   />
                 </div>
               </div>

--- a/client/src/containers/update-profile-form/component.tsx
+++ b/client/src/containers/update-profile-form/component.tsx
@@ -84,7 +84,7 @@ const UserDataForm: React.FC = () => {
                   />
                 </div>
                 <div>
-                  <Label htmlFor="companyTitle">Company title</Label>
+                  <Label htmlFor="companyTitle">Title</Label>
                   <Input
                     {...register('companyTitle')}
                     defaultValue={user.data.companyTitle}

--- a/client/src/types.d.ts
+++ b/client/src/types.d.ts
@@ -231,10 +231,11 @@ export type Role = {
 export type ProfilePayload = {
   fname?: string;
   lname?: string;
-  email: string;
+  email?: string;
   password?: string;
-  roles: Role[];
-  id: string;
+  roles?: Role[];
+  id?: string;
+  companyTitle?: string;
 };
 
 // Password payload for API
@@ -363,6 +364,7 @@ export type Task = {
 export type User = {
   displayName: string;
   email: string;
+  companyTitle?: string;
   isActive: boolean;
   fname: string;
   lname: string;


### PR DESCRIPTION
### General description

This PR replaces the field 'display name' for 'company title' on edit user form
  
### Designs

[user form](https://www.figma.com/file/7bmF29CIXDJwCpuloW5Nt6/%F0%9F%94%B5-Landgriffon---Redesign_BLUE?type=design&node-id=1870-169612&mode=design&t=HBVAeGd7bLfirA0r-4)
Notice that there is a note in the designs and on the task comments to replace 'Company' for 'Title'

### Testing instructions

Go to /profile 
The edit user form shouldn’t have the field 'display name' anymore, but should have the 'title' field  

### Task
https://vizzuality.atlassian.net/browse/LANDGRIF-1343