### PR TITLE
Add user creation and edition form

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 - From update user form: removed 'display name' adn added 'company title' [LANDGRIF-1343](https://vizzuality.atlassian.net/browse/LANDGRIF-1343)
 - Changed the intervention form to send 'Unknown' newT1SupplierId and newProducerId when there is no value. [LANDGRIF-1448](https://vizzuality.atlassian.net/browse/LANDGRIF-1448)
+- Changed create and update user form [LANDGRIF-1345](https://vizzuality.atlassian.net/browse/LANDGRIF-1345)
 - Changed analysis/table 'group by' filter value 'Supplier' to 'T1 Supplier' and 'Producer' [LANDGRIF-1441](https://vizzuality.atlassian.net/browse/LANDGRIF-1441)
 - Add avatar to user list [LANDGRIF-1344](https://vizzuality.atlassian.net/browse/LANDGRIF-1344)
 - Change users list to don't show the current user [LANDGRIF-1346](https://vizzuality.atlassian.net/browse/LANDGRIF-1346)

--- a/client/cypress/fixtures/auth/me.json
+++ b/client/cypress/fixtures/auth/me.json
@@ -6,7 +6,6 @@
       "fname": null,
       "lname": null,
       "email": "jhon.smith@vizzuality.com",
-      "displayName": null,
       "avatarDataUrl": null,
       "isActive": true,
       "isDeleted": false,

--- a/client/cypress/fixtures/profiles/admin.json
+++ b/client/cypress/fixtures/profiles/admin.json
@@ -6,7 +6,6 @@
       "fname": null,
       "lname": null,
       "email": "user@vizzuality.com",
-      "displayName": null,
       "avatarDataUrl": null,
       "isActive": true,
       "isDeleted": false,

--- a/client/cypress/fixtures/profiles/all-permissions.json
+++ b/client/cypress/fixtures/profiles/all-permissions.json
@@ -6,7 +6,6 @@
       "fname": null,
       "lname": null,
       "email": "user@vizzuality.com",
-      "displayName": null,
       "avatarDataUrl": null,
       "isActive": true,
       "isDeleted": false,

--- a/client/cypress/fixtures/profiles/no-permissions.json
+++ b/client/cypress/fixtures/profiles/no-permissions.json
@@ -6,7 +6,6 @@
       "fname": null,
       "lname": null,
       "email": "user@vizzuality.com",
-      "displayName": null,
       "avatarDataUrl": null,
       "isActive": true,
       "isDeleted": false,

--- a/client/src/containers/admin/data-table/component.tsx
+++ b/client/src/containers/admin/data-table/component.tsx
@@ -171,7 +171,7 @@ const AdminDataPage: React.FC<{ task: Task }> = ({ task }) => {
               <span className="text-navy-400 underline">Last update</span> at{' '}
               {format(new Date(sourcingLocations.data[0].updatedAt), 'd MMM yyyy HH:mm z')}
               {task?.user && ' by '}
-              {getUserFullName(task?.user)}
+              {getUserFullName(task?.user, { replaceByEmail: true })}
             </div>
           </div>
         )}

--- a/client/src/containers/edit-user/component.tsx
+++ b/client/src/containers/edit-user/component.tsx
@@ -6,6 +6,8 @@ import { Button } from 'components/button';
 import Modal from 'components/modal';
 import DeleteUser from 'containers/delete-user-modal';
 import getUserFullName from 'utils/user-full-name';
+import { usePermissions } from 'hooks/permissions';
+import { RoleName } from 'hooks/permissions/enums';
 
 import type { User } from 'types';
 
@@ -17,16 +19,25 @@ const EditUser = ({ user }: EditUserProps) => {
   const [open, setOpenModal] = useState(false);
   const userName = getUserFullName(user, { replaceByEmail: true });
 
+  const closeModal = () => setOpenModal(false);
+  const { hasRole } = usePermissions();
+  const isAdmin = hasRole(RoleName.ADMIN);
   return (
     <>
-      <Button size="xs" variant="white" className="!text-sm" onClick={() => setOpenModal(true)}>
+      <Button
+        size="xs"
+        variant="white"
+        className="!text-sm"
+        disabled={!isAdmin}
+        onClick={() => setOpenModal(true)}
+      >
         Edit
       </Button>
-      <Modal open={open} title={`Edit user ${userName}`} onDismiss={() => setOpenModal(false)}>
-        <UserForm user={user}>
+      <Modal size="narrow" open={open} title={`Edit user ${userName}`} onDismiss={closeModal}>
+        <UserForm user={user} onSubmit={closeModal}>
           <div className="flex justify-between flex-1 mr-2.5 px-0.5">
             <DeleteUser id={user.id} userName={userName} />
-            <Button size="xs" variant="white" onClick={() => setOpenModal(false)}>
+            <Button size="xs" variant="white" onClick={closeModal}>
               Cancel
             </Button>
           </div>

--- a/client/src/containers/edit-user/user-form.tsx
+++ b/client/src/containers/edit-user/user-form.tsx
@@ -1,40 +1,91 @@
-import { useState } from 'react';
+import { useMemo } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import { omit, pick } from 'lodash-es';
+import toast from 'react-hot-toast';
+import * as yup from 'yup';
+import { yupResolver } from '@hookform/resolvers/yup';
 
 import { Button } from 'components/button';
 import Input from 'components/forms/input';
 import Select from 'components/forms/select';
 import { RoleName } from 'hooks/permissions/enums';
+import { useCreateUser, useEditUser } from 'hooks/users';
 
 import type { User } from 'types';
 import type { Option } from 'components/forms/select';
 
-type UserFormData = Pick<User, 'fname' | 'lname' | 'email'> & {
+const schemaValidation = yup.object({
+  fname: yup.string().optional().nullable(),
+  lname: yup.string().optional().nullable(),
+  title: yup.string().optional().nullable(),
+  email: yup.string().email().required('email is required'),
+  roles: yup
+    .array()
+    .of(yup.string())
+    .min(1, 'Select at least one role')
+    .required('role is required'),
+});
+
+type UserFormData = Pick<User, 'fname' | 'lname' | 'email' | 'title'> & {
   roles: RoleName[];
 };
 
 type UserFormProps = {
-  user: User;
-  children: React.ReactNode;
+  user?: User;
+  onSubmit?: () => void;
+  children?: React.ReactNode;
 };
 
-const UserForm = ({ user, children }: UserFormProps) => {
-  const { register, control, setValue } = useForm<UserFormData>({
-    defaultValues: {
-      ...pick(user, 'fname', 'lname', 'email'),
-      roles: user.roles.map((role) => role.name),
-    },
-  });
-
+const UserForm = ({ user, onSubmit, children }: UserFormProps) => {
   const roleOptions = Object.values(RoleName).map((role) => ({ label: role, value: role }));
 
-  const [roleValue, setRoleValue] = useState<Option<string>[]>(
-    user.roles.map((role) => ({ label: role.name, value: role.name })),
-  );
+  const {
+    register,
+    control,
+    setValue,
+    watch,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<UserFormData>({
+    defaultValues: {
+      ...pick(user, 'fname', 'lname', 'email', 'title'),
+      // Set a default role option 'User' if the user has no roles
+      roles: user?.roles.length ? user.roles.map((role) => role.name) : [RoleName.USER],
+    },
+    resolver: yupResolver(schemaValidation),
+  });
+
+  const updateUser = useEditUser();
+  const createUser = useCreateUser();
+
+  const { roles } = watch();
+
+  const roleValue = useMemo(() => {
+    return roles.map((role) => ({ label: role, value: role }));
+  }, [roles]);
+
+  const createOrUpdateOptions = {
+    onSuccess: () => {
+      toast.success(`User was ${!!user ? 'updated' : 'created'} successfully`);
+    },
+    onError: () => {
+      toast.error(`Failed to ${!!user ? 'update' : 'create'} user`);
+    },
+    onSettled: () => {
+      onSubmit?.();
+    },
+  };
+
+  const createOrUpdateUser = (data: UserFormData) => {
+    if (!user?.id) {
+      createUser.mutate(data, createOrUpdateOptions);
+    } else {
+      updateUser.mutate({ id: user.id, ...omit(data, 'email') }, createOrUpdateOptions); // API doesn't allow updating email
+    }
+  };
 
   return (
-    <form>
+    <form onSubmit={handleSubmit(createOrUpdateUser)}>
       <div className="grid grid-cols-2 gap-6 my-6">
         <div>
           <label htmlFor="fname">First Name</label>
@@ -43,6 +94,10 @@ const UserForm = ({ user, children }: UserFormProps) => {
         <div>
           <label htmlFor="lname">Last Name</label>
           <Input {...register('lname')} />
+        </div>
+        <div>
+          <label htmlFor="title">Title</label>
+          <Input {...register('title')} />
         </div>
         <div>
           <label htmlFor="roles">Role</label>
@@ -55,6 +110,7 @@ const UserForm = ({ user, children }: UserFormProps) => {
                   id="roles"
                   {...omit(field, 'ref')}
                   value={roleValue}
+                  defaultValue={roleOptions[0]}
                   options={roleOptions}
                   placeholder="Select a role"
                   onChange={(v: Option<string>[]) => {
@@ -62,10 +118,10 @@ const UserForm = ({ user, children }: UserFormProps) => {
                       'roles',
                       v.map((option) => option.value as RoleName),
                     );
-                    setRoleValue(v);
                   }}
                   multiple
-                  required
+                  error={errors?.roles?.message as string}
+                  showHint
                 />
               );
             }}
@@ -73,12 +129,17 @@ const UserForm = ({ user, children }: UserFormProps) => {
         </div>
         <div className="col-span-2">
           <label htmlFor="email">Email</label>
-          <Input {...register('email')} />
+          <Input
+            {...register('email')}
+            disabled={!!user?.id}
+            error={errors?.email?.message as string}
+            showHint
+          />
         </div>
       </div>
       <div className="flex">
         {children}
-        <Button size="xs" variant="primary" type="submit" disabled>
+        <Button size="xs" variant="primary" type="submit">
           Save
         </Button>
       </div>

--- a/client/src/containers/update-profile-form/component.tsx
+++ b/client/src/containers/update-profile-form/component.tsx
@@ -13,7 +13,7 @@ import type { ProfilePayload, ErrorResponse } from 'types';
 const schemaValidation = yup.object({
   fname: yup.string(),
   lname: yup.string(),
-  companyTitle: yup.string().optional().nullable(),
+  title: yup.string().optional().nullable(),
 });
 
 const UserDataForm: React.FC = () => {
@@ -84,12 +84,11 @@ const UserDataForm: React.FC = () => {
                   />
                 </div>
                 <div>
-                  <Label htmlFor="companyTitle">Title</Label>
+                  <Label htmlFor="title">Title</Label>
                   <Input
-                    {...register('companyTitle')}
-                    defaultValue={user.data.companyTitle}
-                    error={errors.companyTitle?.message as string}
-                    disabled // DISABLED UNTIL API SUPPORTS IT
+                    {...register('title')}
+                    defaultValue={user.data.title}
+                    error={errors.title?.message as string}
                   />
                 </div>
               </div>

--- a/client/src/containers/user-avatar/component.tsx
+++ b/client/src/containers/user-avatar/component.tsx
@@ -5,15 +5,14 @@ import type { User } from 'types';
 
 type UserAvatarProps = {
   user: User;
+  userFullName: string;
   className?: string;
 };
 
-export const UserAvatar = ({ user, className = '' }: UserAvatarProps) => {
+export const UserAvatar = ({ user, userFullName, className = '' }: UserAvatarProps) => {
   if (user?.avatarDataUrl)
     return <Avatar alt="user avatar" src={user?.avatarDataUrl} className={className} />;
-  if (user?.fname)
-    return <StringAvatar fullName={`${user.fname} ${user.lname ?? ''}`} className={className} />;
-  return <StringAvatar fullName={user?.email} className={className} />;
+  return <StringAvatar fullName={userFullName} className={className} />;
 };
 
 export default UserAvatar;

--- a/client/src/containers/user-dropdown/component.tsx
+++ b/client/src/containers/user-dropdown/component.tsx
@@ -24,7 +24,9 @@ const UserDropdown: React.FC = () => {
 
   const handleSignOut = useCallback(() => signOut({ callbackUrl: '/auth/signin' }), []);
 
-  const userName = getUserFullName(user);
+  const userName = getUserFullName(user, {
+    replaceByEmail: true,
+  });
 
   return (
     <Menu as="div" className="flex justify-center flex-col items-center w-full mb-5">
@@ -33,7 +35,11 @@ const UserDropdown: React.FC = () => {
         className="focus-visible:shadow-button-focused focus-visible:outline-none rounded-lg shadow-menu hover:shadow-button-hovered"
         ref={reference}
       >
-        <UserAvatar user={user} className="bg-black/20 h-[50px] w-[50px] " />
+        <UserAvatar
+          userFullName={userName}
+          user={user}
+          className="bg-black/20 h-[50px] w-[50px] "
+        />
       </Menu.Button>
       <span className="text-white text-xs mt-3">Account</span>
       {!!user &&
@@ -48,7 +54,7 @@ const UserDropdown: React.FC = () => {
             className="z-40 p-6 bg-white rounded-md shadow-lg focus:outline-none"
           >
             <div className="flex mb-3 items-center">
-              <UserAvatar user={user} className="w-14 h-14" />
+              <UserAvatar userFullName={userName} user={user} className="w-14 h-14" />
 
               <div className="ml-4">
                 <span className="block text-lg leading-8 text-gray-900">{userName}</span>

--- a/client/src/hooks/users/index.ts
+++ b/client/src/hooks/users/index.ts
@@ -3,7 +3,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { apiService } from 'services/api';
 
 import type { UseQueryOptions } from '@tanstack/react-query';
-import type { UserPayload } from 'types';
+import type { ProfilePayload, UserPayload } from 'types';
 
 export const useUsers = (
   params: Record<string, unknown> = {},
@@ -54,4 +54,38 @@ export const useDeleteUser = () => {
     mutationKey: ['delete-user'],
     onSuccess: () => queryClient.invalidateQueries(['users']),
   });
+};
+
+export const useCreateUser = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation(
+    (data: Omit<ProfilePayload, 'id'>) =>
+      apiService.request({
+        method: 'POST',
+        url: '/users/',
+        data,
+      }),
+    {
+      mutationKey: ['create-user'],
+      onSuccess: () => queryClient.invalidateQueries(['users']),
+    },
+  );
+};
+
+export const useEditUser = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation(
+    ({ id, ...data }: Omit<ProfilePayload, 'email'>) =>
+      apiService.request({
+        method: 'PATCH',
+        url: `/users/${id}`,
+        data,
+      }),
+    {
+      mutationKey: ['edit-user'],
+      onSuccess: () => queryClient.invalidateQueries(['users']),
+    },
+  );
 };

--- a/client/src/layouts/profile/component.tsx
+++ b/client/src/layouts/profile/component.tsx
@@ -1,13 +1,24 @@
 import { USER_TABS } from './constants';
 
+import { usePermissions } from 'hooks/permissions';
 import AdminLayout from 'layouts/admin';
+import { RoleName } from 'hooks/permissions/enums';
 
 import type { AdminLayoutProps } from 'layouts/admin/types';
 
-const UserLayout: React.FC<AdminLayoutProps> = ({ children, ...props }) => (
-  <AdminLayout {...props} adminTabs={USER_TABS}>
-    {children}
-  </AdminLayout>
-);
+const UserLayout: React.FC<AdminLayoutProps> = ({ children, ...props }) => {
+  const { hasRole } = usePermissions();
+  const isAdmin = hasRole(RoleName.ADMIN);
+
+  const TABS = isAdmin
+    ? USER_TABS
+    : { ...USER_TABS, USERS: { ...USER_TABS.USERS, disabled: true } };
+
+  return (
+    <AdminLayout {...props} adminTabs={TABS}>
+      {children}
+    </AdminLayout>
+  );
+};
 
 export default UserLayout;

--- a/client/src/pages/api/auth/[...nextauth].ts
+++ b/client/src/pages/api/auth/[...nextauth].ts
@@ -2,6 +2,7 @@ import NextAuth from 'next-auth';
 import CredentialsProvider from 'next-auth/providers/credentials';
 
 import { authService } from 'services/authentication';
+import getUserFullName from 'utils/user-full-name';
 
 import type { NextAuthOptions } from 'next-auth';
 
@@ -53,9 +54,7 @@ export const options: NextAuthOptions = {
         if (data && status === 201) {
           return {
             ...data.user,
-            name:
-              data.displayName ||
-              (data.user.fname && data.user.lname ? `${data.user.fname} ${data.user.lname}` : null),
+            name: getUserFullName(data.user),
             image: data.user.avatarDataUrl,
             accessToken: data.accessToken,
           };

--- a/client/src/pages/auth/signup.tsx
+++ b/client/src/pages/auth/signup.tsx
@@ -30,7 +30,6 @@ const schemaValidation = yup.object({
 
 // ? https://api.dev.landgriffon.com/swagger/#/Authentication/AuthenticationController_signUp
 export type SignUpPayload = {
-  displayName?: string;
   email: ProfilePayload['email'];
   fname: ProfilePayload['fname'];
   lname: ProfilePayload['lname'];

--- a/client/src/types.d.ts
+++ b/client/src/types.d.ts
@@ -233,9 +233,9 @@ export type ProfilePayload = {
   lname?: string;
   email?: string;
   password?: string;
-  roles?: Role[];
+  roles?: RoleName[];
   id?: string;
-  companyTitle?: string;
+  title?: string;
 };
 
 // Password payload for API
@@ -365,7 +365,7 @@ export type User = {
   fname?: string;
   lname?: string;
   email: string;
-  companyTitle?: string;
+  title?: string;
   isActive: boolean;
   avatarDataUrl?: string;
   isDeleted: boolean;


### PR DESCRIPTION
### General description

This PR enables the 'Add user' button adds the 'edit' user button to the users table and the create/edit user form
 The property 'displayName' will be removed from 'User' in API, so this PR deletes all references to this property

### Designs

[Create](https://www.figma.com/file/7bmF29CIXDJwCpuloW5Nt6/%F0%9F%94%B5-Landgriffon---Redesign_BLUE?type=design&node-id=1870-169588&mode=design&t=7gQKz0kWrGtyw6XR-4)
[Edit](https://www.figma.com/file/7bmF29CIXDJwCpuloW5Nt6/%F0%9F%94%B5-Landgriffon---Redesign_BLUE?type=design&node-id=1870-169568&mode=design&t=7gQKz0kWrGtyw6XR-4)

### Testing instructions

1. Create a user clicking 'Add user'
2. Edit a user clicking 'edit' on the users table

### Task
https://vizzuality.atlassian.net/browse/LANDGRIF-1345