### PR TITLE
Client/feature/default unknown suppliers

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Changed
 
 - From update user form: removed 'display name' adn added 'company title' [LANDGRIF-1343](https://vizzuality.atlassian.net/browse/LANDGRIF-1343)
+- Changed the intervention form to send 'Unknown' newT1SupplierId and newProducerId when there is no value. [LANDGRIF-1448](https://vizzuality.atlassian.net/browse/LANDGRIF-1448)
 - Changed analysis/table 'group by' filter value 'Supplier' to 'T1 Supplier' and 'Producer' [LANDGRIF-1441](https://vizzuality.atlassian.net/browse/LANDGRIF-1441)
 - Add avatar to user list [LANDGRIF-1344](https://vizzuality.atlassian.net/browse/LANDGRIF-1344)
 - Change users list to don't show the current user [LANDGRIF-1346](https://vizzuality.atlassian.net/browse/LANDGRIF-1346)

--- a/client/cypress/e2e/data.cy.ts
+++ b/client/cypress/e2e/data.cy.ts
@@ -6,9 +6,10 @@ const disabledLinks = Object.values(ADMIN_TABS).filter(
   (value: TabType) => value.disabled,
 ) as TabType[];
 
-describe('Data page', () => {
+describe('Data page - admin', () => {
   beforeEach(() => {
     cy.interceptAllRequests();
+    cy.intercept('/api/v1/users/me', { fixture: 'profiles/admin' });
     cy.login();
     cy.visit('/data');
     cy.wait('@sourcingLocations');
@@ -35,8 +36,20 @@ describe('Data page', () => {
   // });
 
   it('admin should be able to upload data source', () => {
-    cy.intercept('/api/v1/users/me', { fixture: 'profiles/admin' });
     cy.get('[data-testid="upload-data-source-btn"]').should('not.be.disabled');
+  });
+});
+
+describe('Data page - user', () => {
+  beforeEach(() => {
+    cy.interceptAllRequests();
+    cy.login();
+    cy.visit('/data');
+    cy.wait('@sourcingLocations');
+  });
+
+  afterEach(() => {
+    cy.logout();
   });
 
   it('not admin user should not be able to upload data source', () => {

--- a/client/cypress/e2e/intervention-creation.cy.ts
+++ b/client/cypress/e2e/intervention-creation.cy.ts
@@ -54,9 +54,10 @@ describe('Intervention creation', () => {
     cy.get('[data-testid="select-newLocationType"]').should('have.length', 1);
     cy.get('[data-testid="select-newLocationCountryInput"]').should('have.length', 1);
 
-    // supplier options should not be visible by default
-    cy.get('[data-testid="new-t1-supplier-select"]').should('have.length', 0);
-    cy.get('[data-testid="new-producer-select"]').should('have.length', 0);
+    // supplier options should have a default value of Unknown
+    cy.wait('@unknownSupplier');
+    cy.get('[data-testid="new-t1-supplier-select"] input').should('have.value', 'Unknown');
+    cy.get('[data-testid="new-producer-select"] input').should('have.value', 'Unknown');
 
     // coefficients should not be visible by default
     cy.get('[data-testid="GHG_LUC_T-input"]').should('have.length', 0);
@@ -133,9 +134,10 @@ describe('Intervention creation', () => {
     cy.get('[data-testid="select-newLocationType"]').should('have.length', 1);
     cy.get('[data-testid="select-newLocationCountryInput"]').should('have.length', 1);
 
-    // supplier options should not be visible by default
-    cy.get('[data-testid="new-t1-supplier-select"]').should('have.length', 0);
-    cy.get('[data-testid="new-producer-select"]').should('have.length', 0);
+    // supplier options should have a default value of Unknown
+    cy.wait('@unknownSupplier');
+    cy.get('[data-testid="new-t1-supplier-select"] input').should('have.value', 'Unknown');
+    cy.get('[data-testid="new-producer-select"] input').should('have.value', 'Unknown');
 
     // coefficients should not be visible by default
     cy.get('[data-testid="GHG_LUC_T-input"]').should('have.length', 0);

--- a/client/cypress/fixtures/intervention/intervention.json
+++ b/client/cypress/fixtures/intervention/intervention.json
@@ -1,0 +1,131 @@
+{
+  "data": {
+    "type": "scenarioInterventions",
+    "id": "6d881784-f6fc-48dd-9ec1-609fe31a4211",
+    "attributes": {
+      "title": "change material",
+      "description": null,
+      "status": "active",
+      "startYear": 2022,
+      "type": "Source from new supplier or location",
+      "createdAt": "2023-07-20T13:56:00.025Z",
+      "updatedAt": "2023-07-20T13:56:00.159Z",
+      "newLocationType": "administrative-region-of-production",
+      "newIndicatorCoefficients": null,
+      "newLocationCountryInput": "Spain",
+      "newLocationAddressInput": null,
+      "newLocationLatitudeInput": "0",
+      "newLocationLongitudeInput": "0",
+      "replacedMaterials": [
+        {
+          "createdAt": "2023-06-23T05:51:38.232Z",
+          "updatedAt": "2023-07-11T15:44:17.198Z",
+          "id": "2cf5e53b-6030-403a-8849-e961474fead7",
+          "parentId": "ed626334-1a6a-43c2-b52f-a61e94e756b4",
+          "name": "Rice",
+          "description": "Rice",
+          "hsCodeId": "1006",
+          "earthstatId": null,
+          "mapspamId": null,
+          "status": "active",
+          "metadata": {
+            "name": "Global rice distribution in 2010",
+            "source": "International Food Policy Research Institute, 2019, “Global Spatially-Disaggregated Crop Production Statistics Data for 2010 Version 2.0”, https://doi.org/10.7910/DVN/PRFF8V, Harvard Dataverse, V4",
+            "license": "CC0 1.0",
+            "cautions": "Global distributions of rice in 2010 expressed in tonnes (T).",
+            "citation": "International Food Policy Research Institute, 2019, “Global Spatially-Disaggregated Crop Production Statistics Data for 2010 Version 2.0”, https://doi.org/10.7910/DVN/PRFF8V, Harvard Dataverse, V4",
+            "datasets": ["SPAM 2010 v2.0 Global Data (Updated 2020-07-15)"],
+            "overview": "'All crops' represent all of the crops that are included in the tool as displayed in the menu. Pixel colors are shaded by level of production. The crop layers displayed on the map reflect 2010 data regardless of the timeframe selected.",
+            "resolution": "10km x 10km",
+            "date of content": "2010",
+            "geographic coverage": "Global coverage",
+            "frequency of updates": ""
+          },
+          "datasetId": "spam_rice"
+        }
+      ],
+      "replacedBusinessUnits": [
+        {
+          "id": "b5f643b1-8118-4967-b4f8-123f37651b79",
+          "name": "Entire company",
+          "description": null,
+          "status": "inactive",
+          "metadata": null
+        }
+      ],
+      "replacedAdminRegions": [
+        {
+          "id": "3e12591b-c441-456a-9a0c-7a098e70cfa9",
+          "parentId": null,
+          "gadmId": "IND",
+          "level": 0,
+          "name": "India",
+          "description": null,
+          "status": "inactive",
+          "isoA2": "IN",
+          "isoA3": "IND",
+          "geoRegionId": "fe9705a7-77b8-4766-bed6-c4d9def54af8"
+        }
+      ],
+      "replacedT1Suppliers": [
+        {
+          "createdAt": "2023-07-11T15:44:17.858Z",
+          "updatedAt": "2023-07-11T15:44:17.858Z",
+          "id": "e18aab38-3996-46f1-b57c-c014d95bd4dd",
+          "parentId": null,
+          "name": "Unknown",
+          "description": "Supplier or producer is unknown",
+          "status": "active",
+          "metadata": null
+        }
+      ],
+      "replacedProducers": [
+        {
+          "createdAt": "2023-07-11T15:44:24.437Z",
+          "updatedAt": "2023-07-11T15:44:24.437Z",
+          "id": "4a5ec1f9-cf94-44d0-b0eb-39461795c7c5",
+          "parentId": null,
+          "name": "ABINASH RICE MILL",
+          "description": null,
+          "status": "active",
+          "metadata": null
+        }
+      ],
+      "newMaterial": null,
+      "newBusinessUnit": null,
+      "newAdminRegion": {
+        "id": "8a3919d0-c1a1-4cea-81e3-f74d0d834b8f",
+        "parentId": "f218c39c-9ece-4f49-9772-5b71402b610a",
+        "gadmId": "ESP.10.3_1",
+        "level": 2,
+        "name": "Valencia",
+        "description": null,
+        "status": "inactive",
+        "isoA2": null,
+        "isoA3": null,
+        "geoRegionId": "266a38a2-66f5-48aa-b2e2-1621b0adece5"
+      },
+      "newT1Supplier": {
+        "createdAt": "2023-07-11T15:44:17.858Z",
+        "updatedAt": "2023-07-11T15:44:17.858Z",
+        "id": "e18aab38-3996-46f1-b57c-c014d95bd4dd",
+        "parentId": null,
+        "name": "Unknown",
+        "description": "Supplier or producer is unknown",
+        "status": "active",
+        "metadata": null
+      },
+      "newProducer": {
+        "createdAt": "2023-07-11T15:44:17.858Z",
+        "updatedAt": "2023-07-11T15:44:17.858Z",
+        "id": "e18aab38-3996-46f1-b57c-c014d95bd4dd",
+        "parentId": null,
+        "name": "Unknown",
+        "description": "Supplier or producer is unknown",
+        "status": "active",
+        "metadata": null
+      },
+      "percentage": 100
+    }
+  }
+}

--- a/client/cypress/fixtures/sourcing-locations/materials.json
+++ b/client/cypress/fixtures/sourcing-locations/materials.json
@@ -1,0 +1,68 @@
+{
+  "data": [
+    {
+      "type": "sourcingLocations",
+      "attributes": {
+        "material": "Barley",
+        "materialId": "24bcd3aa-0a9a-495b-958b-8a7fb712890f",
+        "t1Supplier": "Europe",
+        "producer": "Luxembourg",
+        "businessUnit": "Entire company",
+        "country": "Luxembourg",
+        "locationType": "country-of-production",
+        "purchases": [
+          {
+            "year": 2022,
+            "tonnage": "4"
+          },
+          {
+            "year": 2021,
+            "tonnage": "7"
+          },
+          {
+            "year": 2020,
+            "tonnage": "3"
+          },
+          {
+            "year": 2019,
+            "tonnage": "6"
+          },
+          {
+            "year": 2012,
+            "tonnage": "3"
+          },
+          {
+            "year": 2018,
+            "tonnage": "1"
+          },
+          {
+            "year": 2017,
+            "tonnage": "1"
+          },
+          {
+            "year": 2016,
+            "tonnage": "9"
+          },
+          {
+            "year": 2015,
+            "tonnage": "2"
+          },
+          {
+            "year": 2014,
+            "tonnage": "8"
+          },
+          {
+            "year": 2013,
+            "tonnage": "9"
+          }
+        ]
+      }
+    }
+  ],
+  "meta": {
+    "totalItems": 1314,
+    "totalPages": 27,
+    "size": 50,
+    "page": 1
+  }
+}

--- a/client/cypress/fixtures/suppliers/unknown-supplier.json
+++ b/client/cypress/fixtures/suppliers/unknown-supplier.json
@@ -1,0 +1,23 @@
+{
+  "meta": {
+    "totalItems": 1,
+    "totalPages": 1,
+    "size": 25,
+    "page": 1
+  },
+  "data": [
+    {
+      "type": "suppliers",
+      "id": "e18aab38-3996-46f1-b57c-c014d95bd4dd",
+      "attributes": {
+        "name": "Unknown",
+        "description": "Supplier or producer is unknown",
+        "status": "active",
+        "metadata": null,
+        "parentId": null,
+        "createdAt": "2023-07-11T15:44:17.858Z",
+        "updatedAt": "2023-07-11T15:44:17.858Z"
+      }
+    }
+  ]
+}

--- a/client/cypress/support/commands.ts
+++ b/client/cypress/support/commands.ts
@@ -164,6 +164,11 @@ Cypress.Commands.add('interceptAllRequests', (): void => {
     fixture: 'intervention/intervention-creation-dto',
   }).as('successfulInterventionEdition');
 
+  cy.intercept('GET', '/api/v1/scenario-interventions/random-intervention-id?*', {
+    statusCode: 200,
+    fixture: 'intervention/intervention',
+  }).as('ntervention');
+
   // Layer requests
   cy.intercept('GET', '/api/v1/h3/map/impact*', {
     fixture: 'layers/impact-layer.json',
@@ -238,6 +243,20 @@ Cypress.Commands.add('interceptAllRequests', (): void => {
       fixture: 'suppliers/types-producer',
     },
   ).as('producers');
+
+  cy.intercept(
+    {
+      method: 'GET',
+      pathname: '/api/v1/suppliers',
+      query: {
+        'filter[name]': 'Unknown',
+      },
+    },
+    {
+      statusCode: 200,
+      fixture: 'suppliers/unknown-supplier',
+    },
+  ).as('unknownSupplier');
 
   // Profile
   cy.intercept('api/v1/users/me', { fixture: 'profiles/all-permissions' }).as('profile');

--- a/client/cypress/support/commands.ts
+++ b/client/cypress/support/commands.ts
@@ -204,6 +204,11 @@ Cypress.Commands.add('interceptAllRequests', (): void => {
   });
 
   // Sourcing locations data requests
+  cy.intercept('GET', '/api/v1/sourcing-locations/materials*', {
+    statusCode: 200,
+    fixture: 'sourcing-locations/materials',
+  }).as('sourcingLocationsMaterials');
+
   cy.intercept('GET', '/api/v1/sourcing-locations*', {
     statusCode: 200,
     fixture: 'sourcing-locations/index',

--- a/client/src/containers/admin/data-table/component.tsx
+++ b/client/src/containers/admin/data-table/component.tsx
@@ -171,7 +171,7 @@ const AdminDataPage: React.FC<{ task: Task }> = ({ task }) => {
               <span className="text-navy-400 underline">Last update</span> at{' '}
               {format(new Date(sourcingLocations.data[0].updatedAt), 'd MMM yyyy HH:mm z')}
               {task?.user && ' by '}
-              {getUserFullName(task.user)}
+              {getUserFullName(task?.user)}
             </div>
           </div>
         )}

--- a/client/src/hooks/suppliers/index.ts
+++ b/client/src/hooks/suppliers/index.ts
@@ -92,3 +92,19 @@ export const useSuppliersTypes = <T = Supplier[]>(
 
   return query;
 };
+
+export const useUnknowSupplier = () => {
+  const query = useQuery(
+    ['unknown-supplier'],
+    () =>
+      apiService
+        .request<{ data: Supplier }>({
+          method: 'GET',
+          url: 'suppliers',
+          params: { 'filter[name]': 'Unknown' },
+        })
+        .then(({ data: responseData }) => responseData.data?.[0]),
+    { ...DEFAULT_QUERY_OPTIONS, staleTime: Infinity },
+  );
+  return query;
+};


### PR DESCRIPTION
### General description

This PR adds a default value to the intervention create/edit form for newT1SupplierId and newProducerId

### Testing instructions

When creating or editing an intervention:

- The fields of Supplier (Tier 1 supplier and Producer) should always have a value. 
- The default value should be 'Unknown': when the user didn’t select any option or when the user clears the field 
- The fields should be clearable unless the value is Unknown 


https://github.com/Vizzuality/landgriffon/assets/48164343/c5e0e1f5-90f3-4e07-80d8-fd8a1ae346e5




### Tasks
https://vizzuality.atlassian.net/browse/LANDGRIF-1448
https://vizzuality.atlassian.net/browse/LANDGRIF-1449