### PR TITLE
Fix permissions for users

### DIFF
--- a/client/cypress/e2e/data.cy.ts
+++ b/client/cypress/e2e/data.cy.ts
@@ -53,7 +53,8 @@ describe('Data page - user', () => {
   });
 
   it('not admin user should not be able to upload data source', () => {
-    cy.intercept('/api/v1/users/me', { fixture: 'profiles/no-permissions' });
+    cy.intercept('/api/v1/users/me', { fixture: 'profiles/no-permissions' }).as('user-profile');
+    cy.wait('@user-profile');
     cy.get('[data-testid="upload-data-source-btn"]').should('be.disabled');
   });
 });

--- a/client/src/containers/analysis-sidebar/component.tsx
+++ b/client/src/containers/analysis-sidebar/component.tsx
@@ -38,7 +38,7 @@ const ScenariosComponent: React.FC<{ scrollref?: MutableRefObject<HTMLDivElement
   const { scenarioId = ACTUAL_DATA.id } = query;
   const { hasPermission } = usePermissions();
 
-  const canCreateScenario = hasPermission(Permission.CAN_CREATE_SCENARIO, false);
+  const canCreateScenario = hasPermission(Permission.CAN_CREATE_SCENARIO);
 
   const { sort, searchTerm } = useAppSelector(scenarios);
   const dispatch = useAppDispatch();

--- a/client/src/containers/scenarios/form/component.tsx
+++ b/client/src/containers/scenarios/form/component.tsx
@@ -51,7 +51,7 @@ const ScenarioForm: React.FC<React.PropsWithChildren<ScenarioFormProps>> = ({
   // else, check if the user can create a scenario
   const canSave =
     (scenario?.id
-      ? hasPermission(Permission.CAN_EDIT_SCENARIO, scenario.user.id)
+      ? hasPermission(Permission.CAN_EDIT_SCENARIO, scenario.user?.id)
       : hasPermission(Permission.CAN_CREATE_SCENARIO)) && isValid;
 
   return (

--- a/client/src/containers/scenarios/form/component.tsx
+++ b/client/src/containers/scenarios/form/component.tsx
@@ -46,13 +46,13 @@ const ScenarioForm: React.FC<React.PropsWithChildren<ScenarioFormProps>> = ({
     criteriaMode: 'all',
   });
 
-  const { hasPermission } = usePermissions(scenario?.user?.id);
+  const { hasPermission } = usePermissions();
   // If scenario exists, check if the user can edit,
   // else, check if the user can create a scenario
   const canSave =
     (scenario?.id
-      ? hasPermission(Permission.CAN_EDIT_SCENARIO)
-      : hasPermission(Permission.CAN_CREATE_SCENARIO, false)) && isValid;
+      ? hasPermission(Permission.CAN_EDIT_SCENARIO, scenario.user.id)
+      : hasPermission(Permission.CAN_CREATE_SCENARIO)) && isValid;
 
   return (
     <form

--- a/client/src/containers/scenarios/item/component.tsx
+++ b/client/src/containers/scenarios/item/component.tsx
@@ -47,7 +47,7 @@ const ScenarioItem = ({ scenario, isSelected }: ScenariosItemProps) => {
   );
 
   const { hasPermission } = usePermissions();
-  const canEdit = hasPermission(Permission.CAN_EDIT_SCENARIO, scenario.user.id);
+  const canEdit = hasPermission(Permission.CAN_EDIT_SCENARIO, scenario.user?.id);
 
   return (
     <div data-testid={`scenario-item-${scenario.id || 'null'}`}>

--- a/client/src/containers/scenarios/item/component.tsx
+++ b/client/src/containers/scenarios/item/component.tsx
@@ -46,8 +46,8 @@ const ScenarioItem = ({ scenario, isSelected }: ScenariosItemProps) => {
     [updatedAt],
   );
 
-  const { hasPermission } = usePermissions(scenario?.user?.id);
-  const canEdit = hasPermission(Permission.CAN_EDIT_SCENARIO);
+  const { hasPermission } = usePermissions();
+  const canEdit = hasPermission(Permission.CAN_EDIT_SCENARIO, scenario.user.id);
 
   return (
     <div data-testid={`scenario-item-${scenario.id || 'null'}`}>

--- a/client/src/containers/scenarios/table/component.tsx
+++ b/client/src/containers/scenarios/table/component.tsx
@@ -48,7 +48,7 @@ export const ScenarioTable = ({ data, className, onDelete }: ScenarioTableProps)
             cell: ({ row }) => {
               const canEditScenario = hasPermission(
                 Permission.CAN_EDIT_SCENARIO,
-                row.original.user.id,
+                row.original?.user.id,
               );
               return (
                 <ScenarioMakePublic
@@ -69,11 +69,11 @@ export const ScenarioTable = ({ data, className, onDelete }: ScenarioTableProps)
             cell: ({ row }) => {
               const canDeleteScenario = hasPermission(
                 Permission.CAN_DELETE_SCENARIO,
-                row.original.user.id,
+                row.original?.user.id,
               );
               const canEditScenario = hasPermission(
                 Permission.CAN_EDIT_SCENARIO,
-                row.original.user.id,
+                row.original?.user.id,
               );
               return (
                 <ScenarioActions

--- a/client/src/containers/scenarios/table/component.tsx
+++ b/client/src/containers/scenarios/table/component.tsx
@@ -6,16 +6,14 @@ import ScenarioMakePublic from '../scenario-items/make-public';
 import ScenarioActions from '../scenario-items/actions';
 
 import Table from 'components/table';
+import { usePermissions } from 'hooks/permissions';
+import { Permission } from 'hooks/permissions/enums';
 
 import type { ScenarioTableProps } from '../types';
 
-export const ScenarioTable = ({
-  data,
-  className,
-  canDeleteScenario,
-  canEditScenario,
-  onDelete,
-}: ScenarioTableProps) => {
+export const ScenarioTable = ({ data, className, onDelete }: ScenarioTableProps) => {
+  const { hasPermission } = usePermissions();
+
   return (
     <div className={classNames('w-full h-full', className)}>
       <Table
@@ -42,19 +40,25 @@ export const ScenarioTable = ({
           {
             id: 'ss',
             header: 'Growth Rates',
-            cell: ({ row }) => <ScenarioGrowthRate display="list" />,
+            cell: () => <ScenarioGrowthRate display="list" />,
           },
           {
             id: 'ssss',
             header: 'Access',
-            cell: ({ row }) => (
-              <ScenarioMakePublic
-                id={row.original.id}
-                display="list"
-                isPublic={row.original.isPublic}
-                canEditScenario={canEditScenario}
-              />
-            ),
+            cell: ({ row }) => {
+              const canEditScenario = hasPermission(
+                Permission.CAN_EDIT_SCENARIO,
+                row.original.user.id,
+              );
+              return (
+                <ScenarioMakePublic
+                  id={row.original.id}
+                  display="list"
+                  isPublic={row.original.isPublic}
+                  canEditScenario={canEditScenario}
+                />
+              );
+            },
           },
           {
             id: 'actions',
@@ -62,15 +66,25 @@ export const ScenarioTable = ({
             align: 'right',
             size: 260,
             isSticky: 'right',
-            cell: ({ row }) => (
-              <ScenarioActions
-                canDeleteScenario={canDeleteScenario}
-                canEditScenario={canEditScenario}
-                scenarioId={row.original.id}
-                display="list"
-                setDeleteVisibility={() => onDelete(row.original.id)}
-              />
-            ),
+            cell: ({ row }) => {
+              const canDeleteScenario = hasPermission(
+                Permission.CAN_DELETE_SCENARIO,
+                row.original.user.id,
+              );
+              const canEditScenario = hasPermission(
+                Permission.CAN_EDIT_SCENARIO,
+                row.original.user.id,
+              );
+              return (
+                <ScenarioActions
+                  canDeleteScenario={canDeleteScenario}
+                  canEditScenario={canEditScenario}
+                  scenarioId={row.original.id}
+                  display="list"
+                  setDeleteVisibility={() => onDelete(row.original.id)}
+                />
+              );
+            },
           },
         ]}
       />

--- a/client/src/containers/scenarios/types.d.ts
+++ b/client/src/containers/scenarios/types.d.ts
@@ -78,8 +78,6 @@ export type ScenarioInterventionProps = {
 export type ScenarioTableProps = {
   data: Scenario[];
   className?: string;
-  canEditScenario: boolean;
-  canDeleteScenario: boolean;
   onDelete: (id: string) => void;
 };
 

--- a/client/src/hooks/permissions/index.ts
+++ b/client/src/hooks/permissions/index.ts
@@ -4,7 +4,7 @@ import { useProfile } from 'hooks/profile';
 
 import type { Permission } from './enums';
 
-export function usePermissions(creatorId?: string) {
+export function usePermissions() {
   const { data, isLoading } = useProfile();
 
   const roles: RoleName[] = [];
@@ -27,11 +27,11 @@ export function usePermissions(creatorId?: string) {
    * Function to determine if a user is allowed to perform an action.
    * For CREATE actions add param needsCreatorPermission=false, so it will not check the 'creatorId'
    */
-  const hasPermission = (permissionName: Permission, needsCreatorPermission = true) => {
+  const hasPermission = (permissionName: Permission, creatorId?: string) => {
     // The user has permission
     let permission = permissions?.includes(permissionName);
     // The user is creator of the entity and has permission (for delete and update actions)
-    if (needsCreatorPermission) {
+    if (!!creatorId) {
       permission = permission && creatorId === data?.id;
     }
     // Admin always has permission

--- a/client/src/pages/data/scenarios/index.tsx
+++ b/client/src/pages/data/scenarios/index.tsx
@@ -223,11 +223,11 @@ const ScenariosAdminPage: React.FC = () => {
                   data?.map((scenarioData) => {
                     const canDeleteScenario = hasPermission(
                       Permission.CAN_DELETE_SCENARIO,
-                      scenarioData.user.id,
+                      scenarioData.user?.id,
                     );
                     const canEditScenario = hasPermission(
                       Permission.CAN_EDIT_SCENARIO,
-                      scenarioData.user.id,
+                      scenarioData.user?.id,
                     );
                     return (
                       <ScenarioCard

--- a/client/src/pages/data/scenarios/index.tsx
+++ b/client/src/pages/data/scenarios/index.tsx
@@ -70,9 +70,7 @@ const ScenariosAdminPage: React.FC = () => {
   }, [deleteScenario, scenatioToDelete]);
 
   const { hasPermission } = usePermissions();
-  const canCreateScenario = hasPermission(Permission.CAN_CREATE_SCENARIO, false);
-  const canDeleteScenario = hasPermission(Permission.CAN_DELETE_SCENARIO);
-  const canEditScenario = hasPermission(Permission.CAN_EDIT_SCENARIO);
+  const canCreateScenario = hasPermission(Permission.CAN_CREATE_SCENARIO);
   const handleSort = useCallback(
     ({ value }: Option<string>) => {
       router.replace(
@@ -222,23 +220,28 @@ const ScenariosAdminPage: React.FC = () => {
             (currentDisplay === 'grid' ? (
               <div className={displayClasses[currentDisplay]}>
                 {!isLoading &&
-                  data?.map((scenarioData) => (
-                    <ScenarioCard
-                      key={`scenario-card-${scenarioData.id}`}
-                      data={scenarioData}
-                      canEditScenario={canEditScenario}
-                      canDeleteScenario={canDeleteScenario}
-                      onDelete={onDeleteScenario}
-                    />
-                  ))}
+                  data?.map((scenarioData) => {
+                    const canDeleteScenario = hasPermission(
+                      Permission.CAN_DELETE_SCENARIO,
+                      scenarioData.user.id,
+                    );
+                    const canEditScenario = hasPermission(
+                      Permission.CAN_EDIT_SCENARIO,
+                      scenarioData.user.id,
+                    );
+                    return (
+                      <ScenarioCard
+                        key={`scenario-card-${scenarioData.id}`}
+                        data={scenarioData}
+                        onDelete={onDeleteScenario}
+                        canDeleteScenario={canDeleteScenario}
+                        canEditScenario={canEditScenario}
+                      />
+                    );
+                  })}
               </div>
             ) : (
-              <ScenarioTable
-                data={data}
-                canEditScenario={canEditScenario}
-                canDeleteScenario={canDeleteScenario}
-                onDelete={onDeleteScenario}
-              />
+              <ScenarioTable data={data} onDelete={onDeleteScenario} />
             ))}
         </div>
         <DeleteDialog


### PR DESCRIPTION
### Fix permissions for users

This PR fixes a bug related to the users (role=user) permissions.
The permissions to EDIT and DELETE scenarios were not being applied correctly, so the users with role=user were never allowed to edit or delete their own scenarios.

<img width="1417" alt="Screenshot 2023-08-14 at 11 01 06" src="https://github.com/Vizzuality/landgriffon/assets/48164343/f34c67b5-9bfb-4714-b10e-289c51f3b050">

In the image above the first 3 scenarios was created by the logged-in user, but the user could not edit or delete them. The image below shows the bug fixed, and the user can edit their scenarios.

<img width="1417" alt="Screenshot 2023-08-14 at 11 02 51" src="https://github.com/Vizzuality/landgriffon/assets/48164343/66999abf-471c-4e1f-8577-dda714cc17a4">
