### PR TITLE
Clean h3 and contextuals tables

### DIFF
--- a/data/Makefile
+++ b/data/Makefile
@@ -34,3 +34,7 @@ seed-contextual-layers:
 seed-indicator-coefficients:
 	@echo "Starting seeding indicator coeficients... "
 	cd ./indicator_coefficient_importer && make
+
+delete-h3-tables:
+	@echo "Cleaning h3 tables... "
+	cd ./h3_data_importer && make delete-h3-tables

--- a/data/h3_data_importer/Makefile
+++ b/data/h3_data_importer/Makefile
@@ -319,3 +319,5 @@ convert-default-commodity: download-default-commodity
 
 clean:
 	rm -rf data/*
+
+delete-h3-tables:

--- a/data/h3_data_importer/Makefile
+++ b/data/h3_data_importer/Makefile
@@ -40,6 +40,7 @@ all:
 	@echo "AWS S3 bucket access confirmed, proceeding with import..."
 	make clean
 	make crop indicators
+	make delete-h3-tables
 
 crop: convert-mapspam-crop-production convert-mapspam-crop-harvest convert-glw3-livestock convert-livestock-processed convert-default-commodity
 
@@ -321,3 +322,4 @@ clean:
 	rm -rf data/*
 
 delete-h3-tables:
+	python delete_h3_tables.py

--- a/data/h3_data_importer/delete_h3_tables.py
+++ b/data/h3_data_importer/delete_h3_tables.py
@@ -10,8 +10,9 @@ logging.basicConfig(level=logging.INFO)
 
 
 @click.command()
+@click.option("--drop-contextuals", is_flag=True)
 @click.option("--dry-run", is_flag=True)
-def main(dry_run: bool):
+def main(drop_contextuals: bool, dry_run: bool):
     with psycopg.connect(get_connection_info()) as conn:
         with conn.cursor() as cursor:
             # find all the tables that start with h3_grid*
@@ -25,22 +26,36 @@ def main(dry_run: bool):
             )
             tables_to_drop = cursor.fetchall()
             if tables_to_drop:
-                for table in tables_to_drop:
-                    if not dry_run:
+                if not dry_run:
+                    for table in tables_to_drop:
                         cursor.execute(f"DROP TABLE {table[0]}")
-                log.info(f"Tables {', '.join(table[0] for table in tables_to_drop)} were deleted")
-                cursor.execute(
-                    """
-                SELECT "contextualLayerId" FROM h3_data
-                WHERE "h3tableName" in (%s)
-                """,
-                    (tables_to_drop,),
-                )
-                tables_deleted_with_contextuals = cursor.fetchall()
-                print(tables_deleted_with_contextuals)
-                # TODO: Find some logic to delete the contextual layers safely if they are not used anymore.
+                log.info(f"Deleted tables {', '.join(table[0] for table in tables_to_drop)}")
             else:
-                log.info("No tables to delete")
+                log.info("All tables are linked properly to h3_data. Nothing to delete.")
+            if drop_contextuals:
+                # Contextual layer entries with a tileUrl defined are rasters that don't have a h3 dataset related.
+                # We can't know if they are used or not, so we don't delete them.
+                cursor.execute(
+                    """SELECT contextual_layer.id
+                FROM contextual_layer
+                LEFT JOIN h3_data ON contextual_layer.id = h3_data."contextualLayerId"
+                WHERE h3_data."contextualLayerId" IS NULL AND contextual_layer."tilerUrl" IS NULL;
+                """
+                )
+                contextuals_to_drop = cursor.fetchall()
+                if contextuals_to_drop:
+                    if dry_run:
+                        print(contextuals_to_drop)
+                        return
+                    cursor.execute(
+                        """DELETE FROM contextual_layer
+                    WHERE id = ANY(%s);
+                    """,
+                        (list(ctx[0] for ctx in contextuals_to_drop),),
+                    )
+                    log.info(f"Deleted contextual layers {', '.join(str(ctx[0]) for ctx in contextuals_to_drop)}")
+                else:
+                    log.info("All contextual layers are linked properly to h3_data. Nothing to delete.")
 
 
 if __name__ == "__main__":

--- a/data/h3_data_importer/delete_h3_tables.py
+++ b/data/h3_data_importer/delete_h3_tables.py
@@ -5,7 +5,7 @@ import psycopg
 
 from utils import get_connection_info
 
-log = logging.getLogger(__name__)
+log = logging.getLogger("delete_h3_tables")
 logging.basicConfig(level=logging.INFO)
 
 
@@ -28,7 +28,7 @@ def main(dry_run: bool):
                 for table in tables_to_drop:
                     if not dry_run:
                         cursor.execute(f"DROP TABLE {table[0]}")
-                log.info(f"Tables {[table[0] for table in tables_to_drop]} were deleted")
+                log.info(f"Tables {', '.join(table[0] for table in tables_to_drop)} were deleted")
                 cursor.execute(
                     """
                 SELECT "contextualLayerId" FROM h3_data
@@ -43,5 +43,4 @@ def main(dry_run: bool):
 
 
 if __name__ == "__main__":
-    log.info("Starting delete_h3_tables.py")
     main()

--- a/data/h3_data_importer/delete_h3_tables.py
+++ b/data/h3_data_importer/delete_h3_tables.py
@@ -38,6 +38,7 @@ def main(dry_run: bool):
                 )
                 tables_deleted_with_contextuals = cursor.fetchall()
                 print(tables_deleted_with_contextuals)
+                # TODO: Find some logic to delete the contextual layers safely if they are not used anymore.
             else:
                 log.info("No tables to delete")
 

--- a/data/h3_data_importer/delete_h3_tables.py
+++ b/data/h3_data_importer/delete_h3_tables.py
@@ -1,7 +1,11 @@
+import logging
+
 import click
 import psycopg
 
 from utils import get_connection_info
+
+log = logging.getLogger(__name__)
 
 
 @click.command()
@@ -17,9 +21,16 @@ def main():
             h3_data."h3tableName" is null;
             """
             )
-            # todo filter by the ones that are here and not int h3_data
-            tables = cursor.fetchall()
-            print(tables)
+            tables_to_drop = cursor.fetchall()
+            if tables_to_drop:
+                for table in tables_to_drop:
+                    cursor.execute(f"DROP TABLE {table[0]}")
+                log.info(
+                    f"Tables {[table[0] for table in tables_to_drop]} don't have "
+                    f"a corresponding entry in h3_data and were deleted"
+                )
+            else:
+                log.info("No tables to delete")
 
 
 if __name__ == "__main__":

--- a/data/h3_data_importer/delete_h3_tables.py
+++ b/data/h3_data_importer/delete_h3_tables.py
@@ -1,0 +1,26 @@
+import click
+import psycopg
+
+from utils import get_connection_info
+
+
+@click.command()
+def main():
+    with psycopg.connect(get_connection_info()) as conn:
+        with conn.cursor() as cursor:
+            # find all the tables that start with h3_grid*
+            cursor.execute(
+                """SELECT table_name
+            FROM information_schema.tables as tables
+            LEFT JOIN  h3_data on h3_data."h3tableName" = tables.table_name
+            WHERE tables.table_name LIKE 'h3_grid%' and
+            h3_data."h3tableName" is null;
+            """
+            )
+            # todo filter by the ones that are here and not int h3_data
+            tables = cursor.fetchall()
+            print(tables)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds script util to delete dangling non-linked h3 tables and contextual layers entries.

It removes tables that start with `h3_grid*` and are not in the `h3_data` table. Contextual layer entries that don't have an id listed in h3-data and are not raster tiles (don't have a tile url) are considered dangling and deleted too 