### PR TITLE
Enable map popup for h3 contextual layers

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Enable map popup for h3 contextual layers [LANDGRIF-1484](https://vizzuality.atlassian.net/browse/LANDGRIF-1484)
 - Update password in profile form was not working as expected [LANDGRIF-1479](https://vizzuality.atlassian.net/browse/LANDGRIF-1479)
 
 ## [v1.0.0]

--- a/client/src/containers/analysis-visualization/analysis-map/layers/contextual/index.tsx
+++ b/client/src/containers/analysis-visualization/analysis-map/layers/contextual/index.tsx
@@ -38,7 +38,7 @@ const ContextualLayer = ({ id, beforeId, zIndex, settings }: LayerProps<LayerSet
     );
   }
 
-  return <ContextualDeckLayer id={id} beforeId={beforeId} zIndex={zIndex} />;
+  return <ContextualDeckLayer id={id} beforeId={beforeId} zIndex={zIndex} {...settings} />;
 
   // // ? data is only needed for H3 layers
 


### PR DESCRIPTION
### General description

This PR fixes the issue: The pop-up displaying hexagon information does not appear for contextual layers

### Testing instructions

1. Add a h3 contextual layer (Baseline water stress)
2. Hover the layer. The popup should appear and display correct info about the area

