### PR TITLE
Add units to analysis table individual indicators

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Fixed
 
 - Enable map popup for h3 contextual layers [LANDGRIF-1484](https://vizzuality.atlassian.net/browse/LANDGRIF-1484)
+- Add units to analysis table individual indicators [LANDGRIF-1486](https://vizzuality.atlassian.net/browse/LANDGRIF-1486)
+- Fixed error message date for faled data upload [LANDGRIF-1493](https://vizzuality.atlassian.net/browse/LANDGRIF-1493)
 - Update password in profile form was not working as expected [LANDGRIF-1479](https://vizzuality.atlassian.net/browse/LANDGRIF-1479)
 
 ## [v1.0.0]

--- a/client/src/containers/admin/data-upload-error/component.tsx
+++ b/client/src/containers/admin/data-upload-error/component.tsx
@@ -55,7 +55,7 @@ const DataUploadError: React.FC<DataUploadErrorProps> = ({ task }) => {
               <h3>Upload completed</h3>
               <p className="text-gray-500">
                 Great news! Your latest changes made on{' '}
-                {format(new Date(task.createdAt), 'MMM 4, yyyy HH:mm z')} have been successfully
+                {format(new Date(task.createdAt), 'MMM d, yyyy HH:mm z')} have been successfully
                 uploaded.
               </p>
             </>
@@ -82,7 +82,7 @@ const DataUploadError: React.FC<DataUploadErrorProps> = ({ task }) => {
               <h3>Upload failed</h3>
               <p className="text-gray-500">
                 Sorry, we couldn&apos;t upload your latest changes made on{' '}
-                {format(new Date(task.createdAt), 'MMM 4, yyyy HH:mm z')}. We have{' '}
+                {format(new Date(task.createdAt), 'MMM d, yyyy HH:mm z')}. We have{' '}
                 <strong className="text-gray-900">reverted to the previous version</strong> to avoid
                 data loss. Please try uploading again.
               </p>
@@ -94,7 +94,7 @@ const DataUploadError: React.FC<DataUploadErrorProps> = ({ task }) => {
               <h3>Upload failed</h3>
               <p className="text-gray-500">
                 Sorry, we couldn&apos;t upload your latest changes made on{' '}
-                {format(new Date(task.createdAt), 'MMM 4, yyyy HH:mm z')}. We have{' '}
+                {format(new Date(task.createdAt), 'MMM d, yyyy HH:mm z')}. We have{' '}
                 <strong className="text-gray-900">reverted to the previous version</strong> to avoid
                 data loss. There had been{' '}
                 <strong className="text-gray-900">

--- a/client/src/containers/analysis-visualization/analysis-table/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-table/component.tsx
@@ -275,6 +275,11 @@ const AnalysisTable = () => {
     [isComparison, isScenarioComparison],
   );
 
+  const expanded = useMemo(
+    () => (indicatorId === 'all' ? null : indicators.find((i) => i.id === indicatorId)),
+    [indicatorId, indicators],
+  );
+
   const comparisonColumn = useCallback(
     <Mode extends ComparisonMode>(year: number): ColumnDefinition<ImpactRowType<Mode>> => {
       const valueIsComparison = (
@@ -297,7 +302,7 @@ const AnalysisTable = () => {
             true
           >;
 
-          const unit: string = parentRowData.metadata?.unit;
+          const unit: string = parentRowData.metadata?.unit || expanded?.metadata?.units;
 
           const value = data.values?.find((value) => value.year === year);
           const isComparison = valueIsComparison(value);
@@ -334,12 +339,7 @@ const AnalysisTable = () => {
         },
       };
     },
-    [isComparison, isScenarioComparison, valueIsScenarioComparison],
-  );
-
-  const expandedName = useMemo(
-    () => (indicatorId === 'all' ? null : indicators.find((i) => i.id === indicatorId)?.name),
-    [indicatorId, indicators],
+    [expanded, isComparison, isScenarioComparison, valueIsScenarioComparison],
   );
 
   const baseColumns = useMemo(
@@ -348,7 +348,7 @@ const AnalysisTable = () => {
         id: 'name',
         header: () => (
           <div>
-            {!!expandedName ? (
+            {!!expanded?.name ? (
               <Button
                 className="pt-1 pb-1 pr-0 pl-0 border-0 bg-transparent"
                 variant="transparent"
@@ -356,7 +356,7 @@ const AnalysisTable = () => {
               >
                 <div className="flex text-gray-900 text-sm text-start font-semibold max-w-[200px] whitespace-normal">
                   <ArrowLeftIcon className="mr-3.5 w-4 h-4" />
-                  {expandedName}
+                  {expanded.name}
                 </div>
               </Button>
             ) : (
@@ -377,11 +377,11 @@ const AnalysisTable = () => {
 
           return (
             <div className="py-5 flex gap-4">
-              {!expandedName && (
+              {!expanded?.name && (
                 <InformationCircleIcon className="w-4 h-4 text-gray-900 shrink-0" />
               )}
               <div>
-                {expandedName ? (
+                {expanded?.name ? (
                   original.name
                 ) : (
                   <div className="block font-semibold">
@@ -390,7 +390,7 @@ const AnalysisTable = () => {
                   </div>
                 )}
 
-                {!expandedName && isParentRow(original) && (
+                {!expanded?.name && isParentRow(original) && (
                   <Button
                     variant="white"
                     className="mt-4"
@@ -429,7 +429,7 @@ const AnalysisTable = () => {
       },
       ...years.map((year) => comparisonColumn<Mode>(year as number)),
     ],
-    [years, expandedName, handleExitExpanded, indicators, handleExpandRow, comparisonColumn],
+    [years, expanded?.name, handleExitExpanded, indicators, handleExpandRow, comparisonColumn],
   );
 
   const tableProps = useMemo(


### PR DESCRIPTION
### General description

This PR fixes 2 bugs:

1. Add units to analysis table individual indicators [LANDGRIF-1486](https://vizzuality.atlassian.net/browse/LANDGRIF-1486)
2. Fixed error message date for faled data upload [LANDGRIF-1493](https://vizzuality.atlassian.net/browse/LANDGRIF-1493)

### testing instructions

#### Bug 1
1. Go to '/data'. If there is no upload error message, upload a file with errors.
2. The upload error message date should be correct
<img width="945" alt="Screenshot 2023-10-10 at 16 09 31" src="https://github.com/Vizzuality/landgriffon/assets/48164343/402b052a-151e-439d-8ee8-feaca650b1bd">

#### Bug 2
1. Go to '/analysis/table'. Click on a indicator. You will see the indicator’s  data.
2. The indicator's unit should be displayed after the row value for all columns, except the comparison column. 
3. Be sure that the unit is correct. Check if is the same displayed at the info text above the table  
<img width="964" alt="Screenshot 2023-10-10 at 16 16 35" src="https://github.com/Vizzuality/landgriffon/assets/48164343/f25bfe72-a729-4b1d-987a-46407d7a5b08">


 

[LANDGRIF-1486]: https://vizzuality.atlassian.net/browse/LANDGRIF-1486?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LANDGRIF-1493]: https://vizzuality.atlassian.net/browse/LANDGRIF-1493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ