### PR TITLE
Add map filters and state to app url params

### DIFF
--- a/client/src/containers/analysis-visualization/analysis-filters/indicators/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-filters/indicators/component.tsx
@@ -1,9 +1,9 @@
-import { useCallback, useMemo, useEffect } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useRouter } from 'next/router';
 
 import { useAppDispatch, useAppSelector } from 'store/hooks';
 import { analysisUI } from 'store/features/analysis/ui';
-import { analysisFilters, setFilter } from 'store/features/analysis/filters';
+import { setFilter } from 'store/features/analysis/filters';
 import { useIndicators } from 'hooks/indicators';
 import Select from 'components/forms/select';
 
@@ -17,10 +17,9 @@ const ALL = {
 };
 
 const IndicatorsFilter = () => {
-  const { query = {}, replace } = useRouter();
+  const { query = {} } = useRouter();
   const { indicator } = query;
   const { visualizationMode } = useAppSelector(analysisUI);
-  const filters = useAppSelector(analysisFilters);
   const dispatch = useAppDispatch();
 
   const {
@@ -50,25 +49,16 @@ const IndicatorsFilter = () => {
     return selected || options?.[0];
   }, [indicator, options]);
 
-  // Update the filter when the indicator changes
-  useEffect(() => {
-    if (current && filters.indicator?.value !== current.value) {
+  const handleChange: SelectProps['onChange'] = useCallback(
+    (selected: Option<string>) => {
       dispatch(
         setFilter({
           id: 'indicator',
-          value: current,
+          value: selected.value,
         }),
       );
-    }
-  }, [current, dispatch, filters.indicator?.value]);
-
-  const handleChange: SelectProps['onChange'] = useCallback(
-    (selected: Option<string>) => {
-      replace({ query: { ...query, indicator: selected?.value } }, undefined, {
-        shallow: true,
-      });
     },
-    [query, replace],
+    [dispatch],
   );
 
   return (

--- a/client/src/store/features/analysis/map.ts
+++ b/client/src/store/features/analysis/map.ts
@@ -1,8 +1,18 @@
 import { createSlice } from '@reduxjs/toolkit';
 
+import type { ViewState } from 'react-map-gl';
 import type { PayloadAction } from '@reduxjs/toolkit';
 import type { RootState } from 'store';
 import type { Layer } from 'types';
+
+export const DEFAULT_MAP_STATE: Partial<ViewState> = {
+  longitude: 0,
+  latitude: 0,
+  zoom: 2,
+  pitch: 0,
+  bearing: 0,
+  padding: null,
+};
 
 const DEFAULT_LAYER_ATTRIBUTES = {
   order: 0,
@@ -54,6 +64,7 @@ export type AnalysisMapState = {
   };
   // Deck.gl layer props by layer id
   layerDeckGLProps: Record<Layer['id'], Partial<DeckGLConstructorProps>>;
+  mapState: Partial<ViewState>;
 };
 
 // Define the initial state using that type
@@ -79,12 +90,17 @@ export const initialState: AnalysisMapState = {
     y: 0,
   },
   layerDeckGLProps: {},
+  mapState: DEFAULT_MAP_STATE,
 };
 
 export const analysisMapSlice = createSlice({
   name: 'analysisMap',
   initialState,
   reducers: {
+    setMapState: (state, action: PayloadAction<AnalysisMapState['mapState']>) => ({
+      ...state,
+      mapState: action.payload,
+    }),
     setLayer: (
       state,
       action: PayloadAction<{
@@ -180,8 +196,14 @@ export const analysisMapSlice = createSlice({
   },
 });
 
-export const { setLayer, setLayerDeckGLProps, setTooltipData, setTooltipPosition, setLayerOrder } =
-  analysisMapSlice.actions;
+export const {
+  setLayer,
+  setLayerDeckGLProps,
+  setTooltipData,
+  setTooltipPosition,
+  setLayerOrder,
+  setMapState,
+} = analysisMapSlice.actions;
 
 export const analysisMap = (state: RootState): AnalysisMapState => state['analysis/map'];
 

--- a/client/src/store/utils.ts
+++ b/client/src/store/utils.ts
@@ -1,0 +1,56 @@
+import { isObject } from 'lodash-es';
+import router from 'next/router';
+
+export const checkValidJSON = (json: string) => {
+  try {
+    isObject(JSON.parse(json));
+    return true;
+  } catch (e) {
+    return false;
+  }
+};
+
+export const formatParam = (param: string): string | boolean | number => {
+  if (['true', 'false'].includes(param)) return param === 'true';
+  if (!Number.isNaN(Number(param))) return Number(param);
+  if (checkValidJSON(param)) {
+    const obj = JSON.parse(param);
+    if (typeof obj === 'string') return param;
+    return obj;
+  }
+  return param;
+};
+
+export const routerReplace = async ({ queryName, queryValue, restQueries }) => {
+  await router.replace(
+    {
+      query: {
+        ...restQueries,
+        ...(!!queryName
+          ? {
+              [queryName]: ['string', 'number'].includes(typeof queryValue)
+                ? queryValue
+                : checkValidJSON(JSON.stringify(queryValue))
+                ? JSON.stringify(queryValue)
+                : queryValue,
+            }
+          : {}),
+      },
+    },
+    null,
+    { shallow: true },
+  );
+};
+
+export const routerReplaceMany = async (newParams, otherParams) => {
+  await router.replace(
+    {
+      query: {
+        ...otherParams,
+        ...newParams,
+      },
+    },
+    null,
+    { shallow: true },
+  );
+};


### PR DESCRIPTION
### General description

This PR adds the analysis  map filters and state (long, lat and zoom) to the url search params.

### Testing instructions

In analysis/map, change the filters and the map state. The changes should be reflected in the url search params.
When refreshing the page, the previous params should be persisted  
