### PR TITLE
Feature/chart legend filters

### DIFF
--- a/client/src/containers/analysis-chart/impact-chart/component.tsx
+++ b/client/src/containers/analysis-chart/impact-chart/component.tsx
@@ -29,9 +29,10 @@ type StackedAreaChartProps = {
   indicator: Indicator;
 };
 
-const COLOR_SCALE = chroma.scale(['#2E34B0', '#5462D8', '#828EF5', '#B9C0FF', '#E3EEFF']);
+const COLORS = ['#1C44C3', '#5DBCC5', '#ED8F23', '#3D8CE7', '#E2564F'];
+const COLOR_SCALE = chroma.scale(COLORS);
 
-const defaultOpacity = 0.9;
+const defaultOpacity = 1;
 
 const StackedAreaChart: React.FC<StackedAreaChartProps> = ({ indicator }) => {
   const [legendKey, setLegendKey] = useState<string | null>(null);
@@ -103,7 +104,10 @@ const StackedAreaChart: React.FC<StackedAreaChartProps> = ({ indicator }) => {
       Object.keys(result[0]).forEach((key) => key !== 'date' && keys.push(key));
     }
 
-    const colorScale = COLOR_SCALE.colors(keys.length);
+    const colorScale =
+      keys.filter((k) => k !== 'Others').length > COLORS.length
+        ? COLOR_SCALE.colors(keys.length)
+        : COLORS;
 
     return {
       values: result,
@@ -134,6 +138,8 @@ const StackedAreaChart: React.FC<StackedAreaChartProps> = ({ indicator }) => {
     const result = [];
     const keys = [];
     let opacities = {};
+
+    const LEGEND_INDEX = rows?.findIndex((row) => row.name === legendKey);
 
     yearSum?.forEach(({ year }) => {
       const items = {};
@@ -188,7 +194,10 @@ const StackedAreaChart: React.FC<StackedAreaChartProps> = ({ indicator }) => {
       Object.keys(result[0]).forEach((key) => key !== 'date' && keys.push(key));
     }
 
-    const colorScale = COLOR_SCALE.colors(keys.length);
+    const c = COLORS[LEGEND_INDEX] || '#1C44C3';
+    const SUB_COLOR_SCALE = chroma.scale([c, chroma(c).brighten(3)]);
+
+    const colorScale = SUB_COLOR_SCALE.colors(keys.length);
 
     return {
       values: result,
@@ -315,12 +324,7 @@ const StackedAreaChart: React.FC<StackedAreaChartProps> = ({ indicator }) => {
                     tickLine={false}
                     tickFormatter={NUMBER_FORMAT}
                   />
-                  <Tooltip<number, string>
-                    animationDuration={500}
-                    contentStyle={{ borderRadius: '8px', borderColor: '#D1D5DB' }}
-                    wrapperStyle={{ zIndex: 1000 }}
-                    content={renderTooltip}
-                  />
+
                   {CHART_DATA.keys.map((key) => (
                     <Area
                       key={key}
@@ -352,6 +356,12 @@ const StackedAreaChart: React.FC<StackedAreaChartProps> = ({ indicator }) => {
                       legendType="none"
                     />
                   ))}
+                  <Tooltip<number, string>
+                    animationDuration={500}
+                    contentStyle={{ borderRadius: '8px', borderColor: '#D1D5DB' }}
+                    wrapperStyle={{ zIndex: 1000 }}
+                    content={renderTooltip}
+                  />
                 </AreaChart>
               </ResponsiveContainer>
             </div>

--- a/client/src/containers/analysis-chart/impact-chart/component.tsx
+++ b/client/src/containers/analysis-chart/impact-chart/component.tsx
@@ -140,10 +140,21 @@ const StackedAreaChart: React.FC<StackedAreaChartProps> = ({ indicator }) => {
 
       const LEGEND_ROW = rows?.find((row) => row.name === legendKey);
 
+      if (legendKey === 'Others' && numberOfAggregatedEntities && numberOfAggregatedEntities > 0) {
+        result.push({
+          date: year,
+          Others: aggregatedValues?.find((aggregatedValue) => aggregatedValue?.year === year)
+            ?.value,
+          ...(aggregatedValues?.isProjected && {
+            [`projected-${LEGEND_ROW.name}`]: aggregatedValues?.value,
+          }),
+        });
+      }
       if (!LEGEND_ROW) return [];
 
       if (!LEGEND_ROW?.children.length) {
         const yearValues = LEGEND_ROW?.values.find((rowValues) => rowValues?.year === year);
+
         result.push({
           date: year,
           [LEGEND_ROW.name]: yearValues?.value,

--- a/client/src/containers/analysis-chart/impact-chart/component.tsx
+++ b/client/src/containers/analysis-chart/impact-chart/component.tsx
@@ -180,12 +180,6 @@ const StackedAreaChart: React.FC<StackedAreaChartProps> = ({ indicator }) => {
           }
         });
 
-        if (numberOfAggregatedEntities && numberOfAggregatedEntities > 0) {
-          items['Others'] = aggregatedValues?.find(
-            (aggregatedValue) => aggregatedValue?.year === year,
-          )?.value;
-          opacities = { ...opacities, Others: 0.9 };
-        }
         result.push({ date: year, ...items });
       }
     });

--- a/client/src/containers/analysis-chart/impact-chart/legend/component.tsx
+++ b/client/src/containers/analysis-chart/impact-chart/legend/component.tsx
@@ -33,7 +33,7 @@ const LegendChart: React.FC<ExtendedLegendProps> = ({
             <li
               key={item.value}
               className={classNames(
-                'flex items-center space-x-1 cursor-pointer border py-0.5 px-1 rounded',
+                'flex items-center space-x-1 cursor-pointer border py-0.5 px-1 rounded hover:border-black',
                 {
                   'opacity-50': legendKey && legendKey !== item.id,
                 },

--- a/client/src/containers/analysis-chart/impact-chart/legend/component.tsx
+++ b/client/src/containers/analysis-chart/impact-chart/legend/component.tsx
@@ -14,27 +14,39 @@ interface ExtendedPayload extends Payload {
 
 export interface ExtendedLegendProps extends LegendProps {
   payload: ExtendedPayload[];
+  legendKey: string | null;
 }
 
-const LegendChart: React.FC<ExtendedLegendProps> = ({ payload, onClick = () => null }) => {
+const LegendChart: React.FC<ExtendedLegendProps> = ({
+  payload,
+  legendKey,
+  onClick = () => null,
+}) => {
   const handleClick = useCallback(onClick, [onClick]);
 
   return (
-    <div className="flex justify-between">
-      <ul className="flex flex-wrap gap-x-2 gap-y-4">
+    <div className="flex justify-between space-x-2.5">
+      <ul className="flex flex-wrap gap-1.5">
         {payload
           .filter(({ type }) => type !== 'none')
           .map((item, index) => (
             <li
               key={item.value}
-              className={classNames('flex items-center mr-2 space-x-1 cursor-pointer', {
-                'opacity-50': item.payload.fillOpacity === 0.1,
-              })}
+              className={classNames(
+                'flex items-center space-x-1 cursor-pointer border py-0.5 px-1 rounded',
+                {
+                  'opacity-50': legendKey && legendKey !== item.id,
+                },
+              )}
               onClick={handleClick.bind(null, item, index)}
             >
               <div
-                className="w-[6px] h-3 rounded shrink-0 grow-0"
-                style={{ backgroundColor: `${item.color}` }}
+                className="w-[6px] h-3 rounded shrink-0 grow-0 bg-gray-400"
+                style={{
+                  ...((!legendKey || legendKey === item.id) && {
+                    backgroundColor: `${item.color}`,
+                  }),
+                }}
               />
               <div
                 className="overflow-hidden text-xs whitespace-nowrap text-ellipsis max-w-[100px]"
@@ -48,7 +60,7 @@ const LegendChart: React.FC<ExtendedLegendProps> = ({ payload, onClick = () => n
       <div>
         <div className="flex items-center space-x-1">
           <ProjectedDataIcon />
-          <div className="text-xs whitespace-nowrap">Projected data</div>
+          <div className="text-xs whitespace-nowrap py-1">Projected data</div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
### General description

This PR add the ability to filter area charts from the legend. It will fade-out the rest of legend items and the chart will change with the new data. In case there aren't children, only the area parent will be shown. We have also took care about the "others" case

### Designs

https://www.figma.com/file/7bmF29CIXDJwCpuloW5Nt6/%F0%9F%94%B5-Landgriffon---Redesign_BLUE?node-id=3121%3A105864&mode=dev

![image](https://github.com/Vizzuality/landgriffon/assets/8928965/a16fc3a6-7ef1-4cd6-8fc0-2874e330565b)
