### PR TITLE
LANDGRIF-1509 Fix small number formatting

### DIFF
--- a/client/src/containers/analysis-visualization/analysis-legend/contextual-legend-item/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-legend/contextual-legend-item/component.tsx
@@ -2,7 +2,7 @@ import { useCallback, useMemo } from 'react';
 
 import { useAppDispatch } from 'store/hooks';
 import { setLayer } from 'store/features/analysis/map';
-import { NUMBER_FORMAT } from 'utils/number-format';
+import {NUMBER_FORMAT, SMALL_NUMBER_FORMAT} from 'utils/number-format';
 import LegendItem from 'components/legend/item';
 import LegendTypeBasic from 'components/legend/types/basic';
 import LegendTypeCategorical from 'components/legend/types/categorical';
@@ -38,7 +38,9 @@ const ContextualLegendItem = ({ layer }: ContextualLegendItemProps) => {
         ...item,
         label:
           item.label ||
-          `${!Number.isNaN(item.value) ? NUMBER_FORMAT(item.value as number) : item.value}`,
+          `${Number.isNaN(item.value) ? item.value :
+              item.value > 1 ? NUMBER_FORMAT(item.value as number) : SMALL_NUMBER_FORMAT(item.value as number)
+        }`,
       })),
     };
     switch (layer.metadata.legend.type) {

--- a/client/src/utils/number-format.ts
+++ b/client/src/utils/number-format.ts
@@ -1,6 +1,10 @@
 import { format } from 'd3-format';
 
-export const NUMBER_FORMAT = format(',.3~s');
+// for numbers bigger than 1
+export const NUMBER_FORMAT = format('.3~s');
+
+// for numbers smaller than 1
+export const SMALL_NUMBER_FORMAT = format('.3~g');
 
 export const PRECISE_NUMBER_FORMAT = format(',.3~r');
 


### PR DESCRIPTION
Improve table/number readability. Avoid using `m` `µ` abbreviations for values <1.0. Put `k` `M` `G` abbreviations in bold to improve readability of results. 
