### PR TITLE
LANDGRIF-1504 Change data binning to use log scale

### DIFF
--- a/api/src/modules/h3-data/h3-data.repository.ts
+++ b/api/src/modules/h3-data/h3-data.repository.ts
@@ -308,10 +308,6 @@ export class H3DataRepository extends Repository<H3Data> {
 
   /** Retrieves single crop data by a given resolution
    *
-   * @param materialH3Data: H3 Data table and column name for a specific material
-   * @param resolution: An integer between 1 (min resolution) and 6 (max resolution).
-   * Resolution validation done at route handler
-   *
    */
   async getMaterialMapByResolution(
     materialH3Data: H3Data,

--- a/api/src/modules/h3-data/h3-data.repository.ts
+++ b/api/src/modules/h3-data/h3-data.repository.ts
@@ -765,7 +765,7 @@ export class H3DataRepository extends Repository<H3Data> {
    * has been don't for the time being to unblock FE. Check with Data if calculus is accurate
    */
   private async calculateQuantiles(tmpTableName: string): Promise<number[]> {
-    const N_BINS: number = 7;
+    const N_BINS: number = 6;
     // TODO: make threshold configurable by unit
     const DISPLAY_THRESHOLD: number = 0.01;
     try {
@@ -775,7 +775,8 @@ export class H3DataRepository extends Repository<H3Data> {
       );
       // DISPLAY_THRESHOLD is the threshold for the smallest value to be displayed in the map and legend
       const max = Math.max(max_q[0]["value"], DISPLAY_THRESHOLD)
-      let bins: number[] = [];
+      this.logger.debug(`Computed 99th percentile for ${tmpTableName}: ${max}`);
+      let bins: number[] = [0];
       for (let i = 1; i <= N_BINS; i++) {
         // Log scale binning value shifted with + 1
         // to avoid values < 1, the zone where log behaves badly (rush to -inf for ->0).
@@ -787,7 +788,7 @@ export class H3DataRepository extends Repository<H3Data> {
         let precision: number = bin >= 10? 1: 2;
         bins.push(Number(bin.toPrecision(precision)));
       }
-      this.logger.debug(`Computed data Bins: ${bins}`);
+      this.logger.debug(`Computed data Bins for ${tmpTableName}: ${bins}`);
       return bins;
 
     } catch (err) {

--- a/api/test/e2e/h3-data/h3-impact-map.spec.ts
+++ b/api/test/e2e/h3-data/h3-impact-map.spec.ts
@@ -110,19 +110,19 @@ describe('H3 Data Module (e2e) - Impact map', () => {
 
     expect(response.body.data).toEqual(
       expect.arrayContaining([
-        { h: '861203a6fffffff', v: '500.0000' },
+        { h: '861203a6fffffff', v: '500' },
         {
           h: '861203a5fffffff',
-          v: '617.0000',
+          v: '617',
         },
-        { h: '861203a4fffffff', v: '1117.0000' },
+        { h: '861203a4fffffff', v: '1117' },
       ]),
     );
     expect(response.body.metadata.unit).toEqual('tonnes');
     expect(
       toBeCloseToArray(
         response.body.metadata.quantiles,
-        [0, 539.0078, 578.0858, 617, 783.699999, 950.7, 1117],
+        [0, 2.2, 9.3, 30, 100, 300, 1000],
         5,
       ),
     ).toBeTruthy();
@@ -140,10 +140,10 @@ describe('H3 Data Module (e2e) - Impact map', () => {
         });
 
       expect(response.body.data).toEqual(
-        expect.arrayContaining([{ h: '821207fffffffff', v: '2234.0000' }]),
+        expect.arrayContaining([{ h: '821207fffffffff', v: '2234' }]),
       );
       expect(response.body.metadata).toEqual({
-        quantiles: [0, 2234, 2234, 2234, 2234, 2234, 2234],
+        quantiles: [0, 2.6, 10, 50, 200, 600, 2000],
         unit: 'tonnes',
       });
     });
@@ -159,10 +159,10 @@ describe('H3 Data Module (e2e) - Impact map', () => {
         });
 
       expect(response.body.data).toEqual(
-        expect.arrayContaining([{ h: '841203bffffffff', v: '2234.0000' }]),
+        expect.arrayContaining([{ h: '841203bffffffff', v: '2234' }]),
       );
       expect(response.body.metadata).toEqual({
-        quantiles: [0, 2234, 2234, 2234, 2234, 2234, 2234],
+        quantiles: [0, 2.6, 10, 50, 200, 600, 2000],
         unit: 'tonnes',
       });
     });
@@ -179,19 +179,19 @@ describe('H3 Data Module (e2e) - Impact map', () => {
 
       expect(response.body.data).toEqual(
         expect.arrayContaining([
-          { h: '861203a6fffffff', v: '500.0000' },
+          { h: '861203a6fffffff', v: '500' },
           {
             h: '861203a5fffffff',
-            v: '617.0000',
+            v: '617',
           },
-          { h: '861203a4fffffff', v: '1117.0000' },
+          { h: '861203a4fffffff', v: '1117' },
         ]),
       );
       expect(response.body.metadata.unit).toEqual('tonnes');
       expect(
         toBeCloseToArray(
           response.body.metadata.quantiles,
-          [0, 539.0078, 578.0858, 617, 783.699999, 950.7, 1117],
+          [0, 2.2, 9.3, 30, 100, 300, 1000],
           5,
         ),
       ).toBeTruthy();
@@ -212,12 +212,12 @@ describe('H3 Data Module (e2e) - Impact map', () => {
 
       expect(response.body.data).toEqual(
         expect.arrayContaining([
-          { h: '861203a5fffffff', v: '617.0000' },
-          { h: '861203a4fffffff', v: '617.0000' },
+          { h: '861203a5fffffff', v: '617' },
+          { h: '861203a4fffffff', v: '617' },
         ]),
       );
       expect(response.body.metadata).toEqual({
-        quantiles: [0, 617, 617, 617, 617, 617, 617],
+        quantiles: [0, 1.9, 7.5, 20, 70, 200, 600],
         unit: 'tonnes',
         materialsH3DataYears: [
           {
@@ -247,12 +247,12 @@ describe('H3 Data Module (e2e) - Impact map', () => {
 
       expect(response.body.data).toEqual(
         expect.arrayContaining([
-          { h: '861203a5fffffff', v: '617.0000' },
-          { h: '861203a4fffffff', v: '617.0000' },
+          { h: '861203a5fffffff', v: '617' },
+          { h: '861203a4fffffff', v: '617' },
         ]),
       );
       expect(response.body.metadata).toEqual({
-        quantiles: [0, 617, 617, 617, 617, 617, 617],
+        quantiles: [0, 1.9, 7.5, 20, 70, 200, 600],
         unit: 'tonnes',
       });
     });
@@ -270,12 +270,12 @@ describe('H3 Data Module (e2e) - Impact map', () => {
 
       expect(response.body.data).toEqual(
         expect.arrayContaining([
-          { h: '861203a5fffffff', v: '617.0000' },
-          { h: '861203a4fffffff', v: '617.0000' },
+          { h: '861203a5fffffff', v: '617' },
+          { h: '861203a4fffffff', v: '617' },
         ]),
       );
       expect(response.body.metadata).toEqual({
-        quantiles: [0, 617, 617, 617, 617, 617, 617],
+        quantiles: [0, 1.9, 7.5, 20, 70, 200, 600],
         unit: 'tonnes',
       });
     });
@@ -293,18 +293,12 @@ describe('H3 Data Module (e2e) - Impact map', () => {
 
       expect(response.body.data).toEqual(
         expect.arrayContaining([
-          {
-            h: '861203a5fffffff',
-            v: '617.0000',
-          },
-          {
-            h: '861203a4fffffff',
-            v: '617.0000',
-          },
+          { h: '861203a5fffffff', v: '617' },
+          { h: '861203a4fffffff', v: '617' },
         ]),
       );
       expect(response.body.metadata).toEqual({
-        quantiles: [0, 617, 617, 617, 617, 617, 617],
+        quantiles: [0, 1.9, 7.5, 20, 70, 200, 600],
         unit: 'tonnes',
       });
     });
@@ -323,9 +317,12 @@ describe('H3 Data Module (e2e) - Impact map', () => {
         });
       expect(response.body.data).toEqual(
         expect.arrayContaining([
-          { h: '861203a6fffffff', v: '500.0000' },
-          { h: '861203a5fffffff', v: '617.0000' },
-          { h: '861203a4fffffff', v: '1117.0000' },
+          { h: '861203a6fffffff', v: '500' },
+          {
+            h: '861203a5fffffff',
+            v: '617',
+          },
+          { h: '861203a4fffffff', v: '1117' },
         ]),
       );
     });
@@ -342,12 +339,12 @@ describe('H3 Data Module (e2e) - Impact map', () => {
 
       expect(response.body.data).toEqual(
         expect.arrayContaining([
-          { h: '861203a5fffffff', v: '617.0000' },
-          { h: '861203a4fffffff', v: '617.0000' },
+          { h: '861203a5fffffff', v: '617' },
+          { h: '861203a4fffffff', v: '617' },
         ]),
       );
       expect(response.body.metadata).toEqual({
-        quantiles: [0, 617, 617, 617, 617, 617, 617],
+        quantiles: [0, 1.9, 7.5, 20, 70, 200, 600],
         unit: 'tonnes',
       });
     });
@@ -365,12 +362,12 @@ describe('H3 Data Module (e2e) - Impact map', () => {
 
       expect(response.body.data).toEqual(
         expect.arrayContaining([
-          { h: '861203a5fffffff', v: '617.0000' },
-          { h: '861203a4fffffff', v: '617.0000' },
+          { h: '861203a5fffffff', v: '617' },
+          { h: '861203a4fffffff', v: '617' },
         ]),
       );
       expect(response.body.metadata).toEqual({
-        quantiles: [0, 617, 617, 617, 617, 617, 617],
+        quantiles: [0, 1.9, 7.5, 20, 70, 200, 600],
         unit: 'tonnes',
       });
     });
@@ -392,12 +389,12 @@ describe('H3 Data Module (e2e) - Impact map', () => {
 
       expect(response.body.data).toEqual(
         expect.arrayContaining([
-          { h: '861203a6fffffff', v: '450.0000' },
+          { h: '861203a6fffffff', v: '450' },
           {
             h: '861203a5fffffff',
-            v: '592.0000',
+            v: '592',
           },
-          { h: '861203a4fffffff', v: '1042.0000' },
+          { h: '861203a4fffffff', v: '1042' },
         ]),
       );
       expect(response.body.metadata).toBeDefined();
@@ -405,7 +402,7 @@ describe('H3 Data Module (e2e) - Impact map', () => {
       expect(
         toBeCloseToArray(
           response.body.metadata.quantiles,
-          [0, 497.3428, 544.7708, 592, 742.03, 892.329999, 1042],
+          [0, 2.2, 9.1, 30, 100, 300, 1000],
           5,
         ),
       ).toBeTruthy();

--- a/api/test/e2e/h3-data/h3-material-map.spec.ts
+++ b/api/test/e2e/h3-data/h3-material-map.spec.ts
@@ -177,10 +177,7 @@ describe('H3 Data Module (e2e) - Material map', () => {
     );
 
     expect(responseRes1.body.metadata).toEqual({
-      quantiles: [
-        0, 615.037, 800.0275, 812.5, 825.0784999999998, 1218.3635000000002,
-        1610,
-      ],
+      quantiles: [0, 2.4, 10, 40, 100, 500, 2000],
       unit: 'tonnes',
     });
 
@@ -197,9 +194,7 @@ describe('H3 Data Module (e2e) - Material map', () => {
     );
 
     expect(responseRes3.body.metadata).toEqual({
-      quantiles: [
-        0, 200.006, 231.1110000000001, 735, 750.01, 800.1320000000001, 860,
-      ],
+      quantiles: [0, 2.1, 8.5, 30, 90, 300, 900],
       unit: 'tonnes',
     });
   });

--- a/client/cypress/e2e/analysis/filters-map.cy.ts
+++ b/client/cypress/e2e/analysis/filters-map.cy.ts
@@ -138,7 +138,7 @@ describe('Analysis filters', () => {
       const firstItem = interception.response.body?.data[0];
       cy.get('[data-testid="tree-select-producers-filter"]').find('div[role="combobox"]').click();
       cy.get('[data-testid="tree-select-producers-filter"]')
-        .find('.rc-tree-list')
+        .find('div[role="listbox"]')
         .find('.rc-tree-treenode')
         .eq(1)
         .should('have.text', firstItem.attributes.name)

--- a/client/src/utils/number-format.ts
+++ b/client/src/utils/number-format.ts
@@ -1,14 +1,17 @@
 import { format } from 'd3-format';
 
 // for numbers bigger than 1
-export const NUMBER_FORMAT = format('.3~s');
+export const NUMBER_FORMAT = format('.2~s');
 
 // for numbers smaller than 1
-export const SMALL_NUMBER_FORMAT = format('.3~g');
+export const SMALL_NUMBER_FORMAT = format('.2~g');
 
 export function formatNumber(number: number): string {
-  if (number < 1) {
-    return SMALL_NUMBER_FORMAT(number);
+  if (Math.abs(number) < 1) {
+    if (Math.abs(number) < 0.001) {
+      return "< 0.001";
+    }
+    return SMALL_NUMBER_FORMAT(number)
   }
   return NUMBER_FORMAT(number);
 }

--- a/client/src/utils/number-format.ts
+++ b/client/src/utils/number-format.ts
@@ -8,7 +8,7 @@ export const SMALL_NUMBER_FORMAT = format('.2~g');
 
 export function formatNumber(number: number): string {
   if (Math.abs(number) < 1) {
-    if (Math.abs(number) < 0.001) {
+    if (Math.abs(number) < 0.001 && Math.abs(number) > 0){
       return "< 0.001";
     }
     return SMALL_NUMBER_FORMAT(number)

--- a/client/src/utils/number-format.ts
+++ b/client/src/utils/number-format.ts
@@ -11,7 +11,7 @@ export function formatNumber(number: number): string {
     if (Math.abs(number) < 0.001 && Math.abs(number) > 0) {
       return '< 0.001';
     }
-    return SMALL_NUMBER_FORMAT(number)
+    return SMALL_NUMBER_FORMAT(number);
   }
   return NUMBER_FORMAT(number);
 }

--- a/client/src/utils/number-format.ts
+++ b/client/src/utils/number-format.ts
@@ -1,4 +1,4 @@
-import {format} from 'd3-format';
+import { format } from 'd3-format';
 
 // for numbers bigger than 1
 export const NUMBER_FORMAT = format('.2~s');

--- a/client/src/utils/number-format.ts
+++ b/client/src/utils/number-format.ts
@@ -1,4 +1,4 @@
-import { format } from 'd3-format';
+import {format} from 'd3-format';
 
 // for numbers bigger than 1
 export const NUMBER_FORMAT = format('.2~s');
@@ -8,8 +8,8 @@ export const SMALL_NUMBER_FORMAT = format('.2~g');
 
 export function formatNumber(number: number): string {
   if (Math.abs(number) < 1) {
-    if (Math.abs(number) < 0.001 && Math.abs(number) > 0){
-      return "< 0.001";
+    if (Math.abs(number) < 0.001 && Math.abs(number) > 0) {
+      return '< 0.001';
     }
     return SMALL_NUMBER_FORMAT(number)
   }


### PR DESCRIPTION
Fixes the problems of using quantiles with weirdly distributed data. The implementation also simplifies the query a lot since I'm just using the max value for given dataset and the rest of the logic is in server land. It caps the max value to 99th percent to avoid possible large outliers that further messed with the distribution and rounds the results to the first significant figure


### General description

#### New:
![image](https://github.com/Vizzuality/landgriffon/assets/9404338/96759299-65a5-4d7d-bdc7-7c93f22ce8b6)
![image](https://github.com/Vizzuality/landgriffon/assets/9404338/5c9907cf-10ec-469c-9206-87bacab28018)


#### Old 
![image](https://github.com/Vizzuality/landgriffon/assets/9404338/c27d0f9e-81bc-441a-86ff-6a2df9ca09c3)
![image](https://github.com/Vizzuality/landgriffon/assets/9404338/e700fd2a-1322-4aeb-94b8-7442ed8455cb)

#### ——————————
Note that the new bins are flat where the values exists but are negligent and only shifts colors where it is more prominent. 

### Testing instructions

Open an arbitrary layer and check if it looks and feels good

## Checklist before merging

- [ ] Branch name / PR includes the related Jira ticket Id.
- [ ] Tests to check core implementation / bug fix added.
- [ ] All checks in Continuous Integration workflow pass.
- [ ] Feature functionally tested by reviewer(s).
- [ ] Code reviewed by reviewer(s).
- [ ] Documentation updated (README, CHANGELOG...) (if required)
