### PR TITLE
migration from Mapbox GL to MapLibre GL

### DIFF
--- a/client/cypress/e2e/analysis/impact-layer.cy.ts
+++ b/client/cypress/e2e/analysis/impact-layer.cy.ts
@@ -16,7 +16,7 @@ describe('Analysis: map impact layer', () => {
   it('request the impact layer', () => {
     cy.visit('/analysis/map');
 
-    cy.get('canvas.mapboxgl-canvas').should('be.visible');
+    cy.get('canvas.maplibregl-canvas').should('be.visible');
 
     cy.wait('@fetchImpactMap').then((interception) => {
       cy.wrap(JSON.stringify(interception.response.body.data[0])).should(

--- a/client/src/components/map/component.tsx
+++ b/client/src/components/map/component.tsx
@@ -73,6 +73,7 @@ export const Map: FC<CustomMapProps> = ({
       {...otherMapProps}
       {...localViewState}
       attributionControl
+      minZoom={1}
     >
       {!!mapRef && children(mapRef.getMap())}
     </ReactMapGL>

--- a/client/src/components/map/styles/map-style-satellite-maplibre.json
+++ b/client/src/components/map/styles/map-style-satellite-maplibre.json
@@ -7,8 +7,9 @@
   "sources": {
     "esri": {
       "type": "raster",
-      "tiles": ["https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}"],
-      "attribution": "Tiles &copy; Esri &mdash; Source: Esri, i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community"
+      "tiles": ["https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}"],
+      "attribution": "Tiles &copy; Esri &mdash; Source: Esri, i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community",
+      "tileSize": 256
     }
   },
   "sprite": "https://tiles.basemaps.cartocdn.com/gl/positron-gl-style/sprite",
@@ -28,8 +29,7 @@
     {
       "id": "esri-world-imagery",
       "type": "raster",
-      "source": "esri",
-      "minzoom": 2
+      "source": "esri"
     },
     {
       "id": "custom-layers",


### PR DESCRIPTION
### General description

Migration from Mapbox GL to MapLibre GL, and also changed the basemaps to:

* Positron Carto https://docs.carto.com/carto-for-developers/carto-for-react/guides/basemaps
* ESRI World Imagery https://services.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer
