### PR TITLE
disabling tree data node in all filters

### DIFF
--- a/client/src/components/tree-select/utils.ts
+++ b/client/src/components/tree-select/utils.ts
@@ -155,6 +155,7 @@ const optionToTreeData = (
   const children = option.children?.map((option) => optionToTreeData(option, render, depth + 1));
   return render({
     ...option,
+    disabled: true, // added to prevent the node from being selectable only for EUDR demo
     style: { paddingLeft: 16 * depth },
     children,
   });


### PR DESCRIPTION
Disabling Tree selector nodes for all filters only for the EUDR demo