### PR TITLE
Add totalArea column to gadm csv preprocessing

### DIFF
--- a/data/h3_data_importer/data_checksums/geo_region.zip.sha256
+++ b/data/h3_data_importer/data_checksums/geo_region.zip.sha256
@@ -1,0 +1,1 @@
+c9cd5f7329207e24c778f5faa0a12d3c24bb5ee120bc29c2c1d0a171fc2656b2  geo_region.zip

--- a/data/preprocessing/gadm/make_geo_region_table.sql
+++ b/data/preprocessing/gadm/make_geo_region_table.sql
@@ -4,7 +4,7 @@ CREATE EXTENSION IF NOT EXISTS ltree;
 TRUNCATE TABLE geo_region CASCADE;
 
 INSERT INTO geo_region
-("name", "h3Flat", "h3Compact", "theGeom", "isCreatedByUser")
+("name", "h3Flat", "h3Compact", "theGeom", "isCreatedByUser", "totalArea")
 
 SELECT
 mpath,
@@ -17,7 +17,8 @@ array(
     ))
 ) AS "h3Compact",
 wkb_geometry,
-false
+false,
+null
 FROM gadm_levels0_2
 ON CONFLICT (name) DO UPDATE SET
 "h3Compact" = EXCLUDED."h3Compact",


### PR DESCRIPTION
### General description

Adds empty column `totalArea` to gadm preprocessing to sync it with the db schema and have a reproducible preprocessing + ingestion pipeline