### PR TITLE
[LANDGRIF-1563] enables cog preview when available

### DIFF
--- a/client/src/containers/analysis-visualization/analysis-contextual-layer/categories/category-layer/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-contextual-layer/categories/category-layer/component.tsx
@@ -45,7 +45,7 @@ const CategoryLayer = ({
               }}
             />
             {previewStatus === 'loading' && isPreviewActive ? (
-              <Loading />
+              <Loading className="h-4 w-4" />
             ) : (
               <TogglePreview
                 isPreviewActive={isPreviewActive}

--- a/client/src/containers/analysis-visualization/analysis-contextual-layer/preview-map/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-contextual-layer/preview-map/component.tsx
@@ -1,24 +1,26 @@
 import { useEffect, useCallback, useMemo } from 'react';
 import { H3HexagonLayer } from '@deck.gl/geo-layers/typed';
 
-import DeckLayer from 'components/map/layers/deck';
-import Map from 'components/map';
-import ZoomControl from 'components/map/controls/zoom';
-import LayerManager from 'components/map/layer-manager';
-import { useH3Data } from 'hooks/h3-data';
-import PageLoading from 'containers/page-loading';
-import { useYears } from 'hooks/years';
+import { PreviewStatus } from '@/containers/analysis-visualization/analysis-contextual-layer/categories/category-layer/types';
+import DeckLayer from '@/components/map/layers/deck';
+import Map from '@/components/map';
+import ZoomControl from '@/components/map/controls/zoom';
+import LayerManager from '@/components/map/layer-manager';
+import { useH3Data } from '@/hooks/h3-data';
+import PageLoading from '@/containers/page-loading';
+import { useYears } from '@/hooks/years';
+import useContextualLayers from '@/hooks/layers/getContextualLayers';
+import ContextualLayer from '@/containers/analysis-visualization/analysis-map/layers/contextual';
 
 import type { H3HexagonLayerProps } from '@deck.gl/geo-layers/typed';
-import type { UseQueryResult } from '@tanstack/react-query';
 import type { Dispatch } from 'react';
-import type { Material, Layer } from 'types';
-import type { MapboxLayerProps } from 'components/map/layers/types';
+import type { Material, Layer } from '@/types';
+import type { MapboxLayerProps } from '@/components/map/layers/types';
 
 interface PreviewMapProps {
   selectedLayerId?: Layer['id'];
   selectedMaterialId?: Material['id'];
-  onStatusChange?: Dispatch<UseQueryResult['status']>;
+  onStatusChange?: Dispatch<PreviewStatus>;
 }
 
 const INITIAL_PREVIEW_SETTINGS = {
@@ -37,39 +39,61 @@ const PreviewMap = ({ selectedLayerId, selectedMaterialId, onStatusChange }: Pre
     },
   });
 
-  const { data, isFetching, status } = useH3Data({
+  const { data: contextualLayers } = useContextualLayers();
+
+  const selectedLayer = useMemo(() => {
+    return contextualLayers
+      ?.flatMap((category) => category.layers)
+      .find((layer) => layer.id === selectedLayerId);
+  }, [contextualLayers, selectedLayerId]);
+
+  const {
+    data: h3data,
+    isFetching,
+    status,
+    fetchStatus,
+  } = useH3Data({
     id: selectedLayerId,
     params: {
       materialId: selectedMaterialId,
       year: materialYear,
     },
     options: {
-      enabled: !!selectedLayerId && (selectedLayerId !== 'material' || !!materialYear),
+      enabled:
+        !!selectedLayerId &&
+        (selectedLayerId !== 'material' || !!materialYear) &&
+        !selectedLayer?.tilerUrl?.length,
       select: (response) => response.data,
-      staleTime: 10000,
-      // having placeholder data makes the status always be success
       placeholderData: undefined,
     },
   });
 
   useEffect(() => {
+    if (selectedLayer?.tilerUrl?.length) {
+      return onStatusChange?.('success');
+    }
     onStatusChange?.(status);
-  }, [onStatusChange, status]);
+  }, [onStatusChange, status, fetchStatus, selectedLayer]);
 
   const PreviewLayer = useCallback(() => {
-    if (!data?.length) return null;
+    if (!selectedLayerId) return null;
 
-    return (
-      <DeckLayer<MapboxLayerProps<H3HexagonLayerProps>>
-        id={PREVIEW_LAYER_ID}
-        type={H3HexagonLayer}
-        data={data}
-        getHexagon={(d) => d.h}
-        getFillColor={(d) => d.c}
-        getLineColor={(d) => d.c}
-      />
-    );
-  }, [data]);
+    if (selectedLayer?.tilerUrl?.length) {
+      return <ContextualLayer id={selectedLayerId} />;
+    }
+    if (h3data?.length) {
+      return (
+        <DeckLayer<MapboxLayerProps<H3HexagonLayerProps>>
+          id={PREVIEW_LAYER_ID}
+          type={H3HexagonLayer}
+          data={h3data}
+          getHexagon={(d) => d.h}
+          getFillColor={(d) => d.c}
+          getLineColor={(d) => d.c}
+        />
+      );
+    }
+  }, [selectedLayerId, h3data, selectedLayer]);
 
   const layers = useMemo(() => [{ id: PREVIEW_LAYER_ID, layer: PreviewLayer }], [PreviewLayer]);
 
@@ -79,7 +103,7 @@ const PreviewMap = ({ selectedLayerId, selectedMaterialId, onStatusChange }: Pre
       <Map id="contextual-preview-map" mapStyle="terrain" viewState={INITIAL_PREVIEW_SETTINGS}>
         {() => <LayerManager layers={layers} />}
       </Map>
-      <div className="absolute bottom-2 right-2 z-10 w-10 space-y-2">
+      <div className="absolute bottom-10 right-2 z-10 w-10 space-y-2">
         <ZoomControl mapId="contextual-preview-map" />
       </div>
     </div>


### PR DESCRIPTION
### General description

This PR enables map preview using the the tiler URL provided by the layer available instead of relying on the `/h3data` endpoint blindly.

![image](https://github.com/Vizzuality/landgriffon/assets/999124/512de03b-1f18-4df7-9268-58d76d48b43a)


https://vizzuality.atlassian.net/browse/LANDGRIF-1563

### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

_Provide minimal instructions on how to test this PR._

- Apart from the added feature / bug fix, check overall performance, styling...

## Checklist before merging

- [ ] Branch name / PR includes the related Jira ticket Id.
- [ ] Tests to check core implementation / bug fix added.
- [ ] All checks in Continuous Integration workflow pass.
- [ ] Feature functionally tested by reviewer(s).
- [ ] Code reviewed by reviewer(s).
- [ ] Documentation updated (README, CHANGELOG...) (if required)
