### PR TITLE
Chore/landgrif 1597 add bucket per instance

### DIFF
--- a/infrastructure/base/modules/aws/s3_bucket/main.tf
+++ b/infrastructure/base/modules/aws/s3_bucket/main.tf
@@ -6,3 +6,6 @@ resource "aws_s3_bucket_acl" "landgriffon-raw-data_acl" {
   bucket = aws_s3_bucket.landgriffon-raw-data.id
   acl    = "private"
 }
+
+
+

--- a/infrastructure/kubernetes/modules/aws/env/main.tf
+++ b/infrastructure/kubernetes/modules/aws/env/main.tf
@@ -237,6 +237,10 @@ module "k8s_data_import" {
       name  = "S3_COG_PATH"
       value = "processed/cogs"
     },
+    {
+      name : "DATA_BUCKET_NAME"
+      value : module.environment_bucket.instance-bucket-name
+    }
   ])
 
   secrets = [
@@ -316,6 +320,15 @@ module "github_actions_frontend_secrets" {
   repo_name = var.repo_name
   branch    = var.repo_branch
   domain    = var.domain
+}
+
+
+module environment_bucket {
+  source      = "../s3"
+  bucket_name = var.environment
+  depends_on = [
+    module.k8s_namespace
+  ]
 }
 
 #module "data_import" {

--- a/infrastructure/kubernetes/modules/aws/s3/main.tf
+++ b/infrastructure/kubernetes/modules/aws/s3/main.tf
@@ -1,0 +1,59 @@
+data "aws_caller_identity" "current" {}
+
+resource "aws_s3_bucket" "instance_bucket" {
+  bucket = "landgriffon-${var.bucket_name}-bucket"
+
+  tags = {
+    Environment = var.bucket_name
+  }
+}
+
+resource "aws_s3_bucket_versioning" "versioning" {
+  bucket = aws_s3_bucket.instance_bucket.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "encryption" {
+  bucket = aws_s3_bucket.instance_bucket.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "block_public_access" {
+  bucket = aws_s3_bucket.instance_bucket.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_policy" "bucket_policy" {
+  bucket = aws_s3_bucket.instance_bucket.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowAllAuthenticatedUsersInAccount"
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+        }
+        Action = "s3:*"
+        Resource = [
+          "arn:aws:s3:::${aws_s3_bucket.instance_bucket.id}",
+          "arn:aws:s3:::${aws_s3_bucket.instance_bucket.id}/*"
+        ]
+      }
+    ]
+  })
+}
+

--- a/infrastructure/kubernetes/modules/aws/s3/outputs.tf
+++ b/infrastructure/kubernetes/modules/aws/s3/outputs.tf
@@ -1,0 +1,7 @@
+output "instance-bucket-arn" {
+  value = aws_s3_bucket.instance_bucket.arn
+}
+
+output "instance-bucket-name" {
+  value = aws_s3_bucket.instance_bucket.bucket
+}

--- a/infrastructure/kubernetes/modules/aws/s3/variables.tf
+++ b/infrastructure/kubernetes/modules/aws/s3/variables.tf
@@ -1,0 +1,6 @@
+variable "bucket_name" {
+  description = "Name of the bucket"
+  type        = string
+}
+
+


### PR DESCRIPTION
This pull request includes several changes to the AWS infrastructure configuration, primarily focusing on the creation and management of an S3 bucket for the environment. The most important changes are summarized below:

### S3 Bucket Configuration

* Added a new S3 bucket resource with versioning, encryption, and public access block settings in `infrastructure/kubernetes/modules/aws/s3/main.tf`.
* Created outputs for the S3 bucket's ARN and name in `infrastructure/kubernetes/modules/aws/s3/outputs.tf`.
* Introduced a new variable for the bucket name in `infrastructure/kubernetes/modules/aws/s3/variables.tf`.

### Environment Configuration

* Added a new module for the environment bucket in `infrastructure/kubernetes/modules/aws/env/main.tf`.
* Included a new environment variable `DATA_BUCKET_NAME` in the `k8s_data_import` module in `infrastructure/kubernetes/modules/aws/env/main.tf`.

### Minor Changes

* Added empty lines for formatting in `infrastructure/base/modules/aws/s3_bucket/main.tf`.