### PR TITLE
comment out unnecessary data

### DIFF
--- a/data/h3_data_importer/Makefile
+++ b/data/h3_data_importer/Makefile
@@ -46,9 +46,9 @@ all:
 	make crop indicators
 	make delete-h3-tables
 
-crop: convert-mapspam-crop-production convert-mapspam-crop-harvest  convert-cropland convert-cropgrids convert-glw3-livestock convert-livestock-processed convert-default-commodity convert-earthstat
+crop: convert-mapspam-crop-production convert-mapspam-crop-harvest  convert-cropland convert-cropgrids #convert-glw3-livestock #convert-livestock-processed #convert-default-commodity #convert-earthstat
 
-indicators: convert-aqueduct convert-deforestation convert-forestGHG convert-naturalCropConversion convert-nutrientLoadReduction convert-biodiversity convert-ghg-farm convert-ghg-farm-livestock
+indicators: convert-aqueduct convert-deforestation convert-forestGHG convert-naturalCropConversion convert-nutrientLoadReduction convert-biodiversity #convert-ghg-farm convert-ghg-farm-livestock
 
 contextual-layers: convert-hdi-contextual \
 	convert-deforest-by-human-landuse \
@@ -83,15 +83,15 @@ convert-mapspam-crop-harvest: download-mapspam-crop-harvest
 # EARTHSTAT - production and harvest
 # ---------------------------------------------
 
-download-earthstat:
-	mkdir -p $(WORKDIR_EARTHSTAT)/production $(WORKDIR_EARTHSTAT)/harvest
-	aws s3 sync $(AWS_S3_BUCKET_URL)/processed/earthstat/ $(WORKDIR_EARTHSTAT)
-	cd $(WORKDIR_EARTHSTAT) && sha256sum --check ../../$(CHECKSUMS_PATH)/earthstat
+# download-earthstat:
+# 	mkdir -p $(WORKDIR_EARTHSTAT)/production $(WORKDIR_EARTHSTAT)/harvest
+# 	aws s3 sync $(AWS_S3_BUCKET_URL)/processed/earthstat/ $(WORKDIR_EARTHSTAT)
+# 	cd $(WORKDIR_EARTHSTAT) && sha256sum --check ../../$(CHECKSUMS_PATH)/earthstat
 
 
-convert-earthstat: download-earthstat
-	python raster_folder_to_h3_table.py $(WORKDIR_EARTHSTAT)/production h3_grid_earthstat_global_prod production earthstat 2000 --h3-res=6 --thread-count=$(PARALLELIZATION_FACTOR)
-	python raster_folder_to_h3_table.py $(WORKDIR_EARTHSTAT)/harvest h3_grid_earthstat_global_ha harvest_area earthstat 2000 --h3-res=6 --thread-count=$(PARALLELIZATION_FACTOR)
+# convert-earthstat: download-earthstat
+# 	python raster_folder_to_h3_table.py $(WORKDIR_EARTHSTAT)/production h3_grid_earthstat_global_prod production earthstat 2000 --h3-res=6 --thread-count=$(PARALLELIZATION_FACTOR)
+# 	python raster_folder_to_h3_table.py $(WORKDIR_EARTHSTAT)/harvest h3_grid_earthstat_global_ha harvest_area earthstat 2000 --h3-res=6 --thread-count=$(PARALLELIZATION_FACTOR)
 
 # ---------------------------------------------
 # CROPGRIDS - production and harvest
@@ -141,96 +141,96 @@ convert-cropland: extract-cropland
 
 # DOWNLOAD PASTURE AND CROPLAND DATASET
 # The original file downloaded from https://s3.us-east-2.amazonaws.com/earthstatdata/CroplandPastureArea2000_Geotiff.zip is no longer available so we have moved it to our own bucket
-download-pasture:
-	mkdir -p $(WORKDIR_GLW3)/cattle/harvestArea $(WORKDIR_GLW3)/chickens/harvestArea $(WORKDIR_GLW3)/horses/harvestArea $(WORKDIR_GLW3)/goats/harvestArea $(WORKDIR_GLW3)/sheep/harvestArea $(WORKDIR_GLW3)/pasture/harvestArea $(WORKDIR_GLW3)/pigs/harvestArea
-	aws s3 cp s3://landgriffon-raw-data/raw/CroplandPastureArea2000_Geotiff.zip $(WORKDIR_GLW3)/pasture/harvestArea/CroplandPastureArea2000_Geotiff.zip
+# download-pasture:
+# 	mkdir -p $(WORKDIR_GLW3)/cattle/harvestArea $(WORKDIR_GLW3)/chickens/harvestArea $(WORKDIR_GLW3)/horses/harvestArea $(WORKDIR_GLW3)/goats/harvestArea $(WORKDIR_GLW3)/sheep/harvestArea $(WORKDIR_GLW3)/pasture/harvestArea $(WORKDIR_GLW3)/pigs/harvestArea
+# 	aws s3 cp s3://landgriffon-raw-data/raw/CroplandPastureArea2000_Geotiff.zip $(WORKDIR_GLW3)/pasture/harvestArea/CroplandPastureArea2000_Geotiff.zip
 
 #unzip
 #remove no data values
-extract-pasture: download-pasture
-	unzip -q -j -o -u $(WORKDIR_GLW3)/pasture/harvestArea/CroplandPastureArea2000_Geotiff.zip */Pasture2000_5m.tif -d $(WORKDIR_GLW3)/pasture/harvestArea
+# extract-pasture: download-pasture
+# 	unzip -q -j -o -u $(WORKDIR_GLW3)/pasture/harvestArea/CroplandPastureArea2000_Geotiff.zip */Pasture2000_5m.tif -d $(WORKDIR_GLW3)/pasture/harvestArea
 
-	gdal_calc.py --quiet --calc "(A>0)*(A*10*10*100)" --format GTiff --type Float32 --NoDataValue=0 \
-		-A $(WORKDIR_GLW3)/pasture/harvestArea/Pasture2000_5m.tif --A_band 1 \
-	 	--outfile $(WORKDIR_GLW3)/pasture/harvestArea/global2000_pasture_ha.tif;
+# 	gdal_calc.py --quiet --calc "(A>0)*(A*10*10*100)" --format GTiff --type Float32 --NoDataValue=0 \
+# 		-A $(WORKDIR_GLW3)/pasture/harvestArea/Pasture2000_5m.tif --A_band 1 \
+# 	 	--outfile $(WORKDIR_GLW3)/pasture/harvestArea/global2000_pasture_ha.tif;
 
-	rm -f $(WORKDIR_GLW3)/pasture/harvestArea/es_pasture_global.tif
+# 	rm -f $(WORKDIR_GLW3)/pasture/harvestArea/es_pasture_global.tif
 
 # data sourced from: https://www.livestockdata.org/contributor/gridded-livestock-world-glw3
 # download livestock data
 # download the area-weighted (AW) data as are free of any influence of spatial predictor variables. MOre information here: https://dataverse.harvard.edu/file.xhtml?persistentId=doi:10.7910/DVN/GIVQ75/3QWTTI&version=3.0
 # download area pixel to obtain total number of animals per pixel
-download-glw3-data: extract-pasture
-	mkdir -p $(WORKDIR_GLW3)/cattle/harvestArea $(WORKDIR_GLW3)/chickens/harvestArea $(WORKDIR_GLW3)/horses/harvestArea $(WORKDIR_GLW3)/goats/harvestArea $(WORKDIR_GLW3)/sheep/harvestArea $(WORKDIR_GLW3)/pasture/harvestArea $(WORKDIR_GLW3)/pigs/harvestArea \
-	$(WORKDIR_GLW3)/cattle/production $(WORKDIR_GLW3)/chickens/production $(WORKDIR_GLW3)/horses/production $(WORKDIR_GLW3)/goats/production $(WORKDIR_GLW3)/sheep/production $(WORKDIR_GLW3)/pasture/production $(WORKDIR_GLW3)/pigs/production
-	wget -q -O $(WORKDIR_GLW3)/cattle/6_Ct_2010_Aw.tif https://dataverse.harvard.edu/api/access/datafile/:persistentId?persistentId=doi:10.7910/DVN/GIVQ75/I5CUJS
-	wget -q -O $(WORKDIR_GLW3)/chickens/6_Ch_2010_Aw.tif https://dataverse.harvard.edu/api/access/datafile/:persistentId?persistentId=doi:10.7910/DVN/SUFASB/AP1LHN
-	wget -q -O $(WORKDIR_GLW3)/horses/6_Ho_2010_Aw.tif https://dataverse.harvard.edu/api/access/datafile/:persistentId?persistentId=doi:10.7910/DVN/7Q52MV/UAWH3Z
-	wget -q -O $(WORKDIR_GLW3)/goats/6_Gt_2010_Aw.tif https://dataverse.harvard.edu/api/access/datafile/:persistentId?persistentId=doi:10.7910/DVN/OCPH42/ZMVOOW
-	wget -q -O $(WORKDIR_GLW3)/sheep/6_Sh_2010_Aw.tif https://dataverse.harvard.edu/api/access/datafile/:persistentId?persistentId=doi:10.7910/DVN/BLWPZN/XDIRM4
-	wget -q -O $(WORKDIR_GLW3)/pigs/6_Pg_2010_Aw.tif https://dataverse.harvard.edu/api/access/datafile/:persistentId?persistentId=doi:10.7910/DVN/33N0JG/9LGGBS
-	wget -q -O $(WORKDIR_GLW3)/8_AreaKm.tif https://dataverse.harvard.edu/api/access/datafile/:persistentId?persistentId=doi:10.7910/DVN/33N0JG/OMPXVT
+# download-glw3-data: extract-pasture
+# 	mkdir -p $(WORKDIR_GLW3)/cattle/harvestArea $(WORKDIR_GLW3)/chickens/harvestArea $(WORKDIR_GLW3)/horses/harvestArea $(WORKDIR_GLW3)/goats/harvestArea $(WORKDIR_GLW3)/sheep/harvestArea $(WORKDIR_GLW3)/pasture/harvestArea $(WORKDIR_GLW3)/pigs/harvestArea \
+# 	$(WORKDIR_GLW3)/cattle/production $(WORKDIR_GLW3)/chickens/production $(WORKDIR_GLW3)/horses/production $(WORKDIR_GLW3)/goats/production $(WORKDIR_GLW3)/sheep/production $(WORKDIR_GLW3)/pasture/production $(WORKDIR_GLW3)/pigs/production
+# 	wget -q -O $(WORKDIR_GLW3)/cattle/6_Ct_2010_Aw.tif https://dataverse.harvard.edu/api/access/datafile/:persistentId?persistentId=doi:10.7910/DVN/GIVQ75/I5CUJS
+# 	wget -q -O $(WORKDIR_GLW3)/chickens/6_Ch_2010_Aw.tif https://dataverse.harvard.edu/api/access/datafile/:persistentId?persistentId=doi:10.7910/DVN/SUFASB/AP1LHN
+# 	wget -q -O $(WORKDIR_GLW3)/horses/6_Ho_2010_Aw.tif https://dataverse.harvard.edu/api/access/datafile/:persistentId?persistentId=doi:10.7910/DVN/7Q52MV/UAWH3Z
+# 	wget -q -O $(WORKDIR_GLW3)/goats/6_Gt_2010_Aw.tif https://dataverse.harvard.edu/api/access/datafile/:persistentId?persistentId=doi:10.7910/DVN/OCPH42/ZMVOOW
+# 	wget -q -O $(WORKDIR_GLW3)/sheep/6_Sh_2010_Aw.tif https://dataverse.harvard.edu/api/access/datafile/:persistentId?persistentId=doi:10.7910/DVN/BLWPZN/XDIRM4
+# 	wget -q -O $(WORKDIR_GLW3)/pigs/6_Pg_2010_Aw.tif https://dataverse.harvard.edu/api/access/datafile/:persistentId?persistentId=doi:10.7910/DVN/33N0JG/9LGGBS
+# 	wget -q -O $(WORKDIR_GLW3)/8_AreaKm.tif https://dataverse.harvard.edu/api/access/datafile/:persistentId?persistentId=doi:10.7910/DVN/33N0JG/OMPXVT
 
 # rasterize livetock per aggricultural land from FAO to get harvest area
 # multiply glw3 cattle (number of animals per km2) by the raster area to get the total number of animals per pixel (LSU)
-rasterize-glw3-livestock: download-glw3-data
-	gdal_calc.py --quiet --calc "A*B" --format GTiff --type Float32 --NoDataValue 0 -A $(WORKDIR_GLW3)/cattle/6_Ct_2010_Aw.tif --A_band 1 -B $(WORKDIR_GLW3)/8_AreaKm.tif --outfile $(WORKDIR_GLW3)/cattle/production/GLW3_2010_cattle_LSU.tif
-	gdal_calc.py --quiet --calc "A*B" --format GTiff --type Float32 --NoDataValue 0 -A $(WORKDIR_GLW3)/chickens/6_Ch_2010_Aw.tif --A_band 1 -B $(WORKDIR_GLW3)/8_AreaKm.tif --outfile $(WORKDIR_GLW3)/chickens/production/GLW3_2010_chickens_LSU.tif
-	gdal_calc.py --quiet --calc "A*B" --format GTiff --type Float32 --NoDataValue 0 -A $(WORKDIR_GLW3)/horses/6_Ho_2010_Aw.tif --A_band 1 -B $(WORKDIR_GLW3)/8_AreaKm.tif --outfile $(WORKDIR_GLW3)/horses/production/GLW3_2010_horses_LSU.tif
-	gdal_calc.py --quiet --calc "A*B" --format GTiff --type Float32 --NoDataValue 0 -A $(WORKDIR_GLW3)/goats/6_Gt_2010_Aw.tif --A_band 1 -B $(WORKDIR_GLW3)/8_AreaKm.tif --outfile $(WORKDIR_GLW3)/goats/production/GLW3_2010_goats_LSU.tif
-	gdal_calc.py --quiet --calc "A*B" --format GTiff --type Float32 --NoDataValue 0 -A $(WORKDIR_GLW3)/sheep/6_Sh_2010_Aw.tif --A_band 1 -B $(WORKDIR_GLW3)/8_AreaKm.tif --outfile $(WORKDIR_GLW3)/sheep/production/GLW3_2010_sheep_LSU.tif
-	gdal_calc.py --quiet --calc "A*B" --format GTiff --type Float32 --NoDataValue 0 -A $(WORKDIR_GLW3)/pigs/6_Pg_2010_Aw.tif --A_band 1 -B $(WORKDIR_GLW3)/8_AreaKm.tif --outfile $(WORKDIR_GLW3)/pigs/production/GLW3_2010_pigs_LSU.tif
-	gdal_calc.py --quiet --calc "A*(B>0)" --format GTiff --type Float32 --NoDataValue 3.402823e+38 -A $(WORKDIR_GLW3)/pasture/harvestArea/global2000_pasture_ha.tif --A_band 1 -B $(WORKDIR_GLW3)/cattle/6_Ct_2010_Aw.tif --outfile $(WORKDIR_GLW3)/cattle/harvestArea/GLW3_2010_cattle_ha.tif
-	gdal_calc.py --quiet --calc "A*(B>0)" --format GTiff --type Float32 --NoDataValue 3.402823e+38 -A $(WORKDIR_GLW3)/pasture/harvestArea/global2000_pasture_ha.tif --A_band 1 -B $(WORKDIR_GLW3)/chickens/6_Ch_2010_Aw.tif --outfile $(WORKDIR_GLW3)/chickens/harvestArea/GLW3_2010_chickens_ha.tif
-	gdal_calc.py --quiet --calc "A*(B>0)" --format GTiff --type Float32 --NoDataValue 3.402823e+38 -A $(WORKDIR_GLW3)/pasture/harvestArea/global2000_pasture_ha.tif --A_band 1 -B $(WORKDIR_GLW3)/horses/6_Ho_2010_Aw.tif --outfile $(WORKDIR_GLW3)/horses/harvestArea/GLW3_2010_horses_ha.tif
-	gdal_calc.py --quiet --calc "A*(B>0)" --format GTiff --type Float32 --NoDataValue 3.402823e+38 -A $(WORKDIR_GLW3)/pasture/harvestArea/global2000_pasture_ha.tif --A_band 1 -B $(WORKDIR_GLW3)/goats/6_Gt_2010_Aw.tif --outfile $(WORKDIR_GLW3)/goats/harvestArea/GLW3_2010_goats_ha.tif
-	gdal_calc.py --quiet --calc "A*(B>0)" --format GTiff --type Float32 --NoDataValue 3.402823e+38 -A $(WORKDIR_GLW3)/pasture/harvestArea/global2000_pasture_ha.tif --A_band 1 -B $(WORKDIR_GLW3)/sheep/6_Sh_2010_Aw.tif --outfile $(WORKDIR_GLW3)/sheep/harvestArea/GLW3_2010_sheep_ha.tif
-	gdal_calc.py --quiet --calc "A*(B>0)" --format GTiff --type Float32 --NoDataValue 3.402823e+38 -A $(WORKDIR_GLW3)/pasture/harvestArea/global2000_pasture_ha.tif --A_band 1 -B $(WORKDIR_GLW3)/pigs/6_Pg_2010_Aw.tif --outfile $(WORKDIR_GLW3)/pigs/harvestArea/GLW3_2010_pigs_ha.tif
-	rm -f $(WORKDIR_GLW3)/cattle/6_Ct_2010_Aw.tif $(WORKDIR_GLW3)/chickens/6_Ch_2010_Aw.tif $(WORKDIR_GLW3)/horses/6_Ho_2010_Aw.tif $(WORKDIR_GLW3)/goats/6_Gt_2010_Aw.tif \
-	$(WORKDIR_GLW3)/sheep/6_Sh_2010_Aw.tif $(WORKDIR_GLW3)/8_AreaKm.tif;
+# rasterize-glw3-livestock: download-glw3-data
+# 	gdal_calc.py --quiet --calc "A*B" --format GTiff --type Float32 --NoDataValue 0 -A $(WORKDIR_GLW3)/cattle/6_Ct_2010_Aw.tif --A_band 1 -B $(WORKDIR_GLW3)/8_AreaKm.tif --outfile $(WORKDIR_GLW3)/cattle/production/GLW3_2010_cattle_LSU.tif
+# 	gdal_calc.py --quiet --calc "A*B" --format GTiff --type Float32 --NoDataValue 0 -A $(WORKDIR_GLW3)/chickens/6_Ch_2010_Aw.tif --A_band 1 -B $(WORKDIR_GLW3)/8_AreaKm.tif --outfile $(WORKDIR_GLW3)/chickens/production/GLW3_2010_chickens_LSU.tif
+# 	gdal_calc.py --quiet --calc "A*B" --format GTiff --type Float32 --NoDataValue 0 -A $(WORKDIR_GLW3)/horses/6_Ho_2010_Aw.tif --A_band 1 -B $(WORKDIR_GLW3)/8_AreaKm.tif --outfile $(WORKDIR_GLW3)/horses/production/GLW3_2010_horses_LSU.tif
+# 	gdal_calc.py --quiet --calc "A*B" --format GTiff --type Float32 --NoDataValue 0 -A $(WORKDIR_GLW3)/goats/6_Gt_2010_Aw.tif --A_band 1 -B $(WORKDIR_GLW3)/8_AreaKm.tif --outfile $(WORKDIR_GLW3)/goats/production/GLW3_2010_goats_LSU.tif
+# 	gdal_calc.py --quiet --calc "A*B" --format GTiff --type Float32 --NoDataValue 0 -A $(WORKDIR_GLW3)/sheep/6_Sh_2010_Aw.tif --A_band 1 -B $(WORKDIR_GLW3)/8_AreaKm.tif --outfile $(WORKDIR_GLW3)/sheep/production/GLW3_2010_sheep_LSU.tif
+# 	gdal_calc.py --quiet --calc "A*B" --format GTiff --type Float32 --NoDataValue 0 -A $(WORKDIR_GLW3)/pigs/6_Pg_2010_Aw.tif --A_band 1 -B $(WORKDIR_GLW3)/8_AreaKm.tif --outfile $(WORKDIR_GLW3)/pigs/production/GLW3_2010_pigs_LSU.tif
+# 	gdal_calc.py --quiet --calc "A*(B>0)" --format GTiff --type Float32 --NoDataValue 3.402823e+38 -A $(WORKDIR_GLW3)/pasture/harvestArea/global2000_pasture_ha.tif --A_band 1 -B $(WORKDIR_GLW3)/cattle/6_Ct_2010_Aw.tif --outfile $(WORKDIR_GLW3)/cattle/harvestArea/GLW3_2010_cattle_ha.tif
+# 	gdal_calc.py --quiet --calc "A*(B>0)" --format GTiff --type Float32 --NoDataValue 3.402823e+38 -A $(WORKDIR_GLW3)/pasture/harvestArea/global2000_pasture_ha.tif --A_band 1 -B $(WORKDIR_GLW3)/chickens/6_Ch_2010_Aw.tif --outfile $(WORKDIR_GLW3)/chickens/harvestArea/GLW3_2010_chickens_ha.tif
+# 	gdal_calc.py --quiet --calc "A*(B>0)" --format GTiff --type Float32 --NoDataValue 3.402823e+38 -A $(WORKDIR_GLW3)/pasture/harvestArea/global2000_pasture_ha.tif --A_band 1 -B $(WORKDIR_GLW3)/horses/6_Ho_2010_Aw.tif --outfile $(WORKDIR_GLW3)/horses/harvestArea/GLW3_2010_horses_ha.tif
+# 	gdal_calc.py --quiet --calc "A*(B>0)" --format GTiff --type Float32 --NoDataValue 3.402823e+38 -A $(WORKDIR_GLW3)/pasture/harvestArea/global2000_pasture_ha.tif --A_band 1 -B $(WORKDIR_GLW3)/goats/6_Gt_2010_Aw.tif --outfile $(WORKDIR_GLW3)/goats/harvestArea/GLW3_2010_goats_ha.tif
+# 	gdal_calc.py --quiet --calc "A*(B>0)" --format GTiff --type Float32 --NoDataValue 3.402823e+38 -A $(WORKDIR_GLW3)/pasture/harvestArea/global2000_pasture_ha.tif --A_band 1 -B $(WORKDIR_GLW3)/sheep/6_Sh_2010_Aw.tif --outfile $(WORKDIR_GLW3)/sheep/harvestArea/GLW3_2010_sheep_ha.tif
+# 	gdal_calc.py --quiet --calc "A*(B>0)" --format GTiff --type Float32 --NoDataValue 3.402823e+38 -A $(WORKDIR_GLW3)/pasture/harvestArea/global2000_pasture_ha.tif --A_band 1 -B $(WORKDIR_GLW3)/pigs/6_Pg_2010_Aw.tif --outfile $(WORKDIR_GLW3)/pigs/harvestArea/GLW3_2010_pigs_ha.tif
+# 	rm -f $(WORKDIR_GLW3)/cattle/6_Ct_2010_Aw.tif $(WORKDIR_GLW3)/chickens/6_Ch_2010_Aw.tif $(WORKDIR_GLW3)/horses/6_Ho_2010_Aw.tif $(WORKDIR_GLW3)/goats/6_Gt_2010_Aw.tif \
+# 	$(WORKDIR_GLW3)/sheep/6_Sh_2010_Aw.tif $(WORKDIR_GLW3)/8_AreaKm.tif;
 
-rasterize-glw3-livestock-pasture: rasterize-glw3-livestock
-	gdal_calc.py --quiet --calc "A+B+C+D+E+F" --format GTiff --type Float32 --NoDataValue 0.0 \
-	-A $(WORKDIR_GLW3)/cattle/production/GLW3_2010_cattle_LSU.tif --A_band 1 \
-	-B $(WORKDIR_GLW3)/chickens/production/GLW3_2010_chickens_LSU.tif \
-	-C $(WORKDIR_GLW3)/horses/production/GLW3_2010_horses_LSU.tif \
-	-D $(WORKDIR_GLW3)/goats/production/GLW3_2010_goats_LSU.tif \
-	-E $(WORKDIR_GLW3)/sheep/production/GLW3_2010_sheep_LSU.tif \
-	-F $(WORKDIR_GLW3)/pigs/production/GLW3_2010_pigs_LSU.tif \
-	--outfile $(WORKDIR_GLW3)/pasture/production/GLW3_2010_pasture_LSU.tif;
+# rasterize-glw3-livestock-pasture: rasterize-glw3-livestock
+# 	gdal_calc.py --quiet --calc "A+B+C+D+E+F" --format GTiff --type Float32 --NoDataValue 0.0 \
+# 	-A $(WORKDIR_GLW3)/cattle/production/GLW3_2010_cattle_LSU.tif --A_band 1 \
+# 	-B $(WORKDIR_GLW3)/chickens/production/GLW3_2010_chickens_LSU.tif \
+# 	-C $(WORKDIR_GLW3)/horses/production/GLW3_2010_horses_LSU.tif \
+# 	-D $(WORKDIR_GLW3)/goats/production/GLW3_2010_goats_LSU.tif \
+# 	-E $(WORKDIR_GLW3)/sheep/production/GLW3_2010_sheep_LSU.tif \
+# 	-F $(WORKDIR_GLW3)/pigs/production/GLW3_2010_pigs_LSU.tif \
+# 	--outfile $(WORKDIR_GLW3)/pasture/production/GLW3_2010_pasture_LSU.tif;
 
-#Ingest livetock data- harvest area and production
-convert-glw3-livestock: rasterize-glw3-livestock-pasture
-	python raster_folder_to_h3_table.py $(WORKDIR_GLW3)/cattle/production h3_grid_cattle_glo_lsu production glw3 2010 --h3-res=6 --thread-count=$(PARALLELIZATION_FACTOR)
-	python raster_folder_to_h3_table.py $(WORKDIR_GLW3)/chickens/production h3_grid_chickens_glo_lsu production glw3 2010 --h3-res=6 --thread-count=$(PARALLELIZATION_FACTOR)
-	python raster_folder_to_h3_table.py $(WORKDIR_GLW3)/horses/production h3_grid_horses_glo_lsu production glw3 2010 --h3-res=6 --thread-count=$(PARALLELIZATION_FACTOR)
-	python raster_folder_to_h3_table.py $(WORKDIR_GLW3)/goats/production h3_grid_goats_glo_lsu production glw3 2010 --h3-res=6 --thread-count=$(PARALLELIZATION_FACTOR)
-	python raster_folder_to_h3_table.py $(WORKDIR_GLW3)/sheep/production h3_grid_sheep_glo_lsu production glw3 2010 --h3-res=6 --thread-count=$(PARALLELIZATION_FACTOR)
-	python raster_folder_to_h3_table.py $(WORKDIR_GLW3)/pigs/production h3_grid_pigs_glo_lsu production glw3 2010 --h3-res=6 --thread-count=$(PARALLELIZATION_FACTOR)
-	python raster_folder_to_h3_table.py $(WORKDIR_GLW3)/pasture/production h3_grid_pasture_glo_lsu production glw3 2010 --h3-res=6 --thread-count=$(PARALLELIZATION_FACTOR)
-	python raster_folder_to_h3_table.py $(WORKDIR_GLW3)/cattle/harvestArea h3_grid_cattle_glo_ha harvest_area glw3 2010 --h3-res=6 --thread-count=$(PARALLELIZATION_FACTOR)
-	python raster_folder_to_h3_table.py $(WORKDIR_GLW3)/chickens/harvestArea h3_grid_chickens_glo_ha harvest_area glw3 2010 --h3-res=6 --thread-count=$(PARALLELIZATION_FACTOR)
-	python raster_folder_to_h3_table.py $(WORKDIR_GLW3)/horses/harvestArea h3_grid_horses_glo_ha harvest_area glw3 2010 --h3-res=6 --thread-count=$(PARALLELIZATION_FACTOR)
-	python raster_folder_to_h3_table.py $(WORKDIR_GLW3)/goats/harvestArea h3_grid_goats_glo_ha harvest_area glw3 2010 --h3-res=6 --thread-count=$(PARALLELIZATION_FACTOR)
-	python raster_folder_to_h3_table.py $(WORKDIR_GLW3)/sheep/harvestArea h3_grid_sheep_glo_ha harvest_area glw3 2010 --h3-res=6 --thread-count=$(PARALLELIZATION_FACTOR)
-	python raster_folder_to_h3_table.py $(WORKDIR_GLW3)/pigs/harvestArea h3_grid_pigs_glo_ha harvest_area glw3 2010 --h3-res=6 --thread-count=$(PARALLELIZATION_FACTOR)
-	python raster_folder_to_h3_table.py $(WORKDIR_GLW3)/pasture/harvestArea h3_grid_pasture_glo_ha harvest_area glw3 2010 --h3-res=6 --thread-count=$(PARALLELIZATION_FACTOR)
+# #Ingest livetock data- harvest area and production
+# convert-glw3-livestock: rasterize-glw3-livestock-pasture
+# 	python raster_folder_to_h3_table.py $(WORKDIR_GLW3)/cattle/production h3_grid_cattle_glo_lsu production glw3 2010 --h3-res=6 --thread-count=$(PARALLELIZATION_FACTOR)
+# 	python raster_folder_to_h3_table.py $(WORKDIR_GLW3)/chickens/production h3_grid_chickens_glo_lsu production glw3 2010 --h3-res=6 --thread-count=$(PARALLELIZATION_FACTOR)
+# 	python raster_folder_to_h3_table.py $(WORKDIR_GLW3)/horses/production h3_grid_horses_glo_lsu production glw3 2010 --h3-res=6 --thread-count=$(PARALLELIZATION_FACTOR)
+# 	python raster_folder_to_h3_table.py $(WORKDIR_GLW3)/goats/production h3_grid_goats_glo_lsu production glw3 2010 --h3-res=6 --thread-count=$(PARALLELIZATION_FACTOR)
+# 	python raster_folder_to_h3_table.py $(WORKDIR_GLW3)/sheep/production h3_grid_sheep_glo_lsu production glw3 2010 --h3-res=6 --thread-count=$(PARALLELIZATION_FACTOR)
+# 	python raster_folder_to_h3_table.py $(WORKDIR_GLW3)/pigs/production h3_grid_pigs_glo_lsu production glw3 2010 --h3-res=6 --thread-count=$(PARALLELIZATION_FACTOR)
+# 	python raster_folder_to_h3_table.py $(WORKDIR_GLW3)/pasture/production h3_grid_pasture_glo_lsu production glw3 2010 --h3-res=6 --thread-count=$(PARALLELIZATION_FACTOR)
+# 	python raster_folder_to_h3_table.py $(WORKDIR_GLW3)/cattle/harvestArea h3_grid_cattle_glo_ha harvest_area glw3 2010 --h3-res=6 --thread-count=$(PARALLELIZATION_FACTOR)
+# 	python raster_folder_to_h3_table.py $(WORKDIR_GLW3)/chickens/harvestArea h3_grid_chickens_glo_ha harvest_area glw3 2010 --h3-res=6 --thread-count=$(PARALLELIZATION_FACTOR)
+# 	python raster_folder_to_h3_table.py $(WORKDIR_GLW3)/horses/harvestArea h3_grid_horses_glo_ha harvest_area glw3 2010 --h3-res=6 --thread-count=$(PARALLELIZATION_FACTOR)
+# 	python raster_folder_to_h3_table.py $(WORKDIR_GLW3)/goats/harvestArea h3_grid_goats_glo_ha harvest_area glw3 2010 --h3-res=6 --thread-count=$(PARALLELIZATION_FACTOR)
+# 	python raster_folder_to_h3_table.py $(WORKDIR_GLW3)/sheep/harvestArea h3_grid_sheep_glo_ha harvest_area glw3 2010 --h3-res=6 --thread-count=$(PARALLELIZATION_FACTOR)
+# 	python raster_folder_to_h3_table.py $(WORKDIR_GLW3)/pigs/harvestArea h3_grid_pigs_glo_ha harvest_area glw3 2010 --h3-res=6 --thread-count=$(PARALLELIZATION_FACTOR)
+# 	python raster_folder_to_h3_table.py $(WORKDIR_GLW3)/pasture/harvestArea h3_grid_pasture_glo_ha harvest_area glw3 2010 --h3-res=6 --thread-count=$(PARALLELIZATION_FACTOR)
 
 ###########################
 #  Livestock preprocessed #
 ############################
 
-download-livestock-processed:
-	mkdir -p $(WORKDIR_LIVESTOCK_PROCESSED)/production
-	mkdir -p $(WORKDIR_LIVESTOCK_PROCESSED)/harvest
-	aws s3 sync $(AWS_S3_BUCKET_URL)/processed/livestock_processed/production $(WORKDIR_LIVESTOCK_PROCESSED)/production
-	aws s3 sync $(AWS_S3_BUCKET_URL)/processed/livestock_processed/harvest $(WORKDIR_LIVESTOCK_PROCESSED)/harvest
-	cd $(WORKDIR_LIVESTOCK_PROCESSED)/production && sha256sum --check ../../../$(CHECKSUMS_PATH)/livestock_processed_prod
-	cd $(WORKDIR_LIVESTOCK_PROCESSED)/harvest && sha256sum --check ../../../$(CHECKSUMS_PATH)/livestock_processed_ha
+# download-livestock-processed:
+# 	mkdir -p $(WORKDIR_LIVESTOCK_PROCESSED)/production
+# 	mkdir -p $(WORKDIR_LIVESTOCK_PROCESSED)/harvest
+# 	aws s3 sync $(AWS_S3_BUCKET_URL)/processed/livestock_processed/production $(WORKDIR_LIVESTOCK_PROCESSED)/production
+# 	aws s3 sync $(AWS_S3_BUCKET_URL)/processed/livestock_processed/harvest $(WORKDIR_LIVESTOCK_PROCESSED)/harvest
+# 	cd $(WORKDIR_LIVESTOCK_PROCESSED)/production && sha256sum --check ../../../$(CHECKSUMS_PATH)/livestock_processed_prod
+# 	cd $(WORKDIR_LIVESTOCK_PROCESSED)/harvest && sha256sum --check ../../../$(CHECKSUMS_PATH)/livestock_processed_ha
 
-convert-livestock-processed: download-livestock-processed
-	python raster_folder_to_h3_table.py $(WORKDIR_LIVESTOCK_PROCESSED)/production h3_grid_livestock_processed_global_prod production spam 2021 --h3-res=6 --thread-count=$(PARALLELIZATION_FACTOR)
-	python raster_folder_to_h3_table.py $(WORKDIR_LIVESTOCK_PROCESSED)/harvest h3_grid_livestock_processed_global_ha harvest_area spam 2021 --h3-res=6 --thread-count=$(PARALLELIZATION_FACTOR)
+# convert-livestock-processed: download-livestock-processed
+# 	python raster_folder_to_h3_table.py $(WORKDIR_LIVESTOCK_PROCESSED)/production h3_grid_livestock_processed_global_prod production spam 2021 --h3-res=6 --thread-count=$(PARALLELIZATION_FACTOR)
+# 	python raster_folder_to_h3_table.py $(WORKDIR_LIVESTOCK_PROCESSED)/harvest h3_grid_livestock_processed_global_ha harvest_area spam 2021 --h3-res=6 --thread-count=$(PARALLELIZATION_FACTOR)
 
 #####################################
 # Deforestation footprint (DF_SLUC) #
@@ -330,25 +330,25 @@ convert-nutrientLoadReduction: extract-nutrient-load-reduction
 # GHG FARM (GHG_FARM) - agriculture commodities #
 #################################################
 
-download-ghg-farm:
-	mkdir -p $(WORKDIR_GHG_FARM)
-	aws s3 sync $(AWS_S3_BUCKET_URL)/processed/ghg_emissions $(WORKDIR_GHG_FARM)
-	cd $(WORKDIR_GHG_FARM) && sha256sum --check ../../$(CHECKSUMS_PATH)/ghg_from_farm_emissions
+# download-ghg-farm:
+# 	mkdir -p $(WORKDIR_GHG_FARM)
+# 	aws s3 sync $(AWS_S3_BUCKET_URL)/processed/ghg_emissions $(WORKDIR_GHG_FARM)
+# 	cd $(WORKDIR_GHG_FARM) && sha256sum --check ../../$(CHECKSUMS_PATH)/ghg_from_farm_emissions
 
-convert-ghg-farm: download-ghg-farm
-	python raster_folder_to_h3_table.py $(WORKDIR_GHG_FARM) h3_grid_ghg_farm_global material_indicator GHG_FARM 2017 --h3-res=6 --thread-count=$(PARALLELIZATION_FACTOR)
+# convert-ghg-farm: download-ghg-farm
+# 	python raster_folder_to_h3_table.py $(WORKDIR_GHG_FARM) h3_grid_ghg_farm_global material_indicator GHG_FARM 2017 --h3-res=6 --thread-count=$(PARALLELIZATION_FACTOR)
 
 ###############################################
 # GHG FARM (GHG_FARM) - livestock commodities #
 ###############################################
 
-download-ghg-farm-livestock:
-	mkdir -p $(WORKDIR_GHG_FARM)/livestock
-	aws s3 sync $(AWS_S3_BUCKET_URL)/processed/ghg_emissions_livestock/ $(WORKDIR_GHG_FARM)/livestock
-	cd $(WORKDIR_GHG_FARM)/livestock && sha256sum --check ../../../$(CHECKSUMS_PATH)/ghg_from_farm_emissions_livesock
+# download-ghg-farm-livestock:
+# 	mkdir -p $(WORKDIR_GHG_FARM)/livestock
+# 	aws s3 sync $(AWS_S3_BUCKET_URL)/processed/ghg_emissions_livestock/ $(WORKDIR_GHG_FARM)/livestock
+# 	cd $(WORKDIR_GHG_FARM)/livestock && sha256sum --check ../../../$(CHECKSUMS_PATH)/ghg_from_farm_emissions_livesock
 
-convert-ghg-farm-livestock: download-ghg-farm-livestock
-	python raster_folder_to_h3_table.py $(WORKDIR_GHG_FARM)/livestock h3_grid_ghg_farm_livestock_global material_indicator GHG_FARM 2017 --h3-res=6 --thread-count=$(PARALLELIZATION_FACTOR)
+# convert-ghg-farm-livestock: download-ghg-farm-livestock
+# 	python raster_folder_to_h3_table.py $(WORKDIR_GHG_FARM)/livestock h3_grid_ghg_farm_livestock_global material_indicator GHG_FARM 2017 --h3-res=6 --thread-count=$(PARALLELIZATION_FACTOR)
 
 
 ###################
@@ -382,15 +382,15 @@ convert-crop-net-conversion-by-human-landuse:
 # Default commodity #
 #####################
 
-download-default-commodity:
-	mkdir -p $(WORKDIR_DEFAULT_COMMODITY)
-	aws s3 sync $(AWS_S3_BUCKET_URL)/processed/default_commodity/ $(WORKDIR_DEFAULT_COMMODITY)
-	cd $(WORKDIR_DEFAULT_COMMODITY) && sha256sum --check ../../$(CHECKSUMS_PATH)/default_commodity
+# download-default-commodity:
+# 	mkdir -p $(WORKDIR_DEFAULT_COMMODITY)
+# 	aws s3 sync $(AWS_S3_BUCKET_URL)/processed/default_commodity/ $(WORKDIR_DEFAULT_COMMODITY)
+# 	cd $(WORKDIR_DEFAULT_COMMODITY) && sha256sum --check ../../$(CHECKSUMS_PATH)/default_commodity
 
-# as it's a default commodity with value one for equal distribution, we can add it as production and harvest dataset
-convert-default-commodity: download-default-commodity
-	python raster_folder_to_h3_table.py $(WORKDIR_DEFAULT_COMMODITY) h3_grid_default_commodity_global_p production spam  2021 --h3-res=6 --thread-count=$(PARALLELIZATION_FACTOR)
-	python raster_folder_to_h3_table.py $(WORKDIR_DEFAULT_COMMODITY) h3_grid_default_commodity_global_ha harvest_area spam  2021 --h3-res=6 --thread-count=$(PARALLELIZATION_FACTOR)
+# # as it's a default commodity with value one for equal distribution, we can add it as production and harvest dataset
+# convert-default-commodity: download-default-commodity
+# 	python raster_folder_to_h3_table.py $(WORKDIR_DEFAULT_COMMODITY) h3_grid_default_commodity_global_p production spam  2021 --h3-res=6 --thread-count=$(PARALLELIZATION_FACTOR)
+# 	python raster_folder_to_h3_table.py $(WORKDIR_DEFAULT_COMMODITY) h3_grid_default_commodity_global_ha harvest_area spam  2021 --h3-res=6 --thread-count=$(PARALLELIZATION_FACTOR)
 
 
 #########


### PR DESCRIPTION
This pull request involves significant changes to the `data/h3_data_importer/Makefile` file, primarily commenting out various data conversion and download processes. These changes streamline the Makefile by disabling certain steps related to EarthStat, GLW3 livestock data, and GHG farm emissions.

Commented out data conversion and download processes:

* Disabled conversion steps for EarthStat data, including the `convert-earthstat` and `download-earthstat` targets.
* Commented out the `convert-glw3-livestock` and related GLW3 livestock data download and processing steps.
* Disabled the `convert-livestock-processed` and `download-livestock-processed` targets.
* Commented out GHG farm emissions data processing steps, including `convert-ghg-farm` and `download-ghg-farm` targets.
* Disabled GHG farm livestock emissions data processing steps, including `convert-ghg-farm-livestock` and `download-ghg-farm-livestock` targets.

These changes effectively disable the processing of certain datasets, which may be intended for a temporary pause or a permanent removal, depending on future requirements.