### PR TITLE
Bugix/fix query alias and use uwu for wguwu

### DIFF
--- a/api/src/modules/indicator-records/services/impact-calculation.dependencies.ts
+++ b/api/src/modules/indicator-records/services/impact-calculation.dependencies.ts
@@ -148,6 +148,6 @@ export const INDICATOR_NAME_CODE_TO_QUERY_MAP: {
     [INDICATOR_NAME_CODES.WGUWU]: () =>
       `${get_annual_commodity_weighted_impact_over_georegion}($1, '${INDICATOR_NAME_CODES.WGUWU}', $2, 'producer') as "${INDICATOR_NAME_CODES.WGUWU}"`,
     [INDICATOR_NAME_CODES.WW]: () =>
-      `${get_indicator_coefficient_impact}('${INDICATOR_NAME_CODES.WW}', $3, $2) as "${INDICATOR_NAME_CODES.WU}"`,
+      `${get_indicator_coefficient_impact}('${INDICATOR_NAME_CODES.WW}', $3, $2) as "${INDICATOR_NAME_CODES.WW}"`,
   },
 };

--- a/api/src/modules/indicator-records/services/impact-calculation.dependencies.ts
+++ b/api/src/modules/indicator-records/services/impact-calculation.dependencies.ts
@@ -146,7 +146,7 @@ export const INDICATOR_NAME_CODE_TO_QUERY_MAP: {
   },
   [INDICATOR_NAME_CODES.WGUWU]: {
     [INDICATOR_NAME_CODES.WGUWU]: () =>
-      `${get_annual_commodity_weighted_impact_over_georegion}($1, '${INDICATOR_NAME_CODES.WGUWU}', $2, 'producer') as "${INDICATOR_NAME_CODES.WGUWU}"`,
+      `${get_annual_commodity_weighted_impact_over_georegion}($1, '${INDICATOR_NAME_CODES.UWU}', $2, 'producer') as "${INDICATOR_NAME_CODES.WGUWU}"`,
     [INDICATOR_NAME_CODES.WW]: () =>
       `${get_indicator_coefficient_impact}('${INDICATOR_NAME_CODES.WW}', $3, $2) as "${INDICATOR_NAME_CODES.WW}"`,
   },


### PR DESCRIPTION
This pull request includes a change to the `INDICATOR_NAME_CODE_TO_QUERY_MAP` in the `impact-calculation.dependencies.ts` file. The change corrects the indicator name codes used in the query strings for the `WGUWU` and `WW` indicators.

Corrections to indicator name codes:

* [`api/src/modules/indicator-records/services/impact-calculation.dependencies.ts`](diffhunk://#diff-51b60db74b10568ddef000e51998a8e18b407fb7a87a44309d711c67cef2010aL149-R151): Corrected the indicator name codes in the query strings for `WGUWU` and `WW` indicators.