### PR TITLE
add node worker to parse sheet

### DIFF
--- a/api/src/modules/import-data/file.service.ts
+++ b/api/src/modules/import-data/file.service.ts
@@ -4,6 +4,7 @@ import * as XLSX from 'xlsx';
 import { WorkBook } from 'xlsx';
 import { difference } from 'lodash';
 import { Worker } from 'worker_threads';
+import * as path from 'path';
 
 @Injectable()
 export class FileService<T extends Record<string, any[]>> {
@@ -11,15 +12,18 @@ export class FileService<T extends Record<string, any[]>> {
 
   async transformToJsonInWorker(filePath: string, sheetMap: any): Promise<T> {
     await this.isFilePresentInFs(filePath);
+    const workerFile: string =
+      process.env.NODE_ENV === 'test'
+        ? path.resolve(__dirname, './workers/xlsx.worker.ts') // En tests usa el archivo TypeScript
+        : path.resolve(__dirname, './workers/xlsx.worker.js');
     this.logger.log(`Starting worker to parse ${filePath}...`);
     try {
       const parsedSheet: any = await new Promise((resolve, reject) => {
-        const worker: Worker = new Worker(
-          __dirname + '/workers/xlsx.worker.js',
-          {
-            workerData: { filePath, sheetMap },
-          },
-        );
+        const worker: Worker = new Worker(workerFile, {
+          workerData: { filePath, sheetMap },
+          execArgv:
+            process.env.NODE_ENV === 'test' ? ['-r', 'ts-node/register'] : [],
+        });
 
         worker.on('message', (data: T) => {
           this.logger.warn(`Worker finished processing ${filePath}`);

--- a/api/src/modules/import-data/file.service.ts
+++ b/api/src/modules/import-data/file.service.ts
@@ -3,10 +3,47 @@ import { access, unlink } from 'fs/promises';
 import * as XLSX from 'xlsx';
 import { WorkBook } from 'xlsx';
 import { difference } from 'lodash';
+import { Worker } from 'worker_threads';
 
 @Injectable()
 export class FileService<T extends Record<string, any[]>> {
   private readonly logger: Logger = new Logger(FileService.name);
+
+  async transformToJsonInWorker(filePath: string, sheetMap: any): Promise<T> {
+    await this.isFilePresentInFs(filePath);
+    this.logger.log(`Starting worker to parse ${filePath}...`);
+    try {
+      const parsedSheet: any = await new Promise((resolve, reject) => {
+        const worker: Worker = new Worker(
+          __dirname + '/workers/xlsx.worker.js',
+          {
+            workerData: { filePath, sheetMap },
+          },
+        );
+
+        worker.on('message', (data: T) => {
+          this.logger.warn(`Worker finished processing ${filePath}`);
+          resolve(data);
+        });
+
+        worker.on('error', (error: Error) => {
+          this.logger.error(`Worker failed processing ${filePath}: ${error}`);
+          reject(error);
+        });
+
+        worker.on('exit', (code: number) => {
+          if (code !== 0) {
+            this.logger.error(`Worker stopped with exit code ${code}`);
+            reject(new Error(`Worker stopped with exit code ${code}`));
+          }
+        });
+      });
+      return parsedSheet;
+    } catch (error) {
+      this.logger.error(error);
+      throw new Error(`XLSX file could not been parsed: ${error}`);
+    }
+  }
 
   async transformToJson(
     filePath: string,

--- a/api/src/modules/import-data/file.service.ts
+++ b/api/src/modules/import-data/file.service.ts
@@ -4,7 +4,7 @@ import * as XLSX from 'xlsx';
 import { WorkBook } from 'xlsx';
 import { difference } from 'lodash';
 import { Worker } from 'worker_threads';
-import * as path from 'path';
+import { getWorkerConfig } from 'modules/import-data/utils';
 
 @Injectable()
 export class FileService<T extends Record<string, any[]>> {
@@ -12,17 +12,13 @@ export class FileService<T extends Record<string, any[]>> {
 
   async transformToJsonInWorker(filePath: string, sheetMap: any): Promise<T> {
     await this.isFilePresentInFs(filePath);
-    const workerFile: string =
-      process.env.NODE_ENV === 'test'
-        ? path.resolve(__dirname, './workers/xlsx.worker.ts') // En tests usa el archivo TypeScript
-        : path.resolve(__dirname, './workers/xlsx.worker.js');
+    const { workerPath, execArgv } = getWorkerConfig('xlsx.worker');
     this.logger.log(`Starting worker to parse ${filePath}...`);
     try {
       const parsedSheet: any = await new Promise((resolve, reject) => {
-        const worker: Worker = new Worker(workerFile, {
+        const worker: Worker = new Worker(workerPath, {
           workerData: { filePath, sheetMap },
-          execArgv:
-            process.env.NODE_ENV === 'test' ? ['-r', 'ts-node/register'] : [],
+          execArgv,
         });
 
         worker.on('message', (data: T) => {

--- a/api/src/modules/import-data/sourcing-data/sourcing-data-import.service.ts
+++ b/api/src/modules/import-data/sourcing-data/sourcing-data-import.service.ts
@@ -68,89 +68,88 @@ export class SourcingDataImportService {
 
   async importSourcingData(filePath: string, taskId: string): Promise<any> {
     this.logger.log(`Starting import process`);
-    //await this.fileService.isFilePresentInFs(filePath);
     try {
       const parsedXLSXDataset: SourcingRecordsSheets =
-        await this.fileService.transformToJson(filePath, SHEETS_MAP);
+        await this.fileService.transformToJsonInWorker(filePath, SHEETS_MAP);
 
       const { data: dtoMatchedData, validationErrors } =
         await this.excelValidator.validate(
           parsedXLSXDataset as unknown as SourcingDataSheet,
         );
-      // if (validationErrors.length) {
-      //   throw new ExcelValidationError('Validation Errors', validationErrors);
-      // }
-      //
-      // //TODO: Implement transactional import. Move geocoding to first step
-      //
-      // await this.dbCleaner.cleanDataBeforeImport();
-      //
-      // const materials: Material[] =
-      //   await this.materialService.findAllUnpaginated();
-      // if (!materials.length) {
-      //   throw new ServiceUnavailableException(
-      //     'No Materials found present in the DB. Please check the LandGriffon installation manual',
-      //   );
-      // }
+      if (validationErrors.length) {
+        throw new ExcelValidationError('Validation Errors', validationErrors);
+      }
+
+      //TODO: Implement transactional import. Move geocoding to first step
+
+      await this.dbCleaner.cleanDataBeforeImport();
+
+      const materials: Material[] =
+        await this.materialService.findAllUnpaginated();
+      if (!materials.length) {
+        throw new ServiceUnavailableException(
+          'No Materials found present in the DB. Please check the LandGriffon installation manual',
+        );
+      }
       this.logger.log('Activating Indicators...');
       const activeIndicators: Indicator[] =
         await this.indicatorService.activateIndicators(
           dtoMatchedData.indicators,
         );
-      // this.logger.log('Activating Materials...');
-      // const activeMaterials: Material[] =
-      //   await this.materialService.activateMaterials(dtoMatchedData.materials);
-      //
-      // await this.tasksService.updateImportTask({
-      //   taskId,
-      //   newLogs: [
-      //     `Activated indicators: ${activeIndicators
-      //       .map((i: Indicator) => i.name)
-      //       .join(', ')}`,
-      //     `Activated materials: ${activeMaterials
-      //       .map((i: Material) => i.hsCodeId)
-      //       .join(', ')}`,
-      //   ],
-      // });
-      //
-      // const businessUnits: BusinessUnit[] =
-      //   await this.businessUnitService.createTree(dtoMatchedData.businessUnits);
-      //
-      // const suppliers: Supplier[] = await this.supplierService.createTree(
-      //   dtoMatchedData.suppliers,
-      // );
-      //
-      // const { geoCodedSourcingData, errors } =
-      //   await this.geoCodingService.geoCodeLocations(
-      //     dtoMatchedData.sourcingData,
-      //   );
-      // if (errors.length) {
-      //   throw new GeoCodingError(
-      //     'Import failed. There are GeoCoding errors present in the file',
-      //     errors,
-      //   );
-      // }
-      // const warnings: string[] = [];
-      // geoCodedSourcingData.forEach((elem: SourcingData) => {
-      //   if (elem.locationWarning) warnings.push(elem.locationWarning);
-      // });
-      // warnings.length > 0 &&
-      //   (await this.tasksService.updateImportTask({
-      //     taskId,
-      //     newLogs: warnings,
-      //   }));
-      //
-      // const sourcingDataWithOrganizationalEntities: SourcingLocation[] =
-      //   await this.relateSourcingDataWithOrganizationalEntities(
-      //     suppliers,
-      //     businessUnits,
-      //     materials,
-      //     geoCodedSourcingData,
-      //   );
-      //
-      // await this.sourcingLocationService.save(
-      //   sourcingDataWithOrganizationalEntities,
-      // );
+      this.logger.log('Activating Materials...');
+      const activeMaterials: Material[] =
+        await this.materialService.activateMaterials(dtoMatchedData.materials);
+
+      await this.tasksService.updateImportTask({
+        taskId,
+        newLogs: [
+          `Activated indicators: ${activeIndicators
+            .map((i: Indicator) => i.name)
+            .join(', ')}`,
+          `Activated materials: ${activeMaterials
+            .map((i: Material) => i.hsCodeId)
+            .join(', ')}`,
+        ],
+      });
+
+      const businessUnits: BusinessUnit[] =
+        await this.businessUnitService.createTree(dtoMatchedData.businessUnits);
+
+      const suppliers: Supplier[] = await this.supplierService.createTree(
+        dtoMatchedData.suppliers,
+      );
+
+      const { geoCodedSourcingData, errors } =
+        await this.geoCodingService.geoCodeLocations(
+          dtoMatchedData.sourcingData,
+        );
+      if (errors.length) {
+        throw new GeoCodingError(
+          'Import failed. There are GeoCoding errors present in the file',
+          errors,
+        );
+      }
+      const warnings: string[] = [];
+      geoCodedSourcingData.forEach((elem: SourcingData) => {
+        if (elem.locationWarning) warnings.push(elem.locationWarning);
+      });
+      warnings.length > 0 &&
+        (await this.tasksService.updateImportTask({
+          taskId,
+          newLogs: warnings,
+        }));
+
+      const sourcingDataWithOrganizationalEntities: SourcingLocation[] =
+        await this.relateSourcingDataWithOrganizationalEntities(
+          suppliers,
+          businessUnits,
+          materials,
+          geoCodedSourcingData,
+        );
+
+      await this.sourcingLocationService.save(
+        sourcingDataWithOrganizationalEntities,
+      );
 
       this.logger.log('Generating Indicator Records...');
 

--- a/api/src/modules/import-data/utils.ts
+++ b/api/src/modules/import-data/utils.ts
@@ -1,0 +1,21 @@
+import * as path from 'path';
+
+interface WorkerConfig {
+  workerPath: string;
+  execArgv: string[];
+}
+
+// Since node workers do not support ts out of the box, we need to specify the JS file for the app, but TS file for the tests.
+
+export const getWorkerConfig = (fileName: string): WorkerConfig => {
+  const isTestEnvironment: boolean = process.env.NODE_ENV === 'test';
+  const workerPath: WorkerConfig['workerPath'] = isTestEnvironment
+    ? path.resolve(__dirname, `./workers/${fileName}.ts`)
+    : path.resolve(__dirname, `./workers/${fileName}.js`);
+
+  const execArgv: WorkerConfig['execArgv'] = isTestEnvironment
+    ? ['-r', 'ts-node/register']
+    : [];
+
+  return { workerPath, execArgv };
+};

--- a/api/src/modules/import-data/workers/xlsx.worker.ts
+++ b/api/src/modules/import-data/workers/xlsx.worker.ts
@@ -1,0 +1,19 @@
+import { parentPort, workerData } from 'worker_threads';
+import * as XLSX from 'xlsx';
+
+try {
+  const filePath: string = workerData.filePath;
+  const sheetMap: any = workerData.sheetMap;
+  const workBook: XLSX.WorkBook = XLSX.readFile(filePath);
+  const parsedSheets: Record<string, any[]> = {};
+
+  for (const [key, value] of Object.entries(sheetMap)) {
+    parsedSheets[value as string] = XLSX.utils.sheet_to_json(
+      workBook.Sheets[key],
+    );
+  }
+
+  parentPort?.postMessage(parsedSheets);
+} catch (error: any) {
+  parentPort?.postMessage({ error: error.message });
+}


### PR DESCRIPTION
This pull request introduces a significant enhancement to the file processing system by leveraging worker threads for parsing XLSX files, improving performance and reliability. The key changes include the addition of a new method to handle file parsing using workers, updates to the import service to utilize this new method, and the creation of a worker script for XLSX file parsing.

### Enhancements to file processing:

* [`api/src/modules/import-data/file.service.ts`](diffhunk://#diff-29e1e052f88ef610f0a03e2c3d9b1d47e156b5dd60e224382ce56d3cfe5815b8R6-R47): Added a new method `transformToJsonInWorker` that uses worker threads to parse XLSX files, improving the efficiency of file processing.
* [`api/src/modules/import-data/workers/xlsx.worker.ts`](diffhunk://#diff-79de65ccdf7ebfd5a932c8c194d660c9cdc0260151f058efe307e0f029e61b6eR1-R19): Introduced a new worker script to handle XLSX file parsing, which reads the file and converts sheets to JSON format.

### Updates to import service:

* [`api/src/modules/import-data/sourcing-data/sourcing-data-import.service.ts`](diffhunk://#diff-57d19c40cf494c548c15f284e2ab67097df1256a8c2bb72a1a18856b99fbb853L71-R152): Modified the `importSourcingData` method to use the new `transformToJsonInWorker` method for parsing XLSX files, ensuring better performance and error handling.