### PR TITLE
refactor deployment to optionally get env name from secrets

### DIFF
--- a/.github/workflows/deploy-to-kubernetes.yml
+++ b/.github/workflows/deploy-to-kubernetes.yml
@@ -9,6 +9,7 @@ on:
       - 'expo'
       - 'demo'
       - 'dev'
+      - 'pilot'
     paths:
       - 'api/**'
       - 'client/**'
@@ -17,6 +18,31 @@ on:
   workflow_dispatch:
 
 jobs:
+  set_env_name:
+    name: Set Environment Name
+    runs-on: ubuntu-20.04
+    outputs:
+      env_name: ${{ steps.set_env.outputs.env_name }}
+      env_name_upper: ${{ steps.set_env.outputs.env_name_upper }}
+    steps:
+      - name: Set environment name
+        shell: bash
+        run: |
+          branch_name=$(echo "${GITHUB_REF#refs/heads/}")
+          secret_name=$(echo "$branch_name" | tr '[:lower:]' '[:upper:]')
+          mapped_name=${!secret_name}
+          if [ -z "$mapped_name" ]; then
+            echo "Warning: No secret found for branch '$branch_name'. Falling back to branch name."
+            mapped_name=$branch_name
+          fi
+          mapped_name_upper=$(echo "$mapped_name" | tr '[:lower:]' '[:upper:]')
+          echo "Environment name used: $mapped_name"
+          echo "##[set-output name=env_name;]$mapped_name"
+          echo "##[set-output name=env_name_upper;]$mapped_name_upper"
+        id: set_env
+        env:
+          PILOT: ${{ secrets.PILOT }}
+
   wait_for_image_push:
     name: Wait for Docker images to be pushed
     runs-on: ubuntu-20.04
@@ -38,7 +64,7 @@ jobs:
   deploy_images_to_kubernetes:
     name: Deploy updated Docker image to Kubernetes
     runs-on: ubuntu-20.04
-    needs: wait_for_image_push
+    needs: [ set_env_name, wait_for_image_push ]
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
@@ -87,23 +113,16 @@ jobs:
         run: |
           ssh -i ~/.ssh/bastion.key -o StrictHostKeyChecking=no -N -L 4433:${{ secrets.EKS_HOST }}:443 ${{ secrets.BASTION_USER }}@${{ secrets.BASTION_HOST }} -T &
 
-      - name: Extract branch name
-        shell: bash
-        run: |
-          echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
-          echo "##[set-output name=branch-upper;]$(echo ${GITHUB_REF#refs/heads/} | tr a-z A-Z )"
-        id: extract_branch
-
       - name: Redeploy production pods
-        if: ${{ steps.extract_branch.outputs.branch == 'main' }}
+        if: ${{ needs.set_env_name.outputs.env_name == 'main' }}
         run: |
           kubectl rollout restart deployment api -n production
           kubectl rollout restart deployment tiler -n production
           kubectl rollout restart deployment client -n production
 
       - name: Redeploy pods for other branches
-        if: ${{ steps.extract_branch.outputs.branch != 'main' }}
+        if: ${{ needs.set_env_name.outputs.env_name != 'main' }}
         run: |
-          kubectl rollout restart deployment api -n ${{ steps.extract_branch.outputs.branch }}
-          kubectl rollout restart deployment tiler -n ${{ steps.extract_branch.outputs.branch }}
-          kubectl rollout restart deployment client -n ${{ steps.extract_branch.outputs.branch }}
+          kubectl rollout restart deployment api -n ${{ needs.set_env_name.outputs.env_name }}
+          kubectl rollout restart deployment tiler -n ${{ needs.set_env_name.outputs.env_name }}
+          kubectl rollout restart deployment client -n ${{ needs.set_env_name.outputs.env_name }}

--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -14,6 +14,7 @@ on:
       - 'gcp'
       - 'dev'
       - 'demo'
+      - 'pilot'
     paths:
       - 'api/**'
       - 'client/**'
@@ -29,6 +30,31 @@ on:
         default: true
 
 jobs:
+  set_env_name:
+    name: Set Environment Name
+    runs-on: ubuntu-20.04
+    outputs:
+      env_name: ${{ steps.set_env.outputs.env_name }}
+      env_name_upper: ${{ steps.set_env.outputs.env_name_upper }}
+    steps:
+      - name: Set environment name
+        shell: bash
+        run: |
+          branch_name=$(echo "${GITHUB_REF#refs/heads/}")
+          secret_name=$(echo "$branch_name" | tr '[:lower:]' '[:upper:]')
+          mapped_name=${!secret_name}
+          if [ -z "$mapped_name" ]; then
+            echo "Warning: No secret found for branch '$branch_name'. Falling back to branch name."
+            mapped_name=$branch_name
+          fi
+          mapped_name_upper=$(echo "$mapped_name" | tr '[:lower:]' '[:upper:]')
+          echo "Environment name used: $mapped_name"
+          echo "##[set-output name=env_name;]$mapped_name"
+          echo "##[set-output name=env_name_upper;]$mapped_name_upper"
+        id: set_env
+        env:
+          PILOT: ${{ secrets.PILOT }}
+
   wait_for_tests:
     name: Wait for tests to finish running
     runs-on: ubuntu-20.04
@@ -60,7 +86,7 @@ jobs:
   push_api_to_registry:
     name: Push API Docker image to Docker Hub
     runs-on: ubuntu-20.04
-    needs: wait_for_tests
+    needs: [ set_env_name, wait_for_tests ]
 
     permissions:
       contents: 'read'
@@ -93,18 +119,11 @@ jobs:
       - name: Authorize Docker push
         run: gcloud auth configure-docker europe-west1-docker.pkg.dev
 
-      - name: Extract branch name
-        shell: bash
-        run: |
-          echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
-          echo "##[set-output name=branch-upper;]$(echo ${GITHUB_REF#refs/heads/} | tr a-z A-Z )"
-        id: extract_branch
-
       - name: Build API Docker image
         env:
           ECR_REGISTRY: ${{ steps.ecr-login.outputs.registry }}
           ECR_REPOSITORY: api
-          IMAGE_TAG: ${{ steps.extract_branch.outputs.branch }}
+          IMAGE_TAG: ${{ needs.set_env_name.outputs.env_name }}
         run: |
           docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG \
           -t europe-west1-docker.pkg.dev/${{ env.PROJECT_ID }}/api/main:${{ github.sha }} \
@@ -115,7 +134,7 @@ jobs:
         env:
           ECR_REGISTRY: ${{ steps.ecr-login.outputs.registry }}
           ECR_REPOSITORY: api
-          IMAGE_TAG: ${{ steps.extract_branch.outputs.branch }}
+          IMAGE_TAG: ${{ needs.set_env_name.outputs.env_name }}
         run: |
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
           docker push europe-west1-docker.pkg.dev/${{ env.PROJECT_ID }}/api/main:${{ github.sha }}
@@ -124,7 +143,7 @@ jobs:
   push_client_to_registry:
     name: Push Client Docker image to Docker Hub
     runs-on: ubuntu-20.04
-    needs: wait_for_tests
+    needs: [ set_env_name, wait_for_tests ]
 
     permissions:
       contents: 'read'
@@ -157,24 +176,17 @@ jobs:
       - name: Authorize Docker push
         run: gcloud auth configure-docker europe-west1-docker.pkg.dev
 
-      - name: Extract branch name
-        shell: bash
-        run: |
-          echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
-          echo "##[set-output name=branch-upper;]$(echo ${GITHUB_REF#refs/heads/} | tr a-z A-Z )"
-        id: extract_branch
-
       - name: Build Client Docker image
         env:
           ECR_REGISTRY: ${{ steps.ecr-login.outputs.registry }}
           ECR_REPOSITORY: client
-          IMAGE_TAG: ${{ steps.extract_branch.outputs.branch }}
+          IMAGE_TAG: ${{ needs.set_env_name.outputs.env_name }}
         run: |
           docker build \
-          --build-arg NEXTAUTH_URL=${{ secrets[format('NEXTAUTH_URL_{0}', steps.extract_branch.outputs.branch-upper )] }} \
-          --build-arg NEXTAUTH_SECRET=${{ secrets[format('NEXTAUTH_SECRET_{0}', steps.extract_branch.outputs.branch-upper )] }} \
+          --build-arg NEXTAUTH_URL=${{ secrets[format('NEXTAUTH_URL_{0}', needs.set_env_name.outputs.env_name_upper )] }} \
+          --build-arg NEXTAUTH_SECRET=${{ secrets[format('NEXTAUTH_SECRET_{0}', needs.set_env_name.outputs.env_name_upper )] }} \
           --build-arg NEXT_PUBLIC_MAPBOX_API_TOKEN=${{ secrets.NEXT_PUBLIC_MAPBOX_API_TOKEN }} \
-          --build-arg NEXT_PUBLIC_API_URL=${{ secrets[format('NEXT_PUBLIC_API_URL_{0}', steps.extract_branch.outputs.branch-upper )] }} \
+          --build-arg NEXT_PUBLIC_API_URL=${{ secrets[format('NEXTAUTH_URL_{0}', needs.set_env_name.outputs.env_name_upper )] }} \
           --build-arg CYPRESS_USERNAME=${{ secrets.CYPRESS_USERNAME }} \
           --build-arg CYPRESS_PASSWORD=${{ secrets.CYPRESS_PASSWORD }} \
           -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG  \
@@ -186,17 +198,16 @@ jobs:
         env:
           ECR_REGISTRY: ${{ steps.ecr-login.outputs.registry }}
           ECR_REPOSITORY: client
-          IMAGE_TAG: ${{ steps.extract_branch.outputs.branch }}
+          IMAGE_TAG: ${{ needs.set_env_name.outputs.env_name }}
         run: |
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
           docker push europe-west1-docker.pkg.dev/${{ env.PROJECT_ID }}/client/main:${{ github.sha }}
           docker push europe-west1-docker.pkg.dev/${{ env.PROJECT_ID }}/client/main:latest
 
-
   push_data_import_to_registry:
     name: Push Data Import Docker image to Docker Hub
     runs-on: ubuntu-20.04
-    needs: wait_for_tests
+    needs: [ set_env_name, wait_for_tests ]
 
     permissions:
       contents: 'read'
@@ -229,18 +240,11 @@ jobs:
       - name: Authorize Docker push
         run: gcloud auth configure-docker europe-west1-docker.pkg.dev
 
-      - name: Extract branch name
-        shell: bash
-        run: |
-          echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
-          echo "##[set-output name=branch-upper;]$(echo ${GITHUB_REF#refs/heads/} | tr a-z A-Z )"
-        id: extract_branch
-
       - name: Build Data Import Docker image
         env:
           ECR_REGISTRY: ${{ steps.ecr-login.outputs.registry }}
           ECR_REPOSITORY: data_import
-          IMAGE_TAG: ${{ steps.extract_branch.outputs.branch }}
+          IMAGE_TAG: ${{ needs.set_env_name.outputs.env_name }}
         run: |
           docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG  \
           -t europe-west1-docker.pkg.dev/${{ env.PROJECT_ID }}/data-import/main:${{ github.sha }} \
@@ -251,7 +255,7 @@ jobs:
         env:
           ECR_REGISTRY: ${{ steps.ecr-login.outputs.registry }}
           ECR_REPOSITORY: data_import
-          IMAGE_TAG: ${{ steps.extract_branch.outputs.branch }}
+          IMAGE_TAG: ${{ needs.set_env_name.outputs.env_name }}
         run: |
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
           docker push europe-west1-docker.pkg.dev/${{ env.PROJECT_ID }}/data-import/main:${{ github.sha }}
@@ -260,7 +264,7 @@ jobs:
   push_tiler_to_registry:
     name: Push Tiler Docker image to AWS and GCP
     runs-on: ubuntu-20.04
-    needs: wait_for_tests
+    needs: [ set_env_name, wait_for_tests ]
 
     permissions:
       contents: 'read'
@@ -293,18 +297,11 @@ jobs:
       - name: Authorize Docker push
         run: gcloud auth configure-docker europe-west1-docker.pkg.dev
 
-      - name: Extract branch name
-        shell: bash
-        run: |
-          echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
-          echo "##[set-output name=branch-upper;]$(echo ${GITHUB_REF#refs/heads/} | tr a-z A-Z )"
-        id: extract_branch
-
       - name: Build Tiler Docker image
         env:
           ECR_REGISTRY: ${{ steps.ecr-login.outputs.registry }}
           ECR_REPOSITORY: tiler
-          IMAGE_TAG: ${{ steps.extract_branch.outputs.branch }}
+          IMAGE_TAG: ${{ needs.set_env_name.outputs.env_name }}
         run: |
           docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG \
           -t europe-west1-docker.pkg.dev/${{ env.PROJECT_ID }}/tiler/main:${{ github.sha }} \
@@ -315,7 +312,7 @@ jobs:
         env:
           ECR_REGISTRY: ${{ steps.ecr-login.outputs.registry }}
           ECR_REPOSITORY: tiler
-          IMAGE_TAG: ${{ steps.extract_branch.outputs.branch }}
+          IMAGE_TAG: ${{ needs.set_env_name.outputs.env_name }}
         run: |
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
           docker push europe-west1-docker.pkg.dev/${{ env.PROJECT_ID }}/tiler/main:${{ github.sha }}


### PR DESCRIPTION
This pull request introduces significant changes to the GitHub Actions workflows for deploying to Kubernetes and publishing Docker images. The main updates include adding a new environment, "pilot", and creating a new job to set the environment name dynamically based on the branch name. This change removes the need for extracting the branch name in multiple steps and ensures consistency across different jobs.

Environment and job updates:

* [`.github/workflows/deploy-to-kubernetes.yml`](diffhunk://#diff-49d187ac7b3c79548ffac32c99e8d2320f5b365b764fb98835f0b83484c33160R12): Added the "pilot" environment to the list of branches and created a new `set_env_name` job to dynamically set the environment name based on the branch name. Updated the `deploy_images_to_kubernetes` job to depend on the `set_env_name` job and replaced branch name extraction with the new environment name logic. [[1]](diffhunk://#diff-49d187ac7b3c79548ffac32c99e8d2320f5b365b764fb98835f0b83484c33160R12) [[2]](diffhunk://#diff-49d187ac7b3c79548ffac32c99e8d2320f5b365b764fb98835f0b83484c33160R21-R45) [[3]](diffhunk://#diff-49d187ac7b3c79548ffac32c99e8d2320f5b365b764fb98835f0b83484c33160L41-R67) [[4]](diffhunk://#diff-49d187ac7b3c79548ffac32c99e8d2320f5b365b764fb98835f0b83484c33160L90-R128)

* [`.github/workflows/publish-docker-images.yml`](diffhunk://#diff-a0415f8a50178b93757cf4588a327a98574ff12b2ffd19bf4e70c748e3e2f612R17): Added the "pilot" environment to the list of branches and created a new `set_env_name` job to dynamically set the environment name based on the branch name. Updated various jobs (`push_api_to_registry`, `push_client_to_registry`, `push_data_import_to_registry`, `push_tiler_to_registry`) to depend on the `set_env_name` job and replaced branch name extraction with the new environment name logic. [[1]](diffhunk://#diff-a0415f8a50178b93757cf4588a327a98574ff12b2ffd19bf4e70c748e3e2f612R17) [[2]](diffhunk://#diff-a0415f8a50178b93757cf4588a327a98574ff12b2ffd19bf4e70c748e3e2f612R33-R57) [[3]](diffhunk://#diff-a0415f8a50178b93757cf4588a327a98574ff12b2ffd19bf4e70c748e3e2f612L63-R89) [[4]](diffhunk://#diff-a0415f8a50178b93757cf4588a327a98574ff12b2ffd19bf4e70c748e3e2f612L96-R126) [[5]](diffhunk://#diff-a0415f8a50178b93757cf4588a327a98574ff12b2ffd19bf4e70c748e3e2f612L118-R137) [[6]](diffhunk://#diff-a0415f8a50178b93757cf4588a327a98574ff12b2ffd19bf4e70c748e3e2f612L127-R146) [[7]](diffhunk://#diff-a0415f8a50178b93757cf4588a327a98574ff12b2ffd19bf4e70c748e3e2f612L160-R189) [[8]](diffhunk://#diff-a0415f8a50178b93757cf4588a327a98574ff12b2ffd19bf4e70c748e3e2f612L189-R210) [[9]](diffhunk://#diff-a0415f8a50178b93757cf4588a327a98574ff12b2ffd19bf4e70c748e3e2f612L232-R247) [[10]](diffhunk://#diff-a0415f8a50178b93757cf4588a327a98574ff12b2ffd19bf4e70c748e3e2f612L254-R258) [[11]](diffhunk://#diff-a0415f8a50178b93757cf4588a327a98574ff12b2ffd19bf4e70c748e3e2f612L263-R267) [[12]](diffhunk://#diff-a0415f8a50178b93757cf4588a327a98574ff12b2ffd19bf4e70c748e3e2f612L296-R304) [[13]](diffhunk://#diff-a0415f8a50178b93757cf4588a327a98574ff12b2ffd19bf4e70c748e3e2f612L318-R315)