### PR TITLE
Landgrif 1609 implement a logic to retrieve indicator coefficients based on a hierarchical lookup admin country global

### DIFF
--- a/api/src/migrations/1740046145650-AddLocationFallbackToGetIndicatorCoefficientImpact.ts
+++ b/api/src/migrations/1740046145650-AddLocationFallbackToGetIndicatorCoefficientImpact.ts
@@ -1,0 +1,112 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddLocationFallbackToGetIndicatorCoefficientImpact1740046145650
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE OR REPLACE FUNCTION public.get_indicator_coefficient_impact(
+          name_code text,
+          admin_region_id uuid,
+          material_id uuid
+      )
+      RETURNS double precision
+      LANGUAGE plpgsql
+      AS $function$
+      DECLARE
+        indicator_id uuid;
+        value float;
+      BEGIN
+
+        SELECT "id" INTO indicator_id
+        FROM "indicator"
+        WHERE "nameCode" = name_code;
+
+
+        WITH RECURSIVE region_tree AS (
+          SELECT id, "parentId", 0 AS level
+          FROM admin_region
+          WHERE id = admin_region_id
+
+          UNION ALL
+
+          SELECT ar.id, ar."parentId", rt.level + 1
+          FROM admin_region ar
+          INNER JOIN region_tree rt ON ar.id = rt."parentId"
+        ),
+        candidate_values AS (
+          SELECT ic."value" AS candidate_value, rt.level
+          FROM region_tree rt
+          JOIN indicator_coefficient ic ON ic."adminRegionId" = rt.id
+          WHERE ic."materialId" = material_id
+            AND ic."indicatorId" = indicator_id
+            AND ic."value" IS NOT NULL
+
+          UNION ALL
+
+
+          SELECT ic."value" AS candidate_value, 9999 AS level
+          FROM indicator_coefficient ic
+          WHERE ic."adminRegionId" IS NULL
+            AND ic."materialId" = material_id
+            AND ic."indicatorId" = indicator_id
+            AND ic."value" IS NOT NULL
+        )
+        SELECT candidate_value INTO value
+        FROM candidate_values
+        ORDER BY level ASC
+        LIMIT 1;
+
+        RETURN value;
+      END;
+      $function$;
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE OR REPLACE FUNCTION public.get_indicator_coefficient_impact(
+          name_code text,
+          admin_region_id uuid,
+          material_id uuid
+      )
+      RETURNS double precision
+      LANGUAGE plpgsql
+      AS $function$
+      DECLARE
+        indicator_id uuid;
+        value float;
+      BEGIN
+
+        SELECT "id" INTO indicator_id FROM "indicator"
+        WHERE "nameCode" = name_code;
+
+        EXECUTE format(
+          'SELECT
+              COALESCE (
+                  (
+                  SELECT ic."value"
+                  FROM "indicator_coefficient" ic
+                  WHERE ic."adminRegionId" = $1
+                  AND ic."materialId" = $2
+                  AND ic."indicatorId" = $3
+                  AND ic."value" IS NOT NULL
+                  ),
+                  (
+                  SELECT ic."value"
+                  FROM "indicator_coefficient" ic
+                  WHERE ic."adminRegionId" IS NULL
+                  AND ic."materialId" = $2
+                  AND ic."indicatorId" = $3
+                  AND ic."value" IS NOT NULL
+                  )
+              ) AS value;'
+        )
+        USING admin_region_id, material_id, indicator_id
+        INTO value;
+        RETURN value;
+      END;
+      $function$;
+    `);
+  }
+}

--- a/api/src/modules/indicator-coefficients/indicator-coefficient.entity.ts
+++ b/api/src/modules/indicator-coefficients/indicator-coefficient.entity.ts
@@ -21,6 +21,28 @@ export const indicatorCoefficientResource: BaseServiceResource = {
   columnsAllowedAsFilter: ['value', 'year', 'indicatorSourceId'],
 };
 
+// TODO: Check with data or uniqueness combinations here
+// TODO: Bring up with the team if time to switch snake_case has come, also to rename entities: indicator coefficient to impact factor
+
+// TODO: There are LOTS of rows where material is null, does that make sense? After checking the code, the only layer accesing this table\
+//       seem to be the stored procedure
+
+// SELECT
+// "materialId",
+//   "indicatorId",
+//   "adminRegionId",
+// COUNT(*) AS duplicados
+// FROM indicator_coefficient
+// GROUP BY "materialId", "indicatorId", "adminRegionId"
+// HAVING COUNT(*) > 1;
+
+// TODO: The only query that uses this table also filters by the value not being null, regardless of the admin region being null or not, so we
+//       could also include it in a potential composite index, as this procedure is executed for each year for each location, and it can have more than
+//       700k rows.
+
+// TODO: We also have NULL values, that apparently are always ignored in the queries. Does it make any sense to allow values to be null? should we remove
+//       them all?
+
 @Entity()
 export class IndicatorCoefficient extends BaseEntity {
   @PrimaryGeneratedColumn('uuid')
@@ -29,6 +51,7 @@ export class IndicatorCoefficient extends BaseEntity {
   @Column({ type: 'float', nullable: true })
   value?: number;
 
+  @Index()
   @Column({ type: 'int' })
   year!: number;
 

--- a/api/test/integration/stored-procedures/get-indicator-coefficient-impact.spec.ts
+++ b/api/test/integration/stored-procedures/get-indicator-coefficient-impact.spec.ts
@@ -1,0 +1,124 @@
+import { AdminRegion } from 'modules/admin-regions/admin-region.entity';
+import { IndicatorCoefficient } from 'modules/indicator-coefficients/indicator-coefficient.entity';
+import {
+  Indicator,
+  INDICATOR_NAME_CODES,
+} from 'modules/indicators/indicator.entity';
+import { Material } from 'modules/materials/material.entity';
+import { DataSource, Repository } from 'typeorm';
+import ApplicationManager from '../../utils/application-manager';
+import { clearTestDataFromDatabase } from '../../utils/database-test-helper';
+import {
+  createAdminRegion,
+  createIndicator,
+  createIndicatorCoefficient,
+  createMaterial,
+} from '../../entity-mocks';
+
+type QueryResult = [{ value: number }];
+
+describe('Get Indicator Coefficient Impact Tests', () => {
+  let dataSource: DataSource;
+  let indicatorCoefficientRepository: Repository<IndicatorCoefficient>;
+  let savedIndicator: Indicator;
+  let savedMaterial: Material;
+  let adminRegionChild: AdminRegion;
+  let adminRegionParent: AdminRegion;
+  let adminRegionGrandparent: AdminRegion;
+
+  beforeAll(async () => {
+    const testApplication = await ApplicationManager.init();
+    dataSource = testApplication.get<DataSource>(DataSource);
+    indicatorCoefficientRepository =
+      dataSource.getRepository(IndicatorCoefficient);
+    savedIndicator = await createIndicator({
+      nameCode: INDICATOR_NAME_CODES.NL,
+    });
+    savedMaterial = await createMaterial({ name: 'Material A' });
+
+    adminRegionGrandparent = await createAdminRegion({
+      name: 'Grandparent Region',
+    });
+
+    adminRegionParent = await createAdminRegion({
+      name: 'Parent Region',
+      parent: adminRegionGrandparent,
+    });
+
+    adminRegionChild = await createAdminRegion({
+      name: 'Child Region',
+      parent: adminRegionParent,
+    });
+  });
+
+  afterAll(async () => {
+    await clearTestDataFromDatabase(dataSource);
+  });
+
+  beforeEach(async () => {
+    await indicatorCoefficientRepository.clear();
+  });
+
+  test('Case 1: Exact match in located region', async () => {
+    const coefficient = await createIndicatorCoefficient({
+      adminRegion: adminRegionChild,
+      material: savedMaterial,
+      indicator: savedIndicator,
+      value: 1.23,
+    });
+    const result: QueryResult = await dataSource.query(
+      `SELECT public.get_indicator_coefficient_impact('${savedIndicator.nameCode}', '${adminRegionChild.id}', '${savedMaterial.id}') as value;`,
+    );
+    expect(result[0].value).toEqual(coefficient.value);
+  });
+
+  test('Case 2: Value in parent', async () => {
+    const coefficient = await createIndicatorCoefficient({
+      adminRegion: adminRegionParent,
+      material: savedMaterial,
+      indicator: savedIndicator,
+      value: 2.34,
+    });
+
+    const result: QueryResult = await dataSource.query(
+      `SELECT public.get_indicator_coefficient_impact('${savedIndicator.nameCode}', '${adminRegionChild.id}', '${savedMaterial.id}') as value;`,
+    );
+    expect(result[0].value).toEqual(coefficient.value);
+  });
+
+  test('Case 3: Value in grandparent', async () => {
+    const coefficient = await createIndicatorCoefficient({
+      adminRegion: adminRegionGrandparent,
+      material: savedMaterial,
+      indicator: savedIndicator,
+      value: 3.45,
+    });
+
+    const result: QueryResult = await dataSource.query(
+      `SELECT public.get_indicator_coefficient_impact('${savedIndicator.nameCode}', '${adminRegionChild.id}', '${savedMaterial.id}') as value;`,
+    );
+    expect(result[0].value).toEqual(coefficient.value);
+  });
+
+  test('Case 4: No value in hierarchy, defaulting to global (null admin region)', async () => {
+    const coefficient = await createIndicatorCoefficient({
+      material: savedMaterial,
+      indicator: savedIndicator,
+      value: 4.56,
+      // Making explicit to readers that there is no Admin Region for this coefficient
+      adminRegion: undefined as any,
+    });
+
+    const result: QueryResult = await dataSource.query(
+      `SELECT public.get_indicator_coefficient_impact('${savedIndicator.nameCode}', '${adminRegionChild.id}', '${savedMaterial.id}') as value;`,
+    );
+    expect(result[0].value).toEqual(coefficient.value);
+  });
+
+  test('Case 5: No value found, returns null', async () => {
+    const result: QueryResult = await dataSource.query(
+      `SELECT public.get_indicator_coefficient_impact('${savedIndicator.nameCode}', '${adminRegionChild.id}', '${savedMaterial.id}') as value;`,
+    );
+    expect(result[0].value).toBeNull();
+  });
+});

--- a/data/h3_data_importer/tests/test_h3_import.py
+++ b/data/h3_data_importer/tests/test_h3_import.py
@@ -38,6 +38,7 @@ def test_db_connection(conn):
     except Exception as e:
         pytest.fail(f"DB connection Error: {e}")
 
+## TODO: Even tho this test checks the current behavior, it should be refactored as the behavior is wrong
 
 def test_indicator_coefficient_has_any_link_to_material(conn):
     with conn.cursor() as cur:
@@ -50,6 +51,8 @@ def test_indicator_coefficient_has_any_link_to_material(conn):
         assert len(result) > 0, "The query result is empty"
 
 
+
+## TODO: This also depends on a fixed fixture, check new approaches
 def test_material_is_linked_in_indicator_coefficients(conn):
     with conn.cursor() as cur:
         cur.execute(


### PR DESCRIPTION
https://vizzuality.atlassian.net/browse/LANDGRIF-1627

This PR updates the stored procedure get_indicator_coefficients_impact, by adding a recursive search over the admin-region hierarchy:

Until now, if a coefficient factor was not found for the specific admin region of the location, we were falling back to a NULL admin region, which conceptually represents a global worldwide value.

With this implementation, if the most accurate admin region that is tied location has no coefficient factor, we look up in the admin region hierarchy to try to find a value until we reach the country. 

If some value is found in the hierarchy, we use it. Otherwise we finally fallback to the global level

**IMPORTANT NOTE:**

This implementation is done without taking into account the refactoring and improvements we aim to do both to the query and the entity that is targeted here (the use of level, for example). We will need to refactor it after we tackle those changes, but we cannot afford to do it now for the time being

Additionally, I have added several TODO's with questions that we need to clarify, we can remove those if you don't want them in the code, but we would need to write them down making sure we don't forget about that

