### PR TITLE
chore: remove restart policy, add 0 backoff limit to k8s data import job

### DIFF
--- a/infrastructure/kubernetes/modules/data_import/main.tf
+++ b/infrastructure/kubernetes/modules/data_import/main.tf
@@ -7,8 +7,9 @@ resource "kubernetes_job" "data_import" {
   }
 
   spec {
-    parallelism = 1
-    completions = 1
+    parallelism   = 1
+    completions   = 1
+    backoff_limit = 0
 
     ttl_seconds_after_finished = "86400"
 
@@ -27,7 +28,7 @@ resource "kubernetes_job" "data_import" {
                 match_expressions {
                   key      = "type"
                   operator = "In"
-                  values   = ["data-import-${var.namespace}"]
+                  values = ["data-import-${var.namespace}"]
                 }
               }
             }
@@ -38,7 +39,7 @@ resource "kubernetes_job" "data_import" {
           name = "regcred"
         }
 
-        restart_policy = "OnFailure"
+        restart_policy = "Never"
 
         container {
           image             = var.image


### PR DESCRIPTION
This pull request includes changes to the `infrastructure/kubernetes/modules/data_import/main.tf` file to improve the configuration of the `kubernetes_job` resource for data import. The most important changes include setting a backoff limit and modifying the restart policy.

Changes to `kubernetes_job` resource configuration:

* Added `backoff_limit = 0` to the job specification to prevent retries on failure.
* Changed `restart_policy` from "OnFailure" to "Never" to ensure the job does not restart automatically after a failure.