### PR TITLE
[LANDGRIF-1639] skips running tests when README/CHANGELOG files are modified

### DIFF
--- a/.github/workflows/testing-api.yml
+++ b/.github/workflows/testing-api.yml
@@ -4,6 +4,9 @@ on:
   push:
     paths:
       - 'api/**'
+      - '!api/README.md'
+      - '!api/CHANGELOG.md'
+      - '.github/workflows/testing-api.yml'
 
   workflow_dispatch:
 

--- a/.github/workflows/testing-client-unit-tests.yml
+++ b/.github/workflows/testing-client-unit-tests.yml
@@ -2,8 +2,10 @@ name: Client Unit Tests
 on:
   push:
     paths:
-      - '.github/workflows/testing-client-unit-tests.yml'
       - 'client/**'
+      - '!client/README.md'
+      - '!client/CHANGELOG.md'
+      - '.github/workflows/testing-client-unit-tests.yml'
   workflow_dispatch:
 defaults:
   run:

--- a/.github/workflows/testing-client.yml
+++ b/.github/workflows/testing-client.yml
@@ -4,6 +4,8 @@ on:
   push:
     paths:
       - 'client/**'
+      - '!client/README.md'
+      - '!client/CHANGELOG.md'
       - '.github/workflows/testing-client.yml'
 
   workflow_dispatch:

--- a/.github/workflows/testing-data-import.yml
+++ b/.github/workflows/testing-data-import.yml
@@ -4,6 +4,7 @@ on:
   push:
     paths:
       - 'data/**'
+      - '!data/README.md'
       - '.github/workflows/testing-data-import.yml'
 
   workflow_dispatch:

--- a/.github/workflows/testing-tiler.yml
+++ b/.github/workflows/testing-tiler.yml
@@ -4,6 +4,8 @@ on:
   push:
     paths:
       - 'tiler/**'
+      - '!tiler/README.md'
+      - '.github/workflows/testing-tiler.yml'
 
   workflow_dispatch:
 


### PR DESCRIPTION
### General description

This pull request includes changes to multiple GitHub workflow files to exclude certain documentation files from triggering workflows on push events. The most important changes are as follows:

Exclusions added to workflows:

* [`.github/workflows/testing-api.yml`](diffhunk://#diff-616560eaf8435d1346e0590ad5e706135c9d446a11b3d3db84cb5daffd13447dR7-R9): Excluded `api/README.md` and `api/CHANGELOG.md` from triggering the workflow.
* [`.github/workflows/testing-client-unit-tests.yml`](diffhunk://#diff-b038dd3c9e6fd7ae01639111270b32e7013180eaaa54d936cb9400c8c963cad8L5-R8): Excluded `client/README.md` and `client/CHANGELOG.md` from triggering the workflow.
* [`.github/workflows/testing-client.yml`](diffhunk://#diff-20c38f00250a415f2acc31f2db9d0cc5bdce2dc6c63a5c3c74ec48df8d9bb782R7-R8): Excluded `client/README.md` and `client/CHANGELOG.md` from triggering the workflow.
* [`.github/workflows/testing-data-import.yml`](diffhunk://#diff-38280cba4eb55ecee3efabde3adf28fb410526e959338f7388af17597e08a4faR7): Excluded `data/README.md` from triggering the workflow.
* [`.github/workflows/testing-tiler.yml`](diffhunk://#diff-20204d73867c96d4edf109b6c6e796120308a76643ad8103b3fb5559728c1350R7-R8): Excluded `tiler/README.md` from triggering the workflow.

### Designs

N/A

### Testing instructions

_Provide minimal instructions on how to test this PR._

- Apart from the added feature / bug fix, check overall performance, styling...

## Checklist before merging

- [ ] Branch name / PR includes the related Jira ticket Id.
- [ ] Tests to check core implementation / bug fix added.
- [ ] All checks in Continuous Integration workflow pass.
- [ ] Feature functionally tested by reviewer(s).
- [ ] Code reviewed by reviewer(s).
- [ ] Documentation updated (README, CHANGELOG...) (if required)
