### PR TITLE
[LANDGRIF-1685] updates typing of legend values and map data

### DIFF
--- a/client/src/containers/analysis-visualization/analysis-map/component.tsx
+++ b/client/src/containers/analysis-visualization/analysis-map/component.tsx
@@ -27,9 +27,9 @@ const getLegendScale = (legendInfo: LegendType) => {
   if (legendInfo?.type === 'range' || legendInfo?.type === 'category') {
     const threshold = legendInfo.items.map((item) => item.value);
     const rangeValues = legendInfo.items.map((item) => item.label);
-    const scale = scaleByLegendType(legendInfo?.type, threshold as number[], rangeValues);
-    return scale;
+    return scaleByLegendType(legendInfo?.type, threshold, rangeValues);
   }
+
   return (value: number) => {
     if (!value) return null;
     if (!Number.isNaN(value)) return formatNumber(Number(value));

--- a/client/src/hooks/h3-data/contextual.ts
+++ b/client/src/hooks/h3-data/contextual.ts
@@ -19,15 +19,13 @@ const responseContextualParser = (response: AxiosResponse<H3APIResponse>): H3API
   } = metadata;
   const threshold = items.map((item) => item.value);
   const colors = items.map((item) => chroma(item.color).rgb());
-
   const scale = colorScaleByLegendType(type, threshold, colors);
 
-  const h3DataWithColor: H3Item[] = data.map(
-    (d: H3Item): H3Item => ({
-      ...d,
-      c: scale(d.v as H3Item['v']),
-    }),
-  );
+  const h3DataWithColor: H3Item[] = data.map((d) => ({
+    ...d,
+    c: scale(d.v),
+  }));
+
   return { data: h3DataWithColor, metadata };
 };
 

--- a/client/src/hooks/h3-data/utils.ts
+++ b/client/src/hooks/h3-data/utils.ts
@@ -1,6 +1,5 @@
 import { scaleOrdinal, scaleThreshold } from 'd3-scale';
 
-import type { UseQueryResult } from '@tanstack/react-query';
 import type { ScaleOrdinal, ScaleThreshold } from 'd3-scale';
 import type { AnalysisFiltersState } from 'store/features/analysis/filters';
 import type { ScenariosState } from 'store/features/analysis/scenarios';
@@ -12,7 +11,6 @@ export type H3ImpactResponse = H3APIResponse & {
     unit: string;
   };
 };
-export type H3DataResponse = UseQueryResult<H3APIResponse, unknown>;
 
 type ScalesType = ScaleOrdinal<H3Item['v'], H3Item['c']> | ScaleThreshold<H3Item['v'], H3Item['c']>;
 
@@ -43,17 +41,17 @@ export const storeToQueryParams = ({
 
 export const scaleByLegendType = (
   type: Legend['type'],
-  threshold: number[],
+  threshold: Legend['items'][0]['value'][],
   rangeValues: string[],
-): ScaleOrdinal<number, string> | ScaleThreshold<number, string> => {
+) => {
   switch (type) {
     case 'category':
-      return scaleOrdinal<number, string>()
-        .domain(threshold as number[])
+      return scaleOrdinal<(typeof threshold)[number], (typeof rangeValues)[number]>()
+        .domain(threshold)
         .range(rangeValues);
     default:
-      return scaleThreshold<number, string>()
-        .domain(threshold as number[])
+      return scaleThreshold<(typeof threshold)[number], (typeof rangeValues)[number]>()
+        .domain(threshold)
         .range(rangeValues);
   }
 };

--- a/client/src/types.d.ts
+++ b/client/src/types.d.ts
@@ -31,7 +31,7 @@ export type APIpaginationRequest = {
 export type H3Item = {
   c: RGBColor;
   h: string;
-  v: number;
+  v: number | string;
 };
 
 export type H3Data = H3Item[];
@@ -50,14 +50,6 @@ export type MaterialH3APIParams = CommonH3APIParams & {
   materialId: string;
 };
 
-export type RiskH3APIParams = MaterialH3APIParams & {
-  indicatorId: string;
-};
-
-export type WaterH3APIParams = MaterialH3APIParams & {
-  indicatorId: string;
-};
-
 export type ImpactH3APIParams = CommonH3APIParams & {
   indicatorId: Indicator['id'];
   materialIds?: Material['id'][];
@@ -68,8 +60,6 @@ export type ImpactH3APIParams = CommonH3APIParams & {
   locationTypes?: string[];
   businessUnitIds?: BusinessUnits['id'][];
 };
-
-export type ContextualH3APIParams = CommonH3APIParams;
 
 export type ImpactTabularAPIParams = {
   groupBy: string;
@@ -214,12 +204,6 @@ type Metadata = {
   unit: string;
 };
 
-type AggregatedValues = Readonly<{
-  aggregatedValues: { year: number; value: number }[];
-  numberOfAggregatedEntities: number;
-  sort: 'DES' | 'ASC';
-}>;
-
 export type PaginationMetadata = {
   page?: number;
   size?: number;
@@ -348,9 +332,6 @@ export type Target = {
 };
 
 // Helper types
-
-export type ArrayElement<ArrayType extends readonly unknown[]> =
-  ArrayType extends readonly (infer ElementType)[] ? ElementType : never;
 
 export type WithRequiredProperty<Type, Key extends keyof Type> = Type & {
   [Property in Key]-?: Type[Property];


### PR DESCRIPTION
### General description

https://vizzuality.atlassian.net/browse/LANDGRIF-1685

This pull request focuses on improving type safety and simplifying code in the `analysis-map` and `h3-data` modules. The changes primarily involve refining type definitions, removing unnecessary type assertions, and streamlining function implementations.

### Type Safety Improvements:
* Updated `scaleByLegendType` in `client/src/hooks/h3-data/utils.ts` to use more precise type definitions for `threshold` and `rangeValues`, replacing generic `number[]` and `string[]` with inferred types based on `Legend['items']`. This eliminates the need for type assertions.

### Code Simplifications:
* Simplified the `getLegendScale` function in `client/src/containers/analysis-visualization/analysis-map/component.tsx` by directly returning the result of `scaleByLegendType` instead of assigning it to a variable first.
* Streamlined the `responseContextualParser` function in `client/src/hooks/h3-data/contextual.ts` by removing redundant type annotations and formatting the `data.map` callback for clarity.

### Cleanup:
* Removed an unused import (`UseQueryResult`) and the associated `H3DataResponse` type in `client/src/hooks/h3-data/utils.ts`, as they were no longer utilized in the codebase. [[1]](diffhunk://#diff-0503f570ddc0af63a162f8b15a443b8675fe48159554b752ae9e3c043e130ddaL3) [[2]](diffhunk://#diff-0503f570ddc0af63a162f8b15a443b8675fe48159554b752ae9e3c043e130ddaL15)

### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

_Provide minimal instructions on how to test this PR._

- Apart from the added feature / bug fix, check overall performance, styling...

## Checklist before merging

- [ ] Branch name / PR includes the related Jira ticket Id.
- [ ] Tests to check core implementation / bug fix added.
- [ ] All checks in Continuous Integration workflow pass.
- [ ] Feature functionally tested by reviewer(s).
- [ ] Code reviewed by reviewer(s).
- [ ] Documentation updated (README, CHANGELOG...) (if required)
