### PR TITLE
[LANDGRIF-1705] replaces bit.ly links with full URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,10 @@ instruments will support agribusiness and food enterprises in becoming more sust
 
 **Related Information**:
 
-- [Executive summary](https://bit.ly/3gIJq9n) with an overview of how LandGriffon works.
-- [Full methodology](https://bit.ly/3ONp1MJ) with an in-depth description of every feature.
+- [Executive summary](https://landgriffon.com/docs/LG_Methodology_Executive_Summary.pdf) with an overview of how LandGriffon works.
+- [Full methodology](https://landgriffon.com/docs/LG_Methodology_Technical_Note.pdf) with an in-depth description of every feature.
 
-> TODO: User Guide would also be useful as the [Full methodology](https://bit.ly/3ONp1MJ) document is not exactly a user
+> TODO: User Guide would also be useful as the [Full methodology](https://landgriffon.com/docs/LG_Methodology_Technical_Note.pdf) document is not exactly a user
 guide, only explains how the indicators work and other related information, which does not exactly fit as a user guide.
 
 ## 2. Architecture
@@ -169,8 +169,8 @@ Its contents are in the [`marketing/`](./marketing/) folder.
 In the [Methodology](https://landgriffon.com/methodology) section of the marketing site, you'll find two key documents:
 one providing an overview of how LandGriffon works and another offering a detailed explanation of its features.
 
-- [Executive summary](https://bit.ly/3gIJq9n) with an overview of how LandGriffon works.
-- [Full methodology](https://bit.ly/3ONp1MJ) with an in-depth description of every feature.
+- [Executive summary](https://landgriffon.com/docs/LG_Methodology_Executive_Summary.pdf) with an overview of how LandGriffon works.
+- [Full methodology](https://landgriffon.com/docs/LG_Methodology_Technical_Note.pdf) with an in-depth description of every feature.
 
 More information in its [README.md](./marketing/README.md) file.
 
@@ -377,8 +377,8 @@ process and maintaining project quality standards.
 
 ## 11. Additional documentation?
 
-- [Executive summary](https://bit.ly/3gIJq9n) with an overview of how LandGriffon works.
-- [Full methodology](https://bit.ly/3ONp1MJ) with an in-depth description of every feature.
+- [Executive summary](https://landgriffon.com/docs/LG_Methodology_Executive_Summary.pdf) with an overview of how LandGriffon works.
+- [Full methodology](https://landgriffon.com/docs/LG_Methodology_Technical_Note.pdf) with an in-depth description of every feature.
 
 > TODO: User guide.
 

--- a/marketing/src/containers/methodology/hero/component.tsx
+++ b/marketing/src/containers/methodology/hero/component.tsx
@@ -53,7 +53,7 @@ const Hero: React.FC = () => {
 
               <div className="flex flex-col space-y-6 sm:flex-row sm:space-y-0 sm:space-x-6 xl:justify-between">
                 <a
-                  href="https://bit.ly/3ONp1MJ"
+                  href="https://landgriffon.com/docs/LG_Methodology_Technical_Note.pdf"
                   rel="noreferrer noopener"
                   target="_blank"
                   className="flex-1 p-5 border-2 border-black group hover:bg-orange-500"
@@ -77,7 +77,7 @@ const Hero: React.FC = () => {
                   </div>
                 </a>
                 <a
-                  href="https://bit.ly/3gIJq9n"
+                  href="https://landgriffon.com/docs/LG_Methodology_Executive_Summary.pdf"
                   rel="noreferrer noopener"
                   target="_blank"
                   className="flex-1 p-5 border-2 border-black group hover:bg-orange-500"

--- a/marketing/src/containers/methodology/webinar/component-variant.tsx
+++ b/marketing/src/containers/methodology/webinar/component-variant.tsx
@@ -23,8 +23,10 @@ const Webinar: FC = () => (
         </p>
       </div>
       <a
-        href="https://bit.ly/3uxNHTp"
-        className="font-semibold block w-[195px] h-[82px] flex items-center hover:cursor-pointer justify-center border-2 border-white"
+        href="https://source.coop/repositories/vizzuality/lg-land-carbon-data/description"
+        rel="noopener noreferrer"
+        target="_blank"
+        className="font-semibold w-[195px] h-[82px] flex items-center hover:cursor-pointer justify-center border-2 border-white"
       >
         Download data
       </a>

--- a/marketing/src/containers/methodology/webinar/component.tsx
+++ b/marketing/src/containers/methodology/webinar/component.tsx
@@ -21,8 +21,10 @@ const Webinar: FC = () => (
         <div className="tex-lg md:text-xl lg:text-2xl">Watch our webinar on demand.</div>
       </div>
       <a
-        href="https://bit.ly/3GbWOMa"
-        className="font-semibold block w-[195px] h-[82px] flex items-center hover:cursor-pointer justify-center border-2 border-white focus-visible:ring-0 focus-visible:outline-0"
+        href="https://us02web.zoom.us/rec/share/WMf4vjy3vnTtxdcIAOWrlk4dpC7DZv95YyNgcbfivA6jc1oekLQPOKY-OYXhCYjP.-nyfRc-BK_vPcmq0?startTime=1700575208000%20Passcode:%20Y9p+u7CV"
+        rel="noopener noreferrer"
+        target="_blank"
+        className="font-semibold w-[195px] h-[82px] flex items-center hover:cursor-pointer justify-center border-2 border-white focus-visible:ring-0 focus-visible:outline-0"
       >
         Watch now
       </a>


### PR DESCRIPTION
This pull request updates multiple links across the codebase and documentation to replace outdated shortened URLs with direct, descriptive links. Additionally, it modifies some components to include proper attributes for accessibility and security.

### Link Updates in Documentation:
* Updated links in the `README.md` file to replace shortened URLs with direct links to the LandGriffon methodology documents (`Executive Summary` and `Full Methodology`). [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L59-R62) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L172-R173) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L380-R381)

### Link Updates in Code:
* Updated the `Hero` component in `marketing/src/containers/methodology/hero/component.tsx` to replace shortened URLs with direct links to the methodology documents. [[1]](diffhunk://#diff-0d4e55d15e8dc94076e806793b56ca9dd2dc30052f87dae8adf25d17a3fc54baL56-R56) [[2]](diffhunk://#diff-0d4e55d15e8dc94076e806793b56ca9dd2dc30052f87dae8adf25d17a3fc54baL80-R80)
* Updated the `Webinar` component in `marketing/src/containers/methodology/webinar/component-variant.tsx` to replace a shortened URL with a direct link to the data repository and added `rel` and `target` attributes for security.
* Updated the `Webinar` component in `marketing/src/containers/methodology/webinar/component.tsx` to replace a shortened URL with a direct link to the webinar recording and added `rel` and `target` attributes for security.